### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-processor-quality.yml
+++ b/.github/workflows/pre-processor-quality.yml
@@ -101,6 +101,8 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/Kaikei-e/Alt/security/code-scanning/3](https://github.com/Kaikei-e/Alt/security/code-scanning/3)

To fix the issue, add an explicit `permissions` block to the `Security Audit` job. This block should limit the permissions of the `GITHUB_TOKEN` to the least privilege required for the job. Since the job primarily reads repository contents and uploads SARIF files, the permissions can be set to `contents: read`. This change ensures that the job does not have unnecessary write access to the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
