### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-processor-quality.yml
+++ b/.github/workflows/pre-processor-quality.yml
@@ -14,6 +14,8 @@ jobs:
   quality-check:
     name: Quality Gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/Kaikei-e/Alt/security/code-scanning/2](https://github.com/Kaikei-e/Alt/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `quality-check` job. Based on the job's steps, it primarily reads repository contents and does not perform any write operations. Therefore, we will set `contents: read` as the minimal required permission. This change will ensure the job has only the permissions it needs, reducing potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
