### PR TITLE
Fix URL validation bug

### DIFF
--- a/alt-backend/app/utils/secure_http_client.go
+++ b/alt-backend/app/utils/secure_http_client.go
@@ -171,6 +171,10 @@ func ValidateURL(u *url.URL) error {
 		return errors.New("only HTTP and HTTPS schemes allowed")
 	}
 
+	if u.Hostname() == "" {
+		return errors.New("URL must contain a host")
+	}
+
 	// Block private networks
 	if isPrivateHost(u.Hostname()) {
 		return errors.New("access to private networks not allowed")

--- a/pre-processor/app/service/article_fetcher.go
+++ b/pre-processor/app/service/article_fetcher.go
@@ -108,6 +108,12 @@ func (s *articleFetcherService) ValidateURL(urlStr string) error {
 		return errors.New("only HTTP or HTTPS schemes allowed")
 	}
 
+	// Validate host
+	if parsedURL.Hostname() == "" {
+		s.logger.Error("URL validation failed", "url", urlStr, "error", "missing host")
+		return errors.New("URL must contain a host")
+	}
+
 	s.logger.Info("URL validated successfully", "url", urlStr)
 
 	return nil

--- a/pre-processor/app/service/article_fetcher_test.go
+++ b/pre-processor/app/service/article_fetcher_test.go
@@ -62,6 +62,10 @@ func TestArticleFetcherService_ValidateURL(t *testing.T) {
 			input:       "ftp://example.com",
 			expectError: true,
 		},
+		"should reject missing host": {
+			input:       "http:///path",
+			expectError: true,
+		},
 		"should handle URLs with special characters": {
 			input:       "https://example.com/path with spaces",
 			expectError: false,


### PR DESCRIPTION
## Summary
- ensure host is present when validating URLs in backend and pre-processor
- log and report missing host errors in article fetcher
- test missing-host validation scenario

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b2d4f58832b8c552e969c449dea