### PR TITLE
Add tag generator README

### DIFF
--- a/tag-generator/app/README.md
+++ b/tag-generator/app/README.md
@@ -1,0 +1,11 @@
+## Tag Generator
+
+This service automatically generates tags for articles using machine learning.
+It is implemented in **Python 3.13**.
+
+## Getting Started
+
+1. Clone the repository
+2. Navigate to `tag-generator/app` and install dependencies with `uv sync`
+3. Run `uv run main.py` (or `python main.py`) to start the service
+


### PR DESCRIPTION
## Summary
- add basic instructions for the tag-generator service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: langdetect, psutil, psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_685f5cee84ac832bb46a796a4d2dce6d