### PR TITLE
Add port validation to ArticleFetcherService

### DIFF
--- a/pre-processor/app/service/article_fetcher.go
+++ b/pre-processor/app/service/article_fetcher.go
@@ -108,6 +108,19 @@ func (s *articleFetcherService) ValidateURL(urlStr string) error {
 		return errors.New("only HTTP or HTTPS schemes allowed")
 	}
 
+	// Additional SSRF and port validation
+	if err := s.validateURLForSSRF(parsedURL); err != nil {
+		s.logger.Error("URL validation failed", "url", urlStr, "error", err)
+		return err
+	}
+
+	if port := parsedURL.Port(); port != "" {
+		if err := s.validateTarget(parsedURL.Hostname(), port); err != nil {
+			s.logger.Error("URL validation failed", "url", urlStr, "error", err)
+			return err
+		}
+	}
+
 	s.logger.Info("URL validated successfully", "url", urlStr)
 
 	return nil

--- a/pre-processor/app/service/article_fetcher_test.go
+++ b/pre-processor/app/service/article_fetcher_test.go
@@ -66,6 +66,14 @@ func TestArticleFetcherService_ValidateURL(t *testing.T) {
 			input:       "https://example.com/path with spaces",
 			expectError: false,
 		},
+		"should reject blocked port 22": {
+			input:       "https://example.com:22",
+			expectError: true,
+		},
+		"should reject blocked port 3306": {
+			input:       "https://example.com:3306",
+			expectError: true,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
## Summary
- validate ports in `ArticleFetcherService.ValidateURL`
- test port rejection for blocked ports 22 and 3306

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f5cfe7600832b9abc0c0b51491b60