### PR TITLE
Add vet and coverage steps to workflows

### DIFF
--- a/.github/workflows/backend-go.yaml
+++ b/.github/workflows/backend-go.yaml
@@ -21,10 +21,20 @@ jobs:
       run: |
         cd alt-backend/app
         go mod tidy
-    - name: Run tests
+    - name: Run go vet
       run: |
         cd alt-backend/app
-        go test ./...
+        go vet ./...
+    - name: Run tests with coverage
+      run: |
+        cd alt-backend/app
+        go test -coverprofile=coverage.out ./...
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./alt-backend/app/coverage.out
+        flags: alt-backend
+        name: alt-backend-coverage
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/rask-log-forwarder.yml
+++ b/.github/workflows/rask-log-forwarder.yml
@@ -28,5 +28,22 @@ jobs:
     - name: Build (release)
       run: cargo build --release
 
+    - name: Run clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
+
     - name: Run unit tests
       run: cargo test --all --verbose
+
+    - name: Install cargo-tarpaulin
+      run: cargo install cargo-tarpaulin
+
+    - name: Generate coverage report
+      run: cargo tarpaulin --out Xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./rask-log-forwarder/app/tarpaulin-report.xml
+        flags: rask-log-forwarder
+        name: rask-log-forwarder-coverage
+

--- a/.github/workflows/search-indexer.yaml
+++ b/.github/workflows/search-indexer.yaml
@@ -21,12 +21,23 @@ jobs:
       run: |
         cd search-indexer/app
         go mod tidy
-    - name: Run tests
+    - name: Run go vet
       run: |
         cd search-indexer/app
-        go test ./...
+        go vet ./...
+    - name: Run tests with coverage
+      run: |
+        cd search-indexer/app
+        go test -coverprofile=coverage.out ./...
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./search-indexer/app/coverage.out
+        flags: search-indexer
+        name: search-indexer-coverage
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
         name: go-test-results
         path: search-indexer/test-results/
+        retention-days: 30


### PR DESCRIPTION
## Summary
- run `go vet` and collect coverage for Go services
- send coverage reports to Codecov
- add `cargo clippy` and tarpaulin coverage for Rust log forwarder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f5f7bac20832bb40fa28dbf78be0f