### PR TITLE
Add path filters for CI workflows

### DIFF
--- a/.github/workflows/backend-go.yaml
+++ b/.github/workflows/backend-go.yaml
@@ -2,8 +2,12 @@ name: Backend Go Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'alt-backend/**'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'alt-backend/**'
 
 permissions:
   contents: read

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,8 +2,12 @@ name: Playwright Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'alt-frontend/**'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'alt-frontend/**'
 
 # 同一ブランチ/PR の古い実行をキャンセル
 concurrency:

--- a/.github/workflows/rask-log-forwarder.yml
+++ b/.github/workflows/rask-log-forwarder.yml
@@ -3,8 +3,12 @@ name: Rask Log Forwarder Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'rask-log-forwarder/**'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'rask-log-forwarder/**'
 
 permissions:
   contents: read

--- a/.github/workflows/search-indexer.yaml
+++ b/.github/workflows/search-indexer.yaml
@@ -2,8 +2,12 @@ name: Search Indexer Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'search-indexer/**'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'search-indexer/**'
 
 permissions:
   contents: read

--- a/.github/workflows/tag-generator.yaml
+++ b/.github/workflows/tag-generator.yaml
@@ -3,8 +3,12 @@ name: Tag Generator Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'tag-generator/**'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'tag-generator/**'
 
 permissions:
   contents: read

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -2,8 +2,12 @@ name: Unit and Component Tests
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'alt-frontend/**'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'alt-frontend/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- trigger backend tests only on alt-backend changes
- trigger search-indexer tests only on search-indexer changes
- trigger frontend tests only on alt-frontend changes
- trigger log forwarder tests only on rask-log-forwarder changes
- trigger tag generator tests only on tag-generator changes

## Testing
- `go test ./...` *(fails: Forbidden - proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f5f74c0e0832b8e02e07f116979ee