### PR TITLE
Add cache to CI jobs

### DIFF
--- a/.github/workflows/backend-go.yaml
+++ b/.github/workflows/backend-go.yaml
@@ -17,6 +17,17 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.24
+        cache-dependency-path: alt-backend/app/go.sum
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('alt-backend/app/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Install dependencies
       run: |
         cd alt-backend/app

--- a/.github/workflows/rask-log-forwarder.yml
+++ b/.github/workflows/rask-log-forwarder.yml
@@ -25,6 +25,11 @@ jobs:
         toolchain: stable
         profile: minimal
 
+    - uses: swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          rask-log-forwarder/app
+
     - name: Build (release)
       run: cargo build --release
 

--- a/.github/workflows/search-indexer.yaml
+++ b/.github/workflows/search-indexer.yaml
@@ -17,6 +17,17 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.24
+        cache-dependency-path: search-indexer/app/go.sum
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('search-indexer/app/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Install dependencies
       run: |
         cd search-indexer/app

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -13,13 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: "pnpm"
+          cache-dependency-path: alt-frontend/app/pnpm-lock.yaml
+
       - name: Install dependencies
         run: |
           cd alt-frontend/app
-          npm install -g pnpm && pnpm install
+          pnpm install
       - name: Run tests
         run: |
           cd alt-frontend/app


### PR DESCRIPTION
## Summary
- speed up CI by caching dependencies
- use Go cache for backend-go and search-indexer jobs
- cache pnpm modules in vitest job
- add cargo cache for rask-log-forwarder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f5f675524832bb381c8d10d5f2f9a