### PR TITLE
Fix gosec security issues

### DIFF
--- a/pre-processor/app/middleware/request_id_middleware.go
+++ b/pre-processor/app/middleware/request_id_middleware.go
@@ -5,6 +5,8 @@ package middleware
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -36,6 +38,9 @@ func RequestIDMiddleware() echo.MiddlewareFunc {
 
 func generateRequestID() string {
 	bytes := make([]byte, 8)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		logger.Logger.Error("failed to generate request ID", "error", err)
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
 	return hex.EncodeToString(bytes)
 }

--- a/pre-processor/app/utils/errors/retry_policy.go
+++ b/pre-processor/app/utils/errors/retry_policy.go
@@ -5,8 +5,9 @@ package errors
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
+
+	"pre-processor/app/utils"
 )
 
 // RetryPolicy defines the retry behavior for failed operations
@@ -61,7 +62,7 @@ func (rp *RetryPolicy) CalculateDelay(attempt int) time.Duration {
 	if rp.Jitter {
 		// Add random jitter between 50% and 100% of calculated delay
 		jitterRange := float64(delay) * 0.5
-		jitter := rand.Float64() * jitterRange
+		jitter := utils.SecureRandomFloat64() * jitterRange
 		delay = time.Duration(float64(delay)*0.5 + jitter)
 	}
 

--- a/pre-processor/app/utils/random.go
+++ b/pre-processor/app/utils/random.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	crand "crypto/rand"
+	"math"
+	"math/big"
+)
+
+// SecureRandomFloat64 returns a cryptographically secure random number in [0,1).
+// If the system random number generator fails, 0 is returned.
+func SecureRandomFloat64() float64 {
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return 0
+	}
+	return float64(n.Int64()) / float64(math.MaxInt64)
+}

--- a/pre-processor/app/utils/rate_limiter.go
+++ b/pre-processor/app/utils/rate_limiter.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"sync"
@@ -95,7 +94,8 @@ func (r *RateLimiter) Wait() {
 	elapsed := time.Since(r.lastRequest)
 
 	// Add jitter (±20% of interval) to reduce thundering herd
-	jitter := time.Duration(rand.Float64()*0.4-0.2) * r.interval
+	j := SecureRandomFloat64()*0.4 - 0.2
+	jitter := time.Duration(j * float64(r.interval))
 	waitTime := r.interval + jitter
 
 	if elapsed < waitTime {
@@ -161,7 +161,7 @@ func (c *RateLimitedHTTPClient) GetWithRetry(ctx context.Context, url string) (*
 		if attempt > 0 {
 			// Exponential backoff with jitter
 			backoff := time.Duration(math.Pow(2, float64(attempt-1))) * time.Second
-			jitter := time.Duration(rand.Float64() * float64(backoff) * 0.1)
+			jitter := time.Duration(SecureRandomFloat64() * float64(backoff) * 0.1)
 
 			select {
 			case <-time.After(backoff + jitter):
@@ -176,7 +176,9 @@ func (c *RateLimitedHTTPClient) GetWithRetry(ctx context.Context, url string) (*
 		}
 
 		if resp != nil {
-			resp.Body.Close()
+			if errClose := resp.Body.Close(); errClose != nil {
+				c.logger.Error("failed to close response body", "error", errClose)
+			}
 		}
 
 		c.logger.Warn("request failed, retrying",


### PR DESCRIPTION
## Summary
- replace math/rand usage with cryptographically secure helper
- handle errors when closing HTTP bodies
- handle rand.Read error when generating request IDs

## Testing
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6860b1cbbe08832ba1e3bbaff3425d9f