### PR TITLE
Fix gosec security issues

### DIFF
--- a/pre-processor/app/middleware/request_id_middleware.go
+++ b/pre-processor/app/middleware/request_id_middleware.go
@@ -5,6 +5,8 @@ package middleware
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -36,6 +38,9 @@ func RequestIDMiddleware() echo.MiddlewareFunc {
 
 func generateRequestID() string {
 	bytes := make([]byte, 8)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		logger.Logger.Error("failed to generate request ID", "error", err)
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
 	return hex.EncodeToString(bytes)
 }

--- a/pre-processor/app/utils/errors/random.go
+++ b/pre-processor/app/utils/errors/random.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	crand "crypto/rand"
+	"math"
+	"math/big"
+)
+
+// SecureRandomFloat64 returns a cryptographically secure random number in [0,1).
+// If the system random number generator fails, 0 is returned.
+func SecureRandomFloat64() float64 {
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return 0
+	}
+	return float64(n.Int64()) / float64(math.MaxInt64)
+}

--- a/pre-processor/app/utils/errors/retry_policy.go
+++ b/pre-processor/app/utils/errors/retry_policy.go
@@ -5,7 +5,6 @@ package errors
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 )
 
@@ -61,7 +60,7 @@ func (rp *RetryPolicy) CalculateDelay(attempt int) time.Duration {
 	if rp.Jitter {
 		// Add random jitter between 50% and 100% of calculated delay
 		jitterRange := float64(delay) * 0.5
-		jitter := rand.Float64() * jitterRange
+		jitter := SecureRandomFloat64() * jitterRange
 		delay = time.Duration(float64(delay)*0.5 + jitter)
 	}
 


### PR DESCRIPTION
## Summary
- replace math/rand usage with cryptographically secure helper
- handle errors when closing HTTP bodies
- handle rand.Read error when generating request IDs
- move SecureRandomFloat64 into errors package to avoid import cycle

## Testing
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6860b1cbbe08832ba1e3bbaff3425d9f