### PR TITLE
Fix rate limiter jitter not to shorten wait

### DIFF
--- a/pre-processor/app/utils/rate_limiter.go
+++ b/pre-processor/app/utils/rate_limiter.go
@@ -94,8 +94,9 @@ func (r *RateLimiter) Wait() {
 
 	elapsed := time.Since(r.lastRequest)
 
-	// Add jitter (±20% of interval) to reduce thundering herd
-	jitter := time.Duration(rand.Float64()*0.4-0.2) * r.interval
+	// Add jitter up to +20% of the interval to reduce thundering herd
+	// Jitter should never shorten the wait below the base interval
+	jitter := time.Duration(rand.Float64()*0.2) * r.interval
 	waitTime := r.interval + jitter
 
 	if elapsed < waitTime {


### PR DESCRIPTION
## Summary
- make rate limiter jitter non-negative so intervals aren't shortened

## Testing
- `go test ./utils -run TestRateLimitedHTTPClient_BasicRateLimit -count=1` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6860fdf88ae4832b9bda392a847539e8