### PR TITLE
Fix security warnings in rate limiter

### DIFF
--- a/pre-processor/app/middleware/request_id_middleware.go
+++ b/pre-processor/app/middleware/request_id_middleware.go
@@ -5,6 +5,7 @@ package middleware
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -36,6 +37,9 @@ func RequestIDMiddleware() echo.MiddlewareFunc {
 
 func generateRequestID() string {
 	bytes := make([]byte, 8)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		// In the unlikely event of failure, fallback to timestamp based ID
+		return hex.EncodeToString([]byte(time.Now().Format("150405.000000")))
+	}
 	return hex.EncodeToString(bytes)
 }


### PR DESCRIPTION
## Summary
- replace math/rand usage with crypto/rand helpers
- handle errors from response body close and request ID generator
- ensure jitter calculations use secure random numbers

## Testing
- `make security` *(fails: gosec not installed)*
- `go test ./utils -run TestRateLimitedHTTPClient_BasicRateLimit -count=1` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6860fdf88ae4832b9bda392a847539e8