### PR TITLE
Fix input styles on feeds pages

### DIFF
--- a/alt-frontend/app/src/app/globals.css
+++ b/alt-frontend/app/src/app/globals.css
@@ -492,6 +492,13 @@ select {
   font-size: inherit;
 }
 
+/* Consistent placeholder style */
+input::placeholder {
+  text-align: center;
+  color: var(--text-muted);
+  opacity: 1;
+}
+
 ::selection {
   background: var(--alt-primary);
   color: white;

--- a/alt-frontend/app/src/app/mobile/feeds/register/page.tsx
+++ b/alt-frontend/app/src/app/mobile/feeds/register/page.tsx
@@ -87,13 +87,13 @@ export default function RegisterFeedsPage() {
                   value={feedUrl}
                   onChange={(e) => setFeedUrl(e.target.value)}
                   placeholder="https://example.com/feed.xml"
-                  bg="var(--alt-glass)"
-                  border="1px solid var(--alt-glass-border)"
-                  color="white"
-                  _placeholder={{ color: "var(--alt-text-secondary)" }}
+                  bg="var(--surface-bg)"
+                  border="1px solid var(--alt-primary)"
+                  color="var(--text-primary)"
+                  _placeholder={{ color: "var(--text-muted)" }}
                   _focus={{
-                    borderColor: "var(--accent-primary)",
-                    boxShadow: "0 0 0 1px var(--accent-primary)",
+                    borderColor: "var(--alt-primary)",
+                    boxShadow: "0 0 0 1px var(--alt-primary)",
                   }}
                 />
               </Box>

--- a/alt-frontend/app/src/components/mobile/search/SearchWindow.tsx
+++ b/alt-frontend/app/src/components/mobile/search/SearchWindow.tsx
@@ -139,13 +139,13 @@ const SearchWindow = ({
                 }
               }}
               onKeyDown={handleKeyPress}
-              bg="rgba(255, 255, 255, 0.1)"
-              border={`1px solid ${validationError ? "#f87171" : "rgba(255, 255, 255, 0.2)"}`}
-              color="white"
-              _placeholder={{ color: "rgba(255, 255, 255, 0.5)" }}
+              bg="var(--surface-bg)"
+              border={`1px solid ${validationError ? "#f87171" : "var(--alt-primary)"}`}
+              color="var(--text-primary)"
+              _placeholder={{ color: "var(--text-muted)" }}
               _focus={{
-                borderColor: validationError ? "#f87171" : "#ff006e",
-                boxShadow: `0 0 0 1px ${validationError ? "#f87171" : "#ff006e"}`,
+                borderColor: validationError ? "#f87171" : "var(--alt-primary)",
+                boxShadow: `0 0 0 1px ${validationError ? "#f87171" : "var(--alt-primary)"}`,
               }}
             />
           </Box>


### PR DESCRIPTION
## Summary
- add consistent placeholder styling in global CSS
- use design variables on Register Feeds page
- update Search Feeds input to follow design system

## Testing
- `pnpm test:logic` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a95bae10832b87fd58ae00ef4f68