### PR TITLE
Add consistent design to article search

### DIFF
--- a/alt-frontend/app/src/app/mobile/articles/search/page.tsx
+++ b/alt-frontend/app/src/app/mobile/articles/search/page.tsx
@@ -3,7 +3,7 @@
 import { SearchArticles } from "@/components/mobile/search/SearchArticles";
 import { ArticleCard } from "@/components/mobile/ArticleCard";
 import { FloatingMenu } from "@/components/mobile/utils/FloatingMenu";
-import { Flex, Box } from "@chakra-ui/react";
+import { Box, VStack, Text } from "@chakra-ui/react";
 import { useState, Suspense } from "react";
 import { Article } from "@/schema/article";
 import { CircularProgress } from "@chakra-ui/progress";
@@ -14,36 +14,75 @@ export default function SearchPage() {
   const [error, setError] = useState<string | null>(null);
 
   return (
-    <Box
-      width="100%"
-      className="feed-container"
-      minHeight="100vh"
-      minH="100dvh"
-      position="relative"
-    >
-      <Flex
-        flexDirection="column"
-        alignItems="center"
-        width="100%"
-        px={4}
-        pt={6}
-        pb="calc(80px + env(safe-area-inset-bottom))"
-      >
-        <Suspense fallback={<CircularProgress isIndeterminate />}>
-          <SearchArticles
-            articles={articles}
-            setArticles={setArticles}
-            query={query}
-            setQuery={setQuery}
-            error={error}
-            setError={setError}
-          />
-        </Suspense>
-        {articles.length > 0 &&
-          articles.map((article) => (
-            <ArticleCard key={article.id} article={article} />
-          ))}
-      </Flex>
+    <Box minHeight="100vh" bg="var(--alt-gradient-bg)" color="white" p={4}>
+      <VStack gap={6} align="stretch" maxWidth="600px" mx="auto">
+        {/* Header Section */}
+        <VStack gap={3} mt={8} mb={2}>
+          <Text
+            fontSize="3xl"
+            fontWeight="bold"
+            textAlign="center"
+            color="var(--alt-text-primary)"
+            bgGradient="var(--accent-gradient)"
+            bgClip="text"
+          >
+            Search Articles
+          </Text>
+          <Text
+            textAlign="center"
+            color="var(--alt-text-secondary)"
+            fontSize="md"
+            maxWidth="400px"
+          >
+            Explore articles from your subscribed feeds
+          </Text>
+        </VStack>
+
+        {/* Search Input Section */}
+        <Box
+          bg="var(--alt-glass)"
+          p={6}
+          borderRadius="xl"
+          border="1px solid var(--alt-glass-border)"
+          boxShadow="0 8px 32px var(--alt-glass-shadow)"
+        >
+          <Suspense fallback={<CircularProgress isIndeterminate />}>
+            <SearchArticles
+              articles={articles}
+              setArticles={setArticles}
+              query={query}
+              setQuery={setQuery}
+              error={error}
+              setError={setError}
+            />
+          </Suspense>
+        </Box>
+
+        {/* Search Results Section */}
+        {articles.length > 0 ? (
+          <VStack gap={4} align="stretch">
+            {articles.map((article) => (
+              <ArticleCard key={article.id} article={article} />
+            ))}
+          </VStack>
+        ) : (
+          !error && (
+            <Box
+              bg="var(--alt-glass)"
+              p={4}
+              borderRadius="lg"
+              border="1px solid var(--alt-glass-border)"
+            >
+              <Text color="var(--alt-text-secondary)" fontSize="sm" textAlign="center">
+                {query
+                  ? `No articles match "${query}". Try different keywords.`
+                  : '💡 Try searching for topics like "AI", "technology", or "news"'}
+              </Text>
+            </Box>
+          )
+        )}
+      </VStack>
+
       <FloatingMenu />
     </Box>
   );

--- a/alt-frontend/app/src/components/mobile/ArticleCard.tsx
+++ b/alt-frontend/app/src/components/mobile/ArticleCard.tsx
@@ -8,28 +8,27 @@ interface ArticleCardProps {
 export const ArticleCard = ({ article }: ArticleCardProps) => {
   return (
     <Box
-      data-testid="article-card"
-      className="article-card-wrapper"
-      width="100%"
+      p="2px"
+      borderRadius="18px"
+      border="2px solid var(--surface-border)"
+      transition="transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out"
+      cursor="pointer"
+      data-testid="article-card-container"
     >
       <Box
         className="glass"
         w="full"
         p={5}
+        borderRadius="16px"
         mb={4}
-        borderRadius="18px"
-        cursor="pointer"
-        transition="all 0.3s ease"
-        _hover={{
-          transform: "translateY(-5px)",
-          boxShadow: "0 20px 40px var(--accent-primary)",
-        }}
+        role="article"
+        aria-label={`Article: ${article.title}`}
       >
         <Flex direction="column" gap={3}>
           <Text
             fontSize="lg"
-            fontWeight="bold"
-            color="white"
+            fontWeight="semibold"
+            color="var(--accent-primary)"
             lineHeight="1.4"
             overflow="hidden"
             textOverflow="ellipsis"
@@ -49,12 +48,23 @@ export const ArticleCard = ({ article }: ArticleCardProps) => {
           >
             <Dialog.Trigger asChild>
               <Button
-                color="var(--alt-primary)"
                 size="sm"
-                borderRadius="10px"
+                borderRadius="full"
+                bg="var(--alt-primary)"
+                color="var(--text-primary)"
+                fontWeight="bold"
+                px={4}
+                minHeight="36px"
+                minWidth="100px"
+                fontSize="sm"
+                border="1px solid rgba(255, 255, 255, 0.2)"
                 _hover={{
+                  bg: "var(--accent-gradient)",
                   transform: "scale(1.05)",
+                  boxShadow: "0 4px 12px var(--accent-primary)",
                 }}
+                _active={{ transform: "scale(0.98)" }}
+                transition="all 0.2s ease"
               >
                 Details
               </Button>
@@ -66,6 +76,7 @@ export const ArticleCard = ({ article }: ArticleCardProps) => {
                   className="glass"
                   backdropFilter="blur(20px)"
                   border="1px solid"
+                  borderColor="var(--surface-border)"
                   borderRadius="20px"
                   boxShadow="0 25px 50px var(--accent-primary)"
                   mx={4}
@@ -98,9 +109,14 @@ export const ArticleCard = ({ article }: ArticleCardProps) => {
                       <Button
                         variant="outline"
                         color="var(--alt-primary)"
-                        borderRadius="10px"
+                        borderRadius="full"
                         size="md"
                         w="full"
+                        border="1px solid var(--alt-primary)"
+                        _hover={{
+                          bg: "var(--accent-gradient)",
+                          color: "var(--text-primary)",
+                        }}
                       >
                         Close
                       </Button>


### PR DESCRIPTION
## Summary
- style `/mobile/articles/search` page like `/mobile/feeds/search`
- clean up `ArticleCard` for theme consistency

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm fmt`
- `pnpm test:logic` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863539cdfa8832bb8cf044ee4c26ae5