### PR TITLE
Fix FeedCard icon sizing

### DIFF
--- a/alt-frontend/app/e2e/components/FeedCardIcon.spec.ts
+++ b/alt-frontend/app/e2e/components/FeedCardIcon.spec.ts
@@ -28,11 +28,12 @@ test.describe("FeedCard Icon Size", () => {
   test("icon size remains consistent for varying title lengths", async ({ page }) => {
     await page.goto("/mobile/feeds");
     await page.waitForLoadState("networkidle");
-    const firstIcon = page.getByTestId("feed-link-icon-1");
-    const secondIcon = page.getByTestId("feed-link-icon-2");
+    const icons = page.locator('[data-testid^="feed-link-icon-"]');
+    const firstIcon = icons.nth(0);
+    const secondIcon = icons.nth(1);
 
-    await expect(firstIcon).toBeVisible();
-    await expect(secondIcon).toBeVisible();
+    await expect(firstIcon).toBeVisible({ timeout: 10000 });
+    await expect(secondIcon).toBeVisible({ timeout: 10000 });
 
     const firstSize = await firstIcon.evaluate((el) => ({
       width: el.clientWidth,

--- a/alt-frontend/app/e2e/components/FeedCardIcon.spec.ts
+++ b/alt-frontend/app/e2e/components/FeedCardIcon.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { mockApiEndpoints } from "../helpers/mockApi";
+import { Feed } from "@/schema/feed";
+
+const feeds: Feed[] = [
+  {
+    id: "1",
+    title: "Short title",
+    description: "desc",
+    link: "https://example.com/short",
+    published: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "2",
+    title: "Very long title that spans multiple lines and should not affect the icon size at all",
+    description: "desc",
+    link: "https://example.com/long",
+    published: "2024-01-02T00:00:00Z",
+  },
+];
+
+test.describe("FeedCard Icon Size", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.unrouteAll();
+    await mockApiEndpoints(page, { feeds });
+  });
+
+  test("icon size remains consistent for varying title lengths", async ({ page }) => {
+    await page.goto("/mobile/feeds");
+    await page.waitForLoadState("networkidle");
+    const firstIcon = page.getByTestId("feed-link-icon-1");
+    const secondIcon = page.getByTestId("feed-link-icon-2");
+
+    await expect(firstIcon).toBeVisible();
+    await expect(secondIcon).toBeVisible();
+
+    const firstSize = await firstIcon.evaluate((el) => ({
+      width: el.clientWidth,
+      height: el.clientHeight,
+    }));
+    const secondSize = await secondIcon.evaluate((el) => ({
+      width: el.clientWidth,
+      height: el.clientHeight,
+    }));
+
+    expect(firstSize.width).toBe(secondSize.width);
+    expect(firstSize.height).toBe(secondSize.height);
+  });
+});

--- a/alt-frontend/app/src/components/mobile/FeedCard.tsx
+++ b/alt-frontend/app/src/components/mobile/FeedCard.tsx
@@ -79,7 +79,17 @@ const FeedCard = memo(function FeedCard({
         <Flex direction="column" gap={2}>
           {/* Title as link */}
           <Flex direction="row" align="center" gap={2}>
-            <SquareArrowOutUpRight color="var(--alt-primary)" size={24} />
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              width="24px"
+              height="24px"
+              flexShrink={0}
+              data-testid={`feed-link-icon-${feed.id}`}
+            >
+              <SquareArrowOutUpRight color="var(--alt-primary)" size={24} />
+            </Box>
             <Link
               href={feed.link}
               target="_blank"
@@ -87,7 +97,7 @@ const FeedCard = memo(function FeedCard({
               aria-label={`Open ${feed.title} in external link`}
             >
               <Text
-                fontSize="lg"
+                fontSize="md"
                 fontWeight="semibold"
                 color="var(--accent-primary)"
                 _hover={{ textDecoration: "underline" }}


### PR DESCRIPTION
## Summary
- keep external link icon from shrinking
- lower FeedCard title text size
- test icon sizing in FeedCard

## Testing
- `pnpm run test:logic`
- `pnpm run test:all` *(fails: long-running, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6863a5803bec832b86b7397294caf1e4