### PR TITLE
Fix e2e mocks for alt-frontend

### DIFF
--- a/alt-frontend/app/e2e/mobile/feeds/feeds.spec.ts
+++ b/alt-frontend/app/e2e/mobile/feeds/feeds.spec.ts
@@ -14,6 +14,7 @@ const generateMockFeeds = (count: number, startId: number = 1): Feed[] => {
 
 test.describe("Mobile Feeds Page", () => {
   test.beforeEach(async ({ page }) => {
+    await page.unrouteAll();
     const mockFeeds = generateMockFeeds(10, 1);
 
     // Convert Feed[] to BackendFeedItem[] for API compatibility

--- a/alt-frontend/app/e2e/mobile/feeds/feeds.spec.ts
+++ b/alt-frontend/app/e2e/mobile/feeds/feeds.spec.ts
@@ -99,7 +99,7 @@ test.describe("Mobile Feeds Page", () => {
     // Add error handling for any unmatched routes
     await page.route("**/api/**", async (route) => {
       console.log(`Unmatched API route: ${route.request().url()}`);
-      await route.continue();
+      await route.fallback();
     });
   });
 


### PR DESCRIPTION
## Summary
- update e2e mock API helper to handle requests to localhost:8080
- allow unmatched route logging handler to fallback so specific mocks run

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test:e2e --reporter=line` *(fails: 11 failed, 1 interrupted, 148 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68669bc38900832bbd57b19bc2343807