### PR TITLE
Add 404 redirect to home

### DIFF
--- a/alt-frontend/app/README.md
+++ b/alt-frontend/app/README.md
@@ -16,6 +16,7 @@ This is the frontend for the Alt project - a mobile-first RSS reader built with 
 - **Viewed Feeds Page** (`/mobile/feeds/viewed`): Dedicated page for viewing previously read articles
 - **Enhanced Navigation**: FloatingMenu with active state indicators
 - **Optimized Performance**: Cursor-based pagination with prefetching capabilities
+- **Automatic Redirects**: Unknown routes seamlessly return to the home page
 
 ## Pages Overview
 

--- a/alt-frontend/app/e2e/redirect-404.spec.ts
+++ b/alt-frontend/app/e2e/redirect-404.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("redirects unknown paths to home", async ({ page }) => {
+  await page.route("**/api/v1/feeds/stats", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        feed_amount: { amount: 0 },
+        summarized_feed: { amount: 0 },
+      }),
+    });
+  });
+
+  await page.goto("/non-existent-page");
+  await page.waitForLoadState("networkidle");
+  await expect(page).toHaveURL("/");
+});

--- a/alt-frontend/app/src/app/not-found.tsx
+++ b/alt-frontend/app/src/app/not-found.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function NotFound() {
+  redirect('/')
+}


### PR DESCRIPTION
## Summary
- redirect all unknown routes to the home page via a `not-found.tsx`
- document the new behaviour in the frontend README
- add a Playwright test for the redirect

## Testing
- `pnpm lint`
- `npx vitest run`
- `npx playwright test e2e/redirect-404.spec.ts --project=chromium` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866aed21b1c832b82fb390f03a74027