### PR TITLE
Add favorites page & favorite button

### DIFF
--- a/alt-frontend/app/src/app/mobile/feeds/favorites/page.tsx
+++ b/alt-frontend/app/src/app/mobile/feeds/favorites/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { Flex, Text, Box } from "@chakra-ui/react";
+import { feedsApi } from "@/lib/api";
+import { Feed } from "@/schema/feed";
+import FeedCard from "@/components/mobile/FeedCard";
+import SkeletonFeedCard from "@/components/mobile/SkeletonFeedCard";
+import { useRef, useState, useCallback, useMemo } from "react";
+import { useInfiniteScroll } from "@/lib/utils/infiniteScroll";
+import { useCursorPagination } from "@/hooks/useCursorPagination";
+import ErrorState from "../_components/ErrorState";
+import { FloatingMenu } from "@/components/mobile/utils/FloatingMenu";
+
+const PAGE_SIZE = 20;
+
+export default function FavoriteFeedsPage() {
+  const [readFeeds, setReadFeeds] = useState<Set<string>>(new Set());
+  const [liveRegionMessage, setLiveRegionMessage] = useState<string>("");
+  const [isRetrying, setIsRetrying] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const {
+    data: feeds,
+    hasMore,
+    isLoading,
+    error,
+    isInitialLoading,
+    loadMore,
+    refresh,
+  } = useCursorPagination(feedsApi.getFavoriteFeedsWithCursor, {
+    limit: PAGE_SIZE,
+    autoLoad: true,
+  });
+
+  const visibleFeeds = useMemo(
+    () => feeds?.filter((feed) => !readFeeds.has(feed.link)) || [],
+    [feeds, readFeeds],
+  );
+
+  const handleMarkAsRead = useCallback((feedLink: string) => {
+    setReadFeeds((prev) => {
+      const newSet = new Set(prev);
+      newSet.add(feedLink);
+      setLiveRegionMessage(`Feed marked as read`);
+      setTimeout(() => setLiveRegionMessage(""), 1000);
+      return newSet;
+    });
+  }, []);
+
+  const retryFetch = useCallback(async () => {
+    setIsRetrying(true);
+
+    try {
+      await refresh();
+    } catch (err) {
+      console.error("Retry failed:", err);
+      throw err;
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [refresh]);
+
+  const handleLoadMore = useCallback(() => {
+    if (hasMore && !isLoading) {
+      loadMore();
+    }
+  }, [hasMore, isLoading, loadMore]);
+
+  useInfiniteScroll(handleLoadMore, sentinelRef, feeds?.length || 0, {
+    throttleDelay: 200,
+    rootMargin: "100px 0px",
+    threshold: 0.1,
+  });
+
+  if (isInitialLoading) {
+    return (
+      <Box minH="100vh" position="relative">
+        <Box
+          p={5}
+          maxW="container.sm"
+          mx="auto"
+          height="100vh"
+          data-testid="favorites-skeleton-container"
+        >
+          <Flex direction="column" gap={4}>
+            {Array.from({ length: 5 }).map((_, index) => (
+              <SkeletonFeedCard key={`skeleton-${index}`} />
+            ))}
+          </Flex>
+        </Box>
+
+        <FloatingMenu />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <ErrorState error={error} onRetry={retryFetch} isLoading={isRetrying} />;
+  }
+
+  return (
+    <Box minH="100vh" position="relative">
+      <Box
+        aria-live="polite"
+        aria-atomic="true"
+        position="absolute"
+        left="-10000px"
+        width="1px"
+        height="1px"
+        overflow="hidden"
+      >
+        {liveRegionMessage}
+      </Box>
+
+      <Box
+        ref={scrollContainerRef}
+        p={5}
+        maxW="container.sm"
+        mx="auto"
+        overflowY="auto"
+        overflowX="hidden"
+        height="100vh"
+        data-testid="favorites-scroll-container"
+        bg="var(--app-bg)"
+      >
+        {visibleFeeds.length > 0 ? (
+          <>
+            <Flex direction="column" gap={4}>
+              {visibleFeeds.map((feed: Feed) => (
+                <FeedCard
+                  key={feed.link}
+                  feed={feed}
+                  isReadStatus={readFeeds.has(feed.link)}
+                  setIsReadStatus={() => handleMarkAsRead(feed.link)}
+                />
+              ))}
+            </Flex>
+
+            {!hasMore && visibleFeeds.length > 0 && (
+              <Text
+                textAlign="center"
+                color="var(--alt-text-secondary)"
+                fontSize="sm"
+                mt={8}
+                mb={4}
+              >
+                No more feeds to load
+              </Text>
+            )}
+          </>
+        ) : (
+          <Flex justify="center" align="center" py={20}>
+            <Text color="var(--alt-text-secondary)" fontSize="lg">
+              No feeds available
+            </Text>
+          </Flex>
+        )}
+
+        {visibleFeeds.length > 0 && hasMore && (
+          <div
+            ref={sentinelRef}
+            style={{
+              height: "50px",
+              width: "100%",
+              backgroundColor: "transparent",
+              margin: "10px 0",
+              position: "relative",
+              zIndex: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+            data-testid="infinite-scroll-sentinel"
+          >
+            {isLoading && (
+              <Text color="var(--alt-text-secondary)" fontSize="sm">
+                Loading more...
+              </Text>
+            )}
+          </div>
+        )}
+      </Box>
+
+      <FloatingMenu />
+    </Box>
+  );
+}

--- a/alt-frontend/app/src/components/mobile/FeedDetails.tsx
+++ b/alt-frontend/app/src/components/mobile/FeedDetails.tsx
@@ -290,9 +290,9 @@ export const FeedDetails = ({ feedURL }: { feedURL: string }) => {
                   minWidth="80px"
                   fontSize="sm"
                   border="1px solid rgba(255, 255, 255, 0.2)"
-                  leftIcon={<Star size={16} />}
-                  isDisabled={isFavoriting}
+                  disabled={isFavoriting}
                 >
+                  <Star size={16} style={{ marginRight: 4 }} />
                   {isFavoriting ? "Saving" : "Fave"}
                 </Button>
                 <Button

--- a/alt-frontend/app/src/components/mobile/FeedDetails.tsx
+++ b/alt-frontend/app/src/components/mobile/FeedDetails.tsx
@@ -1,6 +1,6 @@
 import { HStack, Text, Box, Portal, Button } from "@chakra-ui/react";
 import { useState, useEffect, useCallback } from "react";
-import { X } from "lucide-react";
+import { X, Star } from "lucide-react";
 import { FeedDetails as FeedDetailsType, FeedURLPayload } from "@/schema/feed";
 import { feedsApi } from "@/lib/api";
 
@@ -8,6 +8,7 @@ export const FeedDetails = ({ feedURL }: { feedURL: string }) => {
   const [feedDetails, setFeedDetails] = useState<FeedDetailsType | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isFavoriting, setIsFavoriting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleHideDetails = useCallback(() => {
@@ -252,7 +253,7 @@ export const FeedDetails = ({ feedURL }: { feedURL: string }) => {
                 </Text>
               </Box>
 
-              {/* Modal Footer with Hide Details button */}
+              {/* Modal Footer with Fave and Hide Details buttons */}
               <Box
                 position="sticky"
                 bottom="0"
@@ -265,9 +266,35 @@ export const FeedDetails = ({ feedURL }: { feedURL: string }) => {
                 borderBottomRadius="20px"
                 display="flex"
                 alignItems="center"
-                justifyContent="flex-end"
+                justifyContent="space-between"
                 minHeight="50px"
               >
+                <Button
+                  onClick={async () => {
+                    try {
+                      setIsFavoriting(true);
+                      await feedsApi.registerFavoriteFeed(feedURL);
+                    } catch (e) {
+                      console.error("Failed to favorite feed", e);
+                    } finally {
+                      setIsFavoriting(false);
+                    }
+                  }}
+                  size="sm"
+                  borderRadius="full"
+                  bg="var(--alt-primary)"
+                  color="var(--text-primary)"
+                  fontWeight="bold"
+                  px={4}
+                  minHeight="36px"
+                  minWidth="80px"
+                  fontSize="sm"
+                  border="1px solid rgba(255, 255, 255, 0.2)"
+                  leftIcon={<Star size={16} />}
+                  isDisabled={isFavoriting}
+                >
+                  {isFavoriting ? "Saving" : "Fave"}
+                </Button>
                 <Button
                   onClick={handleHideDetails}
                   data-testid={`hide-details-button-${uniqueId}`}

--- a/alt-frontend/app/src/components/mobile/utils/FloatingMenu.tsx
+++ b/alt-frontend/app/src/components/mobile/utils/FloatingMenu.tsx
@@ -113,6 +113,13 @@ export const FloatingMenu = () => {
       description: "Previously read feeds",
     },
     {
+      label: "Favorite Feeds",
+      href: "/mobile/feeds/favorites",
+      category: "feeds",
+      icon: <Star size={18} />,
+      description: "Favorited articles",
+    },
+    {
       label: "Register Feed",
       href: "/mobile/feeds/register",
       category: "feeds",

--- a/alt-frontend/app/src/hooks/useFavoriteFeeds.ts
+++ b/alt-frontend/app/src/hooks/useFavoriteFeeds.ts
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Feed } from "@/schema/feed";
+import { feedsApi } from "@/lib/api";
+
+export interface UseFavoriteFeedsResult {
+  feeds: Feed[];
+  isLoading: boolean;
+  error: Error | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+}
+
+export const useFavoriteFeeds = (
+  initialLimit: number = 20,
+): UseFavoriteFeedsResult => {
+  const enablePrefetch = true;
+
+  const [feeds, setFeeds] = useState<Feed[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+
+  const prefetchCacheRef = useRef<Map<string, unknown>>(new Map());
+  const prefetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const prefetchNextPage = useCallback(
+    async (nextCursor: string) => {
+      if (!enablePrefetch) return;
+
+      if (prefetchCacheRef.current.has(nextCursor)) {
+        return;
+      }
+
+      try {
+        prefetchCacheRef.current.set(nextCursor, "loading");
+
+        const response = await feedsApi.getFavoriteFeedsWithCursor(
+          nextCursor,
+          initialLimit,
+        );
+
+        prefetchCacheRef.current.set(nextCursor, response);
+
+        if (prefetchCacheRef.current.size > 3) {
+          const entries = Array.from(prefetchCacheRef.current.keys());
+          const oldestKey = entries[0];
+          prefetchCacheRef.current.delete(oldestKey);
+        }
+      } catch {
+        prefetchCacheRef.current.delete(nextCursor);
+      }
+    },
+    [initialLimit, enablePrefetch],
+  );
+
+  const loadFeeds = useCallback(
+    async (resetData: boolean = false) => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const currentCursor = resetData ? undefined : cursor;
+        let response: { data: Feed[]; next_cursor: string | null } | undefined;
+
+        if (
+          enablePrefetch &&
+          currentCursor &&
+          prefetchCacheRef.current.has(currentCursor)
+        ) {
+          const cachedResponse = prefetchCacheRef.current.get(currentCursor);
+          if (cachedResponse !== "loading") {
+            response = cachedResponse as {
+              data: Feed[];
+              next_cursor: string | null;
+            };
+            prefetchCacheRef.current.delete(currentCursor);
+          }
+        }
+
+        if (!response) {
+          response = await feedsApi.getFavoriteFeedsWithCursor(
+            currentCursor,
+            initialLimit,
+          );
+        }
+
+        if (resetData) {
+          setFeeds(response.data);
+        } else {
+          setFeeds((prevFeeds) => [...prevFeeds, ...response.data]);
+        }
+
+        setCursor(response.next_cursor || undefined);
+        setHasMore(response.next_cursor !== null);
+
+        if (enablePrefetch && response.next_cursor) {
+          if (prefetchTimeoutRef.current) {
+            clearTimeout(prefetchTimeoutRef.current);
+          }
+          prefetchTimeoutRef.current = setTimeout(() => {
+            prefetchNextPage(response!.next_cursor!);
+          }, 500);
+        }
+      } catch (err) {
+        setError(err as Error);
+        setHasMore(false);
+        if (resetData) {
+          setFeeds([]);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [cursor, initialLimit, prefetchNextPage, enablePrefetch],
+  );
+
+  const loadMore = useCallback(() => {
+    if (!isLoading && hasMore && cursor) {
+      loadFeeds(false);
+    }
+  }, [isLoading, hasMore, cursor, loadFeeds]);
+
+  const refresh = useCallback(async () => {
+    prefetchCacheRef.current.clear();
+    if (prefetchTimeoutRef.current) {
+      clearTimeout(prefetchTimeoutRef.current);
+    }
+
+    setCursor(undefined);
+    setHasMore(true);
+    await loadFeeds(true);
+  }, [loadFeeds]);
+
+  useEffect(() => {
+    const initialLoad = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await feedsApi.getFavoriteFeedsWithCursor(
+          undefined,
+          initialLimit,
+        );
+        setFeeds(response.data);
+        setCursor(response.next_cursor || undefined);
+        setHasMore(response.next_cursor !== null);
+
+        if (enablePrefetch && response.next_cursor) {
+          prefetchTimeoutRef.current = setTimeout(() => {
+            prefetchNextPage(response.next_cursor!);
+          }, 500);
+        }
+      } catch (err) {
+        setError(err as Error);
+        setHasMore(false);
+        setFeeds([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    initialLoad();
+  }, [initialLimit, prefetchNextPage, enablePrefetch]);
+
+  useEffect(() => {
+    const cache = prefetchCacheRef.current;
+    const timeout = prefetchTimeoutRef.current;
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      cache.clear();
+    };
+  }, []);
+
+  return {
+    feeds,
+    isLoading,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  };
+};


### PR DESCRIPTION
## Summary
- implement favorite button in article summary modal
- add API client for favorite feeds
- create favorite feeds page
- add FloatingMenu entry for favorites
- include optional useFavoriteFeeds hook

## Testing
- `pnpm exec vitest run`
- `pnpm exec playwright test` *(fails: serving HTML report)*

------
https://chatgpt.com/codex/tasks/task_e_686775819500832b907f02bc6ebdcc05