### PR TITLE
Fix E2E performance spec timeout

### DIFF
--- a/alt-frontend/app/e2e/desktop-feeds/performance.spec.ts
+++ b/alt-frontend/app/e2e/desktop-feeds/performance.spec.ts
@@ -6,25 +6,19 @@ test.describe('Desktop Feeds Performance', () => {
     await page.goto('/desktop/feeds', { waitUntil: 'networkidle' });
 
     // Core Web Vitalsの測定
-    const metrics = await page.evaluate(() => {
-      return new Promise<{ fcp?: number; lcp?: number }>((resolve) => {
-        new PerformanceObserver((list) => {
-          const entries = list.getEntries();
-          const vitals: { fcp?: number; lcp?: number } = {};
+  const metrics = await page.evaluate(() => {
+    const fcpEntry = performance
+      .getEntriesByName('first-contentful-paint')
+      .at(0) as PerformanceEntry | undefined;
+    const lcpEntry = performance
+      .getEntriesByName('largest-contentful-paint')
+      .at(0) as PerformanceEntry | undefined;
 
-          entries.forEach((entry) => {
-            if (entry.name === 'first-contentful-paint') {
-              vitals.fcp = entry.startTime;
-            }
-            if (entry.name === 'largest-contentful-paint') {
-              vitals.lcp = entry.startTime;
-            }
-          });
-
-          resolve(vitals);
-        }).observe({ entryTypes: ['paint', 'largest-contentful-paint'] });
-      });
-    });
+    return {
+      fcp: fcpEntry?.startTime,
+      lcp: lcpEntry?.startTime,
+    };
+  });
 
     // パフォーマンス要件の確認
     if (metrics.fcp) expect(metrics.fcp).toBeLessThan(1500); // FCP < 1.5s


### PR DESCRIPTION
## Summary
- avoid PerformanceObserver hang in desktop feeds e2e test

## Testing
- `pnpm exec playwright install chromium` *(fails: domain is not in allowlist)*
- `pnpm test:e2e` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868f93436f8832b87314739bc77aba6