### PR TITLE
Implement desktop feed read persistence

### DIFF
--- a/alt-frontend/app/src/components/desktop/timeline/DesktopTimeline.tsx
+++ b/alt-frontend/app/src/components/desktop/timeline/DesktopTimeline.tsx
@@ -535,12 +535,17 @@ export default function DesktopTimeline() {
   );
 
   // Handle marking feed as read
-  const handleMarkAsRead = useCallback((feedId: string) => {
+  const handleMarkAsRead = useCallback(async (feedId: string) => {
     setReadFeeds((prev) => {
       const newSet = new Set(prev);
       newSet.add(feedId);
       return newSet;
     });
+    try {
+      await feedsApi.updateFeedReadStatus(feedId);
+    } catch (err) {
+      console.error('Failed to update feed read status:', err);
+    }
   }, []);
 
   // Retry functionality


### PR DESCRIPTION
## Summary
- call existing API to persist read status when marking feeds as read in `DesktopTimeline`

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686bf2321174832ba4790a37390f4107