### PR TITLE
Fix desktop feed page e2e selectors

### DIFF
--- a/alt-frontend/app/src/app/desktop/feeds/page.spec.ts
+++ b/alt-frontend/app/src/app/desktop/feeds/page.spec.ts
@@ -11,7 +11,7 @@ test.describe('Desktop Feeds Page - PROTECTED', () => {
     // Verify main layout components are present
     await expect(page.locator('[data-testid="desktop-header"]')).toBeVisible();
     await expect(page.locator('[data-testid="desktop-sidebar-filters"]')).toBeVisible();
-    await expect(page.locator('[data-testid="desktop-timeline"]')).toBeVisible();
+    await expect(page.locator('[data-testid="desktop-timeline-container"]')).toBeVisible();
 
     // Verify header shows correct unread count (86 from mock stats)
     await expect(page.locator('text=86')).toBeVisible();
@@ -52,7 +52,7 @@ test.describe('Desktop Feeds Page - PROTECTED', () => {
 
     // Verify 3-column layout is visible
     await expect(page.locator('[data-testid="desktop-sidebar-filters"]')).toBeVisible();
-    await expect(page.locator('[data-testid="desktop-timeline"]')).toBeVisible();
+    await expect(page.locator('[data-testid="desktop-timeline-container"]')).toBeVisible();
     const rightPanel = page.locator('[data-testid="right-panel"]');
     if (await rightPanel.count() > 0) {
       await expect(rightPanel).toBeVisible();
@@ -64,7 +64,7 @@ test.describe('Desktop Feeds Page - PROTECTED', () => {
 
     // Verify 2-column layout
     await expect(page.locator('[data-testid="desktop-sidebar-filters"]')).toBeVisible();
-    await expect(page.locator('[data-testid="desktop-timeline"]')).toBeVisible();
+    await expect(page.locator('[data-testid="desktop-timeline-container"]')).toBeVisible();
 
     // Mobile layout (sm)
     await page.setViewportSize({ width: 480, height: 800 });
@@ -72,7 +72,7 @@ test.describe('Desktop Feeds Page - PROTECTED', () => {
 
     // Verify 1-column layout (sidebar hidden on mobile)
     await expect(page.locator('[data-testid="desktop-sidebar-filters"]')).toBeHidden();
-    await expect(page.locator('[data-testid="desktop-timeline"]')).toBeVisible();
+    await expect(page.locator('[data-testid="desktop-timeline-container"]')).toBeVisible();
   });
 
   test('should handle filter interactions correctly (PROTECTED)', async ({ page }) => {
@@ -135,7 +135,7 @@ test.describe('Desktop Feeds Page - PROTECTED', () => {
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(1000);
 
-    const timeline = page.locator('[data-testid="desktop-timeline"]');
+    const timeline = page.locator('[data-testid="desktop-timeline-container"]');
     await expect(timeline).toBeVisible({ timeout: 10000 });
 
     // Verify timeline has scrollable content
@@ -154,7 +154,7 @@ test.describe('Desktop Feeds Page - PROTECTED', () => {
       // If no scrollable content, just verify the timeline is functional
       // This ensures the test doesn't fail when there's not enough content
       await expect(timeline).toBeVisible();
-      const hasContent = await timeline.locator('[data-testid^="feed-item-"]').count();
+      const hasContent = await timeline.locator('[data-testid^="desktop-feed-card-"]').count();
       expect(hasContent).toBeGreaterThanOrEqual(0);
     }
   });

--- a/alt-frontend/app/src/app/desktop/feeds/page.tsx
+++ b/alt-frontend/app/src/app/desktop/feeds/page.tsx
@@ -15,6 +15,11 @@ const mockStats = {
   weeklyAverage: 45
 };
 
+const mockFeedSources = [
+  { id: 'techcrunch', name: 'TechCrunch', icon: '📰', unreadCount: 12, category: 'tech' },
+  { id: 'hackernews', name: 'Hacker News', icon: '🔥', unreadCount: 8, category: 'tech' }
+];
+
 // Loading fallback
 const LoadingFallback = () => (
   <Box 
@@ -70,7 +75,7 @@ function DesktopFeedsContent() {
           }}
           onFilterChange={() => {}}
           onClearAll={() => {}}
-          feedSources={[]}
+          feedSources={mockFeedSources}
           isCollapsed={false}
           onToggleCollapse={() => {}}
         />


### PR DESCRIPTION
## Summary
- adjust selectors in `page.spec.ts`
- add mock feed sources to make filters visible

## Testing
- `pnpm run lint`
- `pnpm exec vitest run`
- *(Playwright tests failed to run: browsers could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_686c79de4f10832b8eb9b4f968e82757