### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auth-service-deploy.yml
+++ b/.github/workflows/auth-service-deploy.yml
@@ -1,6 +1,10 @@
 # .github/workflows/auth-service-deploy.yml
 name: Deploy Auth Service
 
+permissions:
+  contents: read
+  deployments: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Kaikei-e/Alt/security/code-scanning/19](https://github.com/Kaikei-e/Alt/security/code-scanning/19)

To resolve the issue, add an explicit `permissions` block to the workflow to limit the GITHUB_TOKEN's permissions. Since the deploy jobs (`deploy-staging` and `deploy-production`) require read access to the repository contents and write access to environments, the minimum required permissions will be defined. By applying the `permissions` block at the root level of the workflow, all jobs will inherit these permissions unless they specify their own permissions.

Steps for the fix:
1. Add a `permissions` block at the root level of the workflow file.
2. Set `contents: read` and other necessary permissions (`deployments: write`, if applicable) based on the workflow's needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
