### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-validation.yml
+++ b/.github/workflows/helm-validation.yml
@@ -1,5 +1,9 @@
 name: Helm Chart Validation
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/Kaikei-e/Alt/security/code-scanning/16](https://github.com/Kaikei-e/Alt/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily needs read access to the repository contents and the ability to upload artifacts. Therefore, we will set `contents: read` and `actions: write` (for uploading artifacts). This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
