### PR TITLE
fix: resolve helm chart linting errors

### DIFF
--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -102,3 +102,11 @@ serviceAccount:
   create: true
   name: ""
   annotations: {}
+
+# Autoscaling configuration
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80

--- a/charts/nginx-external/Chart.yaml
+++ b/charts/nginx-external/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: nginx-external
+description: A Helm chart for external nginx with cloudflare tunnel integration
+type: application
+version: 0.1.0
+appVersion: "1.27.0"
+keywords:
+  - nginx
+  - external
+  - cloudflare
+  - tunnel
+home: https://nginx.org/
+sources:
+  - https://github.com/nginx/nginx
+maintainers:
+  - name: Alt Team
+    email: team@alt.example.com
+dependencies:
+  - name: cloudflare-tunnel
+    version: "0.1.0"
+    repository: "file://./charts/cloudflare-tunnel"


### PR DESCRIPTION
Fix helm chart linting errors in /charts directory

## Changes
- Add missing autoscaling section to cloudflare-tunnel values.yaml
- Create missing Chart.yaml for nginx-external chart
- Fix template error: nil pointer evaluating interface{}.enabled
- Enable nginx-external chart with cloudflare-tunnel dependency

## Fixes
- Resolves linting failures for cloudflare-tunnel and nginx-external charts
- Dependency warnings for common-ssl/common-secrets are expected (need helm dependency update)

Closes #81

Generated with [Claude Code](https://claude.ai/code)