### PR TITLE
fix: update theme from liquid-beige to alt-paper and fix React act() warnings

### DIFF
--- a/alt-frontend/app/src/__tests__/theme-integration.test.tsx
+++ b/alt-frontend/app/src/__tests__/theme-integration.test.tsx
@@ -80,17 +80,17 @@ describe("Theme Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorageMock.getItem.mockReturnValue(null);
-    getAttributeMock.mockReturnValue("liquid-beige");
+    getAttributeMock.mockReturnValue("alt-paper");
 
-    // Setup default CSS variables for liquid-beige theme
+    // Setup default CSS variables for alt-paper theme
     mockGetComputedStyle.mockReturnValue({
       getPropertyValue: vi.fn((prop: string) => {
         const cssVars: Record<string, string> = {
           "--foreground": "#2c2c2c",
-          "--background": "#d1c0a8",
-          "--accent-primary": "#b85450",
-          "--accent-secondary": "#7c9070",
-          "--accent-tertiary": "#d4a574",
+          "--background": "#f8f6f2",
+          "--accent-primary": "#6b7280",
+          "--accent-secondary": "#9ca3af",
+          "--accent-tertiary": "#d1d5db",
         };
         return cssVars[prop] || "";
       }),
@@ -105,7 +105,7 @@ describe("Theme Integration", () => {
     window.getComputedStyle = originalGetComputedStyle;
   });
 
-  it("デフォルトでliquid-beigeテーマが適用される", async () => {
+  it("デフォルトでalt-paperテーマが適用される", async () => {
     render(
       <ThemeProvider>
         <ThemeToggle />
@@ -117,9 +117,9 @@ describe("Theme Integration", () => {
       expect(screen.getByTestId("theme-toggle-button")).toBeDefined();
     });
 
-    // Verify default theme is liquid-beige
+    // Verify default theme is alt-paper
     const toggleButton = screen.getByTestId("theme-toggle-button");
-    expect(toggleButton.getAttribute("aria-checked")).toBe("false"); // liquid-beige = false (not vaporwave)
+    expect(toggleButton.getAttribute("aria-checked")).toBe("false"); // alt-paper = false (not vaporwave)
 
     // Wait for the component to fully mount and show icon
     await waitFor(() => {

--- a/alt-frontend/app/src/components/ThemeToggle.tsx
+++ b/alt-frontend/app/src/components/ThemeToggle.tsx
@@ -19,7 +19,7 @@ export interface ThemeToggleProps {
 
 const THEME_ICONS = {
   vaporwave: Moon,
-  "liquid-beige": Sun,
+  "alt-paper": Sun,
 };
 
 export const ThemeToggle: React.FC<ThemeToggleProps> = ({
@@ -99,11 +99,11 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({
 
   const IconComponent = THEME_ICONS[currentTheme];
   const nextTheme =
-    currentTheme === "liquid-beige" ? "vaporwave" : "liquid-beige";
+    currentTheme === "alt-paper" ? "vaporwave" : "alt-paper";
   const nextThemeLabel =
-    nextTheme === "vaporwave" ? "Vaporwave" : "Liquid Beige";
+    nextTheme === "vaporwave" ? "Vaporwave" : "Alt Paper";
   const currentThemeLabel =
-    currentTheme === "vaporwave" ? "Vaporwave" : "Liquid Beige";
+    currentTheme === "vaporwave" ? "Vaporwave" : "Alt Paper";
 
   // Use CSS variables from global.css that work with data-style attribute
   const buttonStyles = {

--- a/alt-frontend/app/src/components/mobile/VirtualFeedListImpl.test.tsx
+++ b/alt-frontend/app/src/components/mobile/VirtualFeedListImpl.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { VirtualFeedListImpl } from "./VirtualFeedListImpl";
 import { Feed } from "@/schema/feed";
@@ -140,7 +140,9 @@ describe("VirtualFeedListImpl", () => {
 
     // Trigger error
     const errorButton = screen.getByText("Trigger Error");
-    errorButton.click();
+    await act(async () => {
+      errorButton.click();
+    });
 
     // Should fallback to fixed sizing
     await waitFor(() => {
@@ -187,7 +189,9 @@ describe("VirtualFeedListImpl", () => {
 
     // Trigger error
     const errorButton = screen.getByText("Trigger Error");
-    errorButton.click();
+    await act(async () => {
+      errorButton.click();
+    });
 
     // Wait for fallback
     await waitFor(() => {


### PR DESCRIPTION
Fixes #84

This PR resolves the failing vitest CI tests after the theme migration from liquid-beige to alt-paper.

## Changes
- Updated ThemeToggle component to use 'alt-paper' instead of 'liquid-beige'
- Fixed THEME_ICONS mapping and toggle logic for new theme
- Updated theme integration test to expect alt-paper as default theme
- Fixed React act() warnings in VirtualFeedListImpl.test.tsx

## Root Cause
The main issue was a mismatch between the ThemeProvider (which was updated to alt-paper) and the ThemeToggle component (which still referenced liquid-beige). This caused the theme icon to not render, breaking the integration test.

Generated with [Claude Code](https://claude.ai/code)