### PR TITLE
fix: ensure mobile floating menu sections expand

### DIFF
--- a/alt-frontend/src/components/mobile/utils/FloatingMenu.test.tsx
+++ b/alt-frontend/src/components/mobile/utils/FloatingMenu.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+expect.extend(matchers);
+
+// Mock Next.js Link and navigation hooks and ThemeToggle before importing component
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("../../ThemeToggle", () => ({
+  ThemeToggle: () => <div />,
+}));
+
+(globalThis as any).scrollTo = vi.fn();
+
+import { FloatingMenu } from "./FloatingMenu";
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+};
+
+describe("FloatingMenu", () => {
+  it("allows switching between accordion categories", async () => {
+    renderWithChakra(<FloatingMenu />);
+
+    fireEvent.click(screen.getByTestId("floating-menu-button"));
+
+    const articlesTab = await screen.findByTestId("tab-articles");
+    fireEvent.click(articlesTab);
+    expect(await screen.findByText("Search Articles")).toBeInTheDocument();
+
+    const otherTab = screen.getByTestId("tab-other");
+    fireEvent.click(otherTab);
+    expect(await screen.findByText("Home")).toBeInTheDocument();
+  });
+});
+

--- a/alt-frontend/src/components/mobile/utils/FloatingMenu.tsx
+++ b/alt-frontend/src/components/mobile/utils/FloatingMenu.tsx
@@ -19,7 +19,7 @@ import {
 } from "@chakra-ui/accordion";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import {
   Rss,
   Search,
@@ -48,10 +48,18 @@ export const FloatingMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isPrefetched, setIsPrefetched] = useState(false);
   const pathname = usePathname();
+  const [activeIndex, setActiveIndex] = useState(0);
 
   const handleCloseMenu = useCallback(() => {
     setIsOpen(false);
   }, []);
+
+  // Reset active accordion section when menu opens
+  useEffect(() => {
+    if (isOpen) {
+      setActiveIndex(0);
+    }
+  }, [isOpen]);
 
   // Handle keyboard interactions
   useEffect(() => {
@@ -333,7 +341,13 @@ export const FloatingMenu = () => {
               </Drawer.Header>
 
               <Drawer.Body px={6} py={4}>
-                <Accordion allowToggle defaultIndex={0}>
+                <Accordion
+                  allowToggle
+                  index={activeIndex}
+                  onChange={(index) =>
+                    setActiveIndex(Array.isArray(index) ? index[0] ?? -1 : index)
+                  }
+                >
                   {categories.map((cat, idx) => (
                     <AccordionItem key={idx} border="none" mb={4}>
                       {({ isExpanded }) => (


### PR DESCRIPTION
## Summary
- track active accordion section and reset when menu opens
- control accordion expansion via state so Articles and Other tabs toggle correctly
- add tests verifying mobile floating menu accordion behavior

## Testing
- `pnpm lint` *(fails: ENOTDIR - Next.js ESLint configuration prompt)*
- `pnpm test:logic --run src/components/mobile/utils/FloatingMenu.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6892dca6fd88832bb8db84ea6476ade7