### PR TITLE
fix(mobile): allow FloatingMenu sections to toggle

### DIFF
--- a/alt-frontend/src/components/mobile/utils/FloatingMenu.tsx
+++ b/alt-frontend/src/components/mobile/utils/FloatingMenu.tsx
@@ -47,10 +47,22 @@ interface MenuItem {
 export const FloatingMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isPrefetched, setIsPrefetched] = useState(false);
+  // Track which accordion section is expanded
+  const [activeCategory, setActiveCategory] = useState<number | null>(0);
   const pathname = usePathname();
 
   const handleCloseMenu = useCallback(() => {
     setIsOpen(false);
+  }, []);
+
+  // Handle accordion state changes
+  const handleAccordionChange = useCallback((index: number | number[]) => {
+    const newIndex = Array.isArray(index) ? index[0] : index;
+    if (newIndex === -1 || typeof newIndex === "undefined") {
+      setActiveCategory(null);
+    } else {
+      setActiveCategory(newIndex);
+    }
   }, []);
 
   // Handle keyboard interactions
@@ -333,7 +345,11 @@ export const FloatingMenu = () => {
               </Drawer.Header>
 
               <Drawer.Body px={6} py={4}>
-                <Accordion allowToggle defaultIndex={0}>
+                <Accordion
+                  allowToggle
+                  index={activeCategory === null ? undefined : activeCategory}
+                  onChange={handleAccordionChange}
+                >
                   {categories.map((cat, idx) => (
                     <AccordionItem key={idx} border="none" mb={4}>
                       {({ isExpanded }) => (


### PR DESCRIPTION
## Summary
- track expanded section in mobile FloatingMenu
- wire Accordion to controlled state so Articles and Other tabs expand

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test:logic` *(fails: ReferenceError: afterEach is not defined, missing modules, document is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68955d5d13b4832b9760760535515617