### PR TITLE
fix: ensure safe integer parsing for config

### DIFF
--- a/auth-service/app/config/config.go
+++ b/auth-service/app/config/config.go
@@ -76,17 +76,11 @@ func Load() (*Config, error) {
 	// CSRF configuration
 	var err error
 	csrfLengthStr := getEnvOrDefault("CSRF_TOKEN_LENGTH", "32")
-	csrfLength, err := strconv.ParseInt(csrfLengthStr, 10, 64)
+	csrfLength, err := strconv.Atoi(csrfLengthStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid CSRF_TOKEN_LENGTH: %w", err)
 	}
-	// Check bounds for int type (platform-dependent)
-	const maxInt64 = 1<<63 - 1
-	const minInt64 = -1 << 63
-	if csrfLength > maxInt64 || csrfLength < minInt64 {
-		return nil, fmt.Errorf("CSRF_TOKEN_LENGTH out of range: %s (max: %d, min: %d)", csrfLengthStr, maxInt64, minInt64)
-	}
-	config.CSRFTokenLength = int(csrfLength)
+	config.CSRFTokenLength = csrfLength
 
 	sessionTimeoutStr := getEnvOrDefault("SESSION_TIMEOUT", "24h")
 	config.SessionTimeout, err = time.ParseDuration(sessionTimeoutStr)
@@ -109,15 +103,9 @@ func Load() (*Config, error) {
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
 	// Validate port
-	port, err := strconv.ParseInt(c.Port, 10, 64)
+	port, err := strconv.Atoi(c.Port)
 	if err != nil {
 		return fmt.Errorf("invalid port: %s", c.Port)
-	}
-	// Check bounds for int type (platform-dependent)
-	const maxInt64 = 1<<63 - 1
-	const minInt64 = -1 << 63
-	if port > maxInt64 || port < minInt64 {
-		return fmt.Errorf("port out of range: %s (max: %d, min: %d)", c.Port, maxInt64, minInt64)
 	}
 	// Check port range (1-65535)
 	if port < 1 || port > 65535 {


### PR DESCRIPTION
## Summary
- parse CSRF token length with `strconv.Atoi` and avoid int64-to-int conversion
- simplify port parsing using `strconv.Atoi`

## Testing
- `go test ./...` *(fails: failed to connect to services)*

------
https://chatgpt.com/codex/tasks/task_e_689596e72ad8832b8dd324b856c1d497