### PR TITLE
Add pre-processor sidecar test workflow

### DIFF
--- a/.github/workflows/pre-processor-sidecar-go.yaml
+++ b/.github/workflows/pre-processor-sidecar-go.yaml
@@ -1,0 +1,27 @@
+name: Pre-processor Sidecar Go Tests
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'pre-processor-sidecar/**'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'pre-processor-sidecar/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-test-go.yaml
+    with:
+      working-directory: 'pre-processor-sidecar/app'
+      go-version: '1.24'
+      coverage-flags: 'pre-processor-sidecar'


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Go tests for pre-processor-sidecar using reusable workflow

## Testing
- `yamllint .github/workflows/pre-processor-sidecar-go.yaml`
- `go test -v ./...` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689765dbacd0832bbd41bd09e516af97