### PR TITLE
guard against overflow when preparing log args

### DIFF
--- a/pre-processor/app/utils/optimized_logging.go
+++ b/pre-processor/app/utils/optimized_logging.go
@@ -129,8 +129,13 @@ func (l *OptimizedLogger) log(level string, msg string, args ...interface{}) {
 		return
 	}
 
-	// Prepare arguments with context fields
-	allArgs := make([]interface{}, 0, len(args)+len(l.contextFields)*2+2)
+	// Prepare arguments with context fields while guarding against overflow
+	const maxInt = int(^uint(0) >> 1)
+	cap := uint64(len(args)) + uint64(len(l.contextFields))*2 + 2
+	if cap > uint64(maxInt) {
+		cap = uint64(maxInt)
+	}
+	allArgs := make([]interface{}, 0, int(cap))
 	allArgs = append(allArgs, "component", l.component)
 
 	// Add context fields


### PR DESCRIPTION
## Summary
- avoid integer overflow when computing logging slice capacity

## Testing
- `go test ./utils -run TestOptimizedLogger -v`


------
https://chatgpt.com/codex/tasks/task_e_689a0a6ce830832ba9e29ba16ee345a9