### PR TITLE
Fix read status updates after Atlas migration

### DIFF
--- a/alt-backend/app/driver/alt_db/fetch_feed_driver.go
+++ b/alt-backend/app/driver/alt_db/fetch_feed_driver.go
@@ -2,7 +2,6 @@ package alt_db
 
 import (
 	"alt/driver/models"
-	"alt/utils"
 	"alt/utils/logger"
 	"context"
 	"errors"
@@ -110,20 +109,19 @@ func (r *AltDBRepository) FetchUnreadFeedsListPage(ctx context.Context, page int
 	// For now, keeping the original OFFSET-based implementation for backward compatibility
 	// Consider migrating to cursor-based pagination (FetchUnreadFeedsListCursor) for better performance
 	query := `
-		SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
-		FROM feeds f
-		WHERE NOT EXISTS (
-			SELECT 1
-			FROM read_status rs
-			WHERE rs.feed_id = f.id
-			AND rs.user_id = $3
-			AND rs.is_read = TRUE
-		)
-		ORDER BY f.created_at DESC
-		LIMIT $1 OFFSET $2
-	`
+                SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
+                FROM feeds f
+                WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM read_status rs
+                        WHERE rs.feed_id = f.id
+                        AND rs.is_read = TRUE
+                )
+                ORDER BY f.created_at DESC
+                LIMIT $1 OFFSET $2
+        `
 
-	rows, err := r.pool.Query(ctx, query, pageSize, pageSize*page, utils.DUMMY_USER_ID)
+	rows, err := r.pool.Query(ctx, query, pageSize, pageSize*page)
 	if err != nil {
 		logger.Logger.Error("error fetching unread feeds list page", "error", err)
 		return nil, errors.New("error fetching feeds list page")
@@ -153,36 +151,34 @@ func (r *AltDBRepository) FetchUnreadFeedsListCursor(ctx context.Context, cursor
 	if cursor == nil {
 		// First page - no cursor
 		query = `
-			SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
-			FROM feeds f
-			WHERE NOT EXISTS (
-				SELECT 1
-				FROM read_status rs
-				WHERE rs.feed_id = f.id
-				AND rs.user_id = $2
-				AND rs.is_read = TRUE
-			)
-			ORDER BY f.created_at DESC, f.id DESC
-			LIMIT $1
-		`
-		args = []interface{}{limit, utils.DUMMY_USER_ID}
+                        SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
+                        FROM feeds f
+                        WHERE NOT EXISTS (
+                                SELECT 1
+                                FROM read_status rs
+                                WHERE rs.feed_id = f.id
+                                AND rs.is_read = TRUE
+                        )
+                        ORDER BY f.created_at DESC, f.id DESC
+                        LIMIT $1
+                `
+		args = []interface{}{limit}
 	} else {
 		// Subsequent pages - use cursor
 		query = `
-			SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
-			FROM feeds f
-			WHERE NOT EXISTS (
-				SELECT 1
-				FROM read_status rs
-				WHERE rs.feed_id = f.id
-				AND rs.user_id = $3
-				AND rs.is_read = TRUE
-			)
-			AND f.created_at < $1
-			ORDER BY f.created_at DESC, f.id DESC
-			LIMIT $2
-		`
-		args = []interface{}{cursor, limit, utils.DUMMY_USER_ID}
+                        SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
+                        FROM feeds f
+                        WHERE NOT EXISTS (
+                                SELECT 1
+                                FROM read_status rs
+                                WHERE rs.feed_id = f.id
+                                AND rs.is_read = TRUE
+                        )
+                        AND f.created_at < $1
+                        ORDER BY f.created_at DESC, f.id DESC
+                        LIMIT $2
+                `
+		args = []interface{}{cursor, limit}
 	}
 
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -215,28 +211,26 @@ func (r *AltDBRepository) FetchReadFeedsListCursor(ctx context.Context, cursor *
 	if cursor == nil {
 		// Initial fetch: INNER JOIN for performance optimization
 		query = `
-			SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
-			FROM feeds f
-			INNER JOIN read_status rs ON rs.feed_id = f.id
-			WHERE rs.is_read = TRUE
-			AND rs.user_id = $2
-			ORDER BY f.created_at DESC, f.id DESC
-			LIMIT $1
-		`
-		args = []interface{}{limit, utils.DUMMY_USER_ID}
+                        SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
+                        FROM feeds f
+                        INNER JOIN read_status rs ON rs.feed_id = f.id
+                        WHERE rs.is_read = TRUE
+                        ORDER BY f.created_at DESC, f.id DESC
+                        LIMIT $1
+                `
+		args = []interface{}{limit}
 	} else {
 		// Subsequent pages: cursor-based pagination
 		query = `
-			SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
-			FROM feeds f
-			INNER JOIN read_status rs ON rs.feed_id = f.id
-			WHERE rs.is_read = TRUE
-			AND rs.user_id = $3
-			AND f.created_at < $1
-			ORDER BY f.created_at DESC, f.id DESC
-			LIMIT $2
-		`
-		args = []interface{}{cursor, limit, utils.DUMMY_USER_ID}
+                        SELECT f.id, f.title, f.description, f.link, f.pub_date, f.created_at, f.updated_at
+                        FROM feeds f
+                        INNER JOIN read_status rs ON rs.feed_id = f.id
+                        WHERE rs.is_read = TRUE
+                        AND f.created_at < $1
+                        ORDER BY f.created_at DESC, f.id DESC
+                        LIMIT $2
+                `
+		args = []interface{}{cursor, limit}
 	}
 
 	rows, err := r.pool.Query(ctx, query, args...)

--- a/alt-backend/app/driver/alt_db/fetch_today_unread_articles_count_driver.go
+++ b/alt-backend/app/driver/alt_db/fetch_today_unread_articles_count_driver.go
@@ -1,6 +1,7 @@
 package alt_db
 
 import (
+	"alt/utils"
 	"alt/utils/logger"
 	"context"
 	"errors"
@@ -11,13 +12,13 @@ func (r *AltDBRepository) FetchTodayUnreadArticlesCount(ctx context.Context, sin
 	query := `
                         SELECT COUNT(*)
                         FROM feeds f
-                        LEFT JOIN read_status rs ON rs.feed_id = f.id
+                        LEFT JOIN read_status rs ON rs.feed_id = f.id AND rs.user_id = $2
                         WHERE f.created_at >= $1
                         AND (rs.feed_id IS NULL OR rs.is_read = FALSE)
     `
 
 	var count int
-	if err := r.pool.QueryRow(ctx, query, since).Scan(&count); err != nil {
+	if err := r.pool.QueryRow(ctx, query, since, utils.DUMMY_USER_ID).Scan(&count); err != nil {
 		logger.SafeError("failed to fetch today's unread articles count", "error", err)
 		return 0, errors.New("failed to fetch today's unread articles count")
 	}

--- a/alt-backend/app/driver/alt_db/fetch_today_unread_articles_count_driver.go
+++ b/alt-backend/app/driver/alt_db/fetch_today_unread_articles_count_driver.go
@@ -1,7 +1,6 @@
 package alt_db
 
 import (
-	"alt/utils"
 	"alt/utils/logger"
 	"context"
 	"errors"
@@ -10,15 +9,15 @@ import (
 
 func (r *AltDBRepository) FetchTodayUnreadArticlesCount(ctx context.Context, since time.Time) (int, error) {
 	query := `
-			SELECT COUNT(*)
-			FROM feeds f
-			LEFT JOIN read_status rs ON rs.feed_id = f.id AND rs.user_id = $2
-			WHERE f.created_at >= $1
-			AND (rs.feed_id IS NULL OR rs.is_read = FALSE)
+                        SELECT COUNT(*)
+                        FROM feeds f
+                        LEFT JOIN read_status rs ON rs.feed_id = f.id
+                        WHERE f.created_at >= $1
+                        AND (rs.feed_id IS NULL OR rs.is_read = FALSE)
     `
 
 	var count int
-	if err := r.pool.QueryRow(ctx, query, since, utils.DUMMY_USER_ID).Scan(&count); err != nil {
+	if err := r.pool.QueryRow(ctx, query, since).Scan(&count); err != nil {
 		logger.SafeError("failed to fetch today's unread articles count", "error", err)
 		return 0, errors.New("failed to fetch today's unread articles count")
 	}

--- a/alt-backend/app/driver/alt_db/update_feed_status_driver.go
+++ b/alt-backend/app/driver/alt_db/update_feed_status_driver.go
@@ -1,7 +1,6 @@
 package alt_db
 
 import (
-	"alt/utils"
 	"alt/utils/logger"
 	"context"
 	"net/url"
@@ -33,14 +32,14 @@ func (r *AltDBRepository) UpdateFeedStatus(ctx context.Context, feedURL url.URL)
 		}
 	}()
 
-	// Upsert read status for the feed with dummy user ID
+	// Upsert read status for the feed
 	updateFeedStatusQuery := `
-                INSERT INTO read_status (feed_id, user_id, is_read, updated_at, created_at)
-                VALUES ($1, $2, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                ON CONFLICT (feed_id, user_id) DO UPDATE
-                SET is_read = TRUE, updated_at = CURRENT_TIMESTAMP
+                INSERT INTO read_status (feed_id, is_read, read_at, created_at)
+                VALUES ($1, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                ON CONFLICT (feed_id) DO UPDATE
+                SET is_read = TRUE, read_at = CURRENT_TIMESTAMP
         `
-	if _, err = tx.Exec(ctx, updateFeedStatusQuery, feedID, utils.DUMMY_USER_ID); err != nil {
+	if _, err = tx.Exec(ctx, updateFeedStatusQuery, feedID); err != nil {
 		logger.SafeError("Error updating feed status", "error", err, "feedID", feedID)
 		return err
 	}

--- a/alt-backend/app/utils/constants.go
+++ b/alt-backend/app/utils/constants.go
@@ -1,0 +1,6 @@
+package utils
+
+// DUMMY_USER_ID is a fixed user ID used for single-user mode read status functionality
+// This constant is used to maintain compatibility with the database schema that requires user_id
+// while keeping the current API structure intact.
+const DUMMY_USER_ID = "00000000-0000-0000-0000-000000000001"

--- a/alt-backend/app/utils/constants.go
+++ b/alt-backend/app/utils/constants.go
@@ -1,6 +1,0 @@
-package utils
-
-// DUMMY_USER_ID is a fixed user ID used for single-user mode read status functionality
-// This constant is used to maintain compatibility with the database schema that requires user_id
-// while keeping the current API structure intact
-const DUMMY_USER_ID = "00000000-0000-0000-0000-000000000001"


### PR DESCRIPTION
## Summary
- remove deprecated `user_id` handling from read status queries
- align update and fetch queries with new `read_status` schema
- drop unused `DUMMY_USER_ID` constant

## Testing
- `go test ./...` *(fails: TestConvertFeedToFeedItem panic, TestFetchFeedsGateway_RateLimiting and TestFetchFeedsGateway_FetchFeeds error parsing feed, port/fetch_feed_port build error)*

------
https://chatgpt.com/codex/tasks/task_e_689a3d4eb158832b9e402512b9ad2873