### PR TITLE
fix next.js link imports and tsconfig types

### DIFF
--- a/alt-frontend/src/app/page.tsx
+++ b/alt-frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import NextLink from "next/link";
+import NextLink from "next/link.js";
 import {
   Box,
   Flex,

--- a/alt-frontend/src/components/desktop/home/ActionButton.tsx
+++ b/alt-frontend/src/components/desktop/home/ActionButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import NextLink from "next/link";
+import NextLink from "next/link.js";
 import { Button, Icon, Text } from "@chakra-ui/react";
 
 interface ActionButtonProps {

--- a/alt-frontend/src/components/desktop/home/CallToActionBar.tsx
+++ b/alt-frontend/src/components/desktop/home/CallToActionBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Link from "next/link";
+import Link from "next/link.js";
 
 interface CallToActionBarProps {
   title: string;

--- a/alt-frontend/src/components/desktop/home/Home.tsx
+++ b/alt-frontend/src/components/desktop/home/Home.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import NextLink from "next/link";
+import NextLink from "next/link.js";
 import {
   Box,
   Flex,

--- a/alt-frontend/src/components/desktop/layout/DesktopSidebar.test.tsx
+++ b/alt-frontend/src/components/desktop/layout/DesktopSidebar.test.tsx
@@ -7,7 +7,7 @@ import { DesktopSidebar } from "./DesktopSidebar";
 import { Home, Rss } from "lucide-react";
 
 // Mock Next.js Link component
-vi.mock("next/link", () => ({
+vi.mock("next/link.js", () => ({
   default: ({
     children,
     href,

--- a/alt-frontend/src/components/desktop/layout/DesktopSidebar.tsx
+++ b/alt-frontend/src/components/desktop/layout/DesktopSidebar.tsx
@@ -19,7 +19,7 @@ import {
   Link as ChakraLink,
   Icon,
 } from "@chakra-ui/react";
-import NextLink from "next/link";
+import NextLink from "next/link.js";
 
 interface NavItem {
   id: number;

--- a/alt-frontend/src/components/desktop/timeline/DesktopFeedCard.tsx
+++ b/alt-frontend/src/components/desktop/timeline/DesktopFeedCard.tsx
@@ -13,7 +13,7 @@ import {
   Spinner,
 } from "@chakra-ui/react";
 import { Heart, Bookmark, Clock, ExternalLink } from "lucide-react";
-import Link from "next/link";
+import Link from "next/link.js";
 import { DesktopFeedCardProps } from "@/types/desktop-feed";
 
 const formatTimeAgo = (dateString: string) => {

--- a/alt-frontend/src/components/mobile/FeedCard.tsx
+++ b/alt-frontend/src/components/mobile/FeedCard.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex, Spinner, Text, Box } from "@chakra-ui/react";
 import { SanitizedFeed } from "@/schema/feed";
-import Link from "next/link";
+import Link from "next/link.js";
 import { feedsApi } from "@/lib/api";
 import { useState, useCallback, useMemo, KeyboardEvent } from "react";
 import { FeedDetails } from "./FeedDetails";

--- a/alt-frontend/src/components/mobile/ReadFeedCard.tsx
+++ b/alt-frontend/src/components/mobile/ReadFeedCard.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text, Box } from "@chakra-ui/react";
 import { Feed } from "@/schema/feed";
-import Link from "next/link";
+import Link from "next/link.js";
 import { memo } from "react";
 import { FeedDetails } from "./FeedDetails";
 import { truncateFeedDescription } from "@/lib/utils/textUtils";

--- a/alt-frontend/src/components/mobile/search/SearchResults.tsx
+++ b/alt-frontend/src/components/mobile/search/SearchResults.tsx
@@ -1,5 +1,5 @@
 import { Box, VStack, Text, HStack, Heading, Spinner } from "@chakra-ui/react";
-import Link from "next/link";
+import Link from "next/link.js";
 import { BackendFeedItem } from "@/schema/feed";
 
 interface SearchResultsProps {

--- a/alt-frontend/src/components/mobile/utils/FloatingMenu.tsx
+++ b/alt-frontend/src/components/mobile/utils/FloatingMenu.tsx
@@ -17,7 +17,7 @@ import {
   AccordionPanel,
   AccordionIcon,
 } from "@chakra-ui/accordion";
-import Link from "next/link";
+import Link from "next/link.js";
 import { usePathname } from "next/navigation";
 import { useState, useCallback, useEffect } from "react";
 import {

--- a/alt-frontend/tsconfig.json
+++ b/alt-frontend/tsconfig.json
@@ -22,10 +22,7 @@
       "@/*": ["./src/*"]
     },
     "types": [
-      "node",
-      "@vitest/browser/providers/playwright",
-      "vitest/globals",
-      "@testing-library/jest-dom"
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- add `.js` extension for Next.js Link imports to satisfy Node ESM resolution
- drop Vitest and Jest-DOM type injections from tsconfig

## Testing
- `pnpm test:e2e` *(fails: Cannot redefine property: Symbol($$jest-matchers-object))*
- `pnpm test:logic` *(fails: ReferenceError: document is not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e07d5c25c832ba20c1d180bd3b2af