### PR TITLE
Mock auth service for Playwright tests

### DIFF
--- a/alt-frontend/playwright.config.ts
+++ b/alt-frontend/playwright.config.ts
@@ -52,11 +52,21 @@ export default defineConfig({
   ],
 
   // WebServerの設定
-  webServer: {
-    // CI ではビルド→本番起動、ローカルでは next dev
-    command: "next dev --port 3010",
-    url: "http://localhost:3010",
-    reuseExistingServer: true,
-    timeout: 1200 * 1000, // 20分のWebServerタイムアウト
-  },
+  webServer: [
+    {
+      command: "node tests/mock-auth-service.cjs",
+      port: 4545,
+      reuseExistingServer: true,
+    },
+    {
+      // CI ではビルド→本番起動、ローカルでは next dev
+      command: "next dev --port 3010",
+      url: "http://localhost:3010",
+      reuseExistingServer: true,
+      timeout: 1200 * 1000, // 20分のWebServerタイムアウト
+      env: {
+        AUTH_SERVICE_URL: "http://localhost:4545",
+      },
+    },
+  ],
 });

--- a/alt-frontend/tests/mock-auth-service.cjs
+++ b/alt-frontend/tests/mock-auth-service.cjs
@@ -1,0 +1,19 @@
+const http = require("http");
+
+const port = process.env.MOCK_AUTH_PORT || 4545;
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/v1/auth/validate") {
+    res.statusCode = 401;
+    res.setHeader("Content-Type", "application/json");
+    res.end("null");
+    return;
+  }
+  res.statusCode = 404;
+  res.end();
+});
+
+server.listen(port, () => {
+  console.log(`Mock auth service running on port ${port}`);
+});
+


### PR DESCRIPTION
## Summary
- remove CI-only auth fallback from validate API
- spin up mock auth service during Playwright tests to avoid touching auth-service

## Testing
- `CI=1 pnpm test:e2e` *(fails: browser executable doesn't exist)*
- `pnpm exec playwright install` *(fails: download blocked by 403)*
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f505a5be0832b93fda2a8e904f166