### PR TITLE
fix: use Go 1.24.3 in backend CI

### DIFF
--- a/.github/workflows/backend-go.yaml
+++ b/.github/workflows/backend-go.yaml
@@ -23,5 +23,5 @@ jobs:
     uses: ./.github/workflows/reusable-test-go.yaml
     with:
       working-directory: 'alt-backend/app'
-      go-version: '1.24'
+      go-version: '1.24.3'
       coverage-flags: 'alt-backend'

--- a/.github/workflows/reusable-test-go.yaml
+++ b/.github/workflows/reusable-test-go.yaml
@@ -12,7 +12,7 @@ on:
       go-version:
         required: false
         type: string
-        default: "1.24"
+        default: "1.24.3"
       upload-coverage:
         required: false
         type: boolean


### PR DESCRIPTION
## Summary
- ensure backend CI uses Go 1.24.3 to match go.mod requirements
- update reusable Go test workflow default to Go 1.24.3

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a21bb61708832b85dcd35071c6f927