### PR TITLE
fix: make go test workflow configurable

### DIFF
--- a/.github/workflows/auth-service-deploy.yml
+++ b/.github/workflows/auth-service-deploy.yml
@@ -29,3 +29,4 @@ jobs:
       go-version: '1.24'
       upload-coverage: true
       coverage-flags: 'auth-service'
+      sparse-checkout: 'auth-service'

--- a/.github/workflows/pre-processor-sidecar-go.yaml
+++ b/.github/workflows/pre-processor-sidecar-go.yaml
@@ -25,3 +25,4 @@ jobs:
       working-directory: 'pre-processor-sidecar/app'
       go-version: '1.24'
       coverage-flags: 'pre-processor-sidecar'
+      sparse-checkout: 'pre-processor-sidecar'

--- a/.github/workflows/reusable-test-go.yaml
+++ b/.github/workflows/reusable-test-go.yaml
@@ -18,6 +18,18 @@ on:
         required: false
         type: boolean
         default: false
+      use-local-persistent-cache:
+        required: false
+        type: boolean
+        default: false
+      upload-coverage:
+        required: false
+        type: boolean
+        default: true
+      sparse-checkout:
+        required: false
+        type: string
+        default: 'alt-backend'
 
   workflow_dispatch:
 
@@ -58,9 +70,9 @@ jobs:
       - name: Checkout (sparse)
         uses: actions/checkout@v5
         with:
-          # alt-backend だけをチェックアウトして無駄を削減
+          # sparse checkout paths to reduce unnecessary files
           sparse-checkout: |
-            alt-backend
+            ${{ inputs.sparse-checkout }}
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       # ^ v5はNode 24ランタイムで、Runner v2.327.1+ が必須。後述の注記を確認。
@@ -109,7 +121,7 @@ jobs:
           go test ./... -count=1 -race -covermode=atomic -coverprofile=coverage.out
 
       - name: Upload coverage to Codecov (v5)
-        if: always()
+        if: always() && inputs.upload-coverage
         uses: codecov/codecov-action@v5
         with:
           # v5は files（複数可）

--- a/.github/workflows/search-indexer.yaml
+++ b/.github/workflows/search-indexer.yaml
@@ -19,4 +19,5 @@ jobs:
       working-directory: 'search-indexer/app'
       coverage-flags: 'search-indexer'
       use-oidc: false
+      sparse-checkout: 'search-indexer'
     secrets: inherit


### PR DESCRIPTION
## Summary
- allow specifying sparse checkout paths and coverage/caching options in reusable Go test workflow
- run search-indexer tests by checking out its directory
- adjust other service workflows to use custom sparse checkout

## Testing
- `go test ./... -count=1 -race -covermode=atomic -coverprofile=coverage.out` (search-indexer/app)
- `go test ./... -count=1` (auth-service/app) *(hangs; aborted)*
- `go test ./... -count=1` (pre-processor-sidecar/app) *(hangs; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dcca6dec832b9190e3aa19289e95