### PR TITLE
Harden sanitizer parsing and regex safeguards

### DIFF
--- a/tag-generator/app/tests/unit/test_input_sanitizer.py
+++ b/tag-generator/app/tests/unit/test_input_sanitizer.py
@@ -160,6 +160,25 @@ class TestInputSanitizer:
         assert "<p>" not in result.sanitized_input.content
         assert "alert('xss')" not in result.sanitized_input.title
 
+    def test_sanitize_removes_dangerous_element_payloads(self, sanitizer):
+        """Ensure dangerous element bodies are stripped before bleaching."""
+        malicious_content = (
+            "<p>Safe start</p>"
+            "<ScRiPt type='text/javascript'>\nalert('boom');\n</ScRiPt>"
+            "<iframe src=\"http://evil.example\"></iframe>"
+            "<p>Safe end</p>"
+        )
+
+        result = sanitizer.sanitize(title="Legit", content=malicious_content)
+
+        assert result.is_valid is True
+        assert result.sanitized_input is not None
+        sanitized_body = result.sanitized_input.content
+        assert "alert('boom')" not in sanitized_body
+        assert "http://evil.example" not in sanitized_body
+        assert "Safe start" in sanitized_body
+        assert "Safe end" in sanitized_body
+
     def test_sanitize_allows_html_when_configured(self, custom_sanitizer):
         """Test sanitization allows HTML when configured."""
         result = custom_sanitizer.sanitize(


### PR DESCRIPTION
## Summary
- replace the regex-only dangerous element stripper with an HTMLParser-backed implementation that logs fallbacks and only removes payloads from script-like tags
- centralize reusable regular expression patterns for whitespace normalization, URL validation, and advanced prompt-injection detection to improve safety and maintainability
- extend the sanitizer unit suite with coverage that asserts script and iframe payloads are fully removed before bleaching

## Testing
- `uv run --python 3.13 pytest tests/unit/test_input_sanitizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ceabb87c48832b8873b854ce11d1ca