### PR TITLE
fix(alt-backend): emit zero-valued scalars for KnowledgeHomeAdminService JSON

### DIFF
--- a/alt-backend/app/connect/v2/codec/json_emit_unpopulated.go
+++ b/alt-backend/app/connect/v2/codec/json_emit_unpopulated.go
@@ -1,0 +1,63 @@
+// Package codec hosts custom connect.Codec implementations used by the
+// alt-backend Connect-RPC server.
+//
+// The default JSON codec shipped with connectrpc.com/connect serializes
+// proto3 messages via protojson with a zero-valued MarshalOptions{},
+// which omits scalar fields holding their proto3 default value. The
+// admin-side Hurl boundary contracts (e.g.
+// e2e/hurl/alt-backend/72-admin-emit-article-url-backfill.hurl) assert
+// that every field of the response envelope is present even at its
+// default value, so a future refactor that drops one of them is caught
+// at the wire boundary. This codec emits unpopulated values for every
+// field so those contracts hold.
+package codec
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// EmitUnpopulatedJSONCodec implements connect.Codec for the bare "json"
+// content sub-type. Marshal uses protojson with EmitUnpopulated=true so
+// proto3 default-valued scalars (int32 = 0, bool = false, string = "")
+// remain present in the JSON output. Unmarshal sets DiscardUnknown=true
+// so a request envelope that grew a field on the client still decodes
+// on the server.
+type EmitUnpopulatedJSONCodec struct{}
+
+func (EmitUnpopulatedJSONCodec) Name() string { return "json" }
+
+func (EmitUnpopulatedJSONCodec) Marshal(v any) ([]byte, error) {
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("emit-unpopulated json codec: expected proto.Message, got %T", v)
+	}
+	return protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(msg)
+}
+
+func (EmitUnpopulatedJSONCodec) Unmarshal(data []byte, v any) error {
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("emit-unpopulated json codec: expected proto.Message, got %T", v)
+	}
+	return protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, msg)
+}
+
+// EmitUnpopulatedJSONCharsetUTF8Codec mirrors EmitUnpopulatedJSONCodec
+// under the "json; charset=utf-8" name. Connect-RPC selects a codec by
+// exact name match against the request Content-Type sub-type, so both
+// names must be registered for the override to apply when a client
+// includes the charset parameter.
+type EmitUnpopulatedJSONCharsetUTF8Codec struct{}
+
+func (EmitUnpopulatedJSONCharsetUTF8Codec) Name() string { return "json; charset=utf-8" }
+
+func (EmitUnpopulatedJSONCharsetUTF8Codec) Marshal(v any) ([]byte, error) {
+	return EmitUnpopulatedJSONCodec{}.Marshal(v)
+}
+
+func (EmitUnpopulatedJSONCharsetUTF8Codec) Unmarshal(data []byte, v any) error {
+	return EmitUnpopulatedJSONCodec{}.Unmarshal(data, v)
+}

--- a/alt-backend/app/connect/v2/codec/json_emit_unpopulated_test.go
+++ b/alt-backend/app/connect/v2/codec/json_emit_unpopulated_test.go
@@ -1,0 +1,107 @@
+package codec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	knowledgehomev1 "alt/gen/proto/alt/knowledge_home/v1"
+)
+
+// staticInterfaceCheck verifies both codecs satisfy connect.Codec at
+// compile time. If the connect API drifts, the build fails here rather
+// than silently at runtime.
+var (
+	_ connect.Codec = EmitUnpopulatedJSONCodec{}
+	_ connect.Codec = EmitUnpopulatedJSONCharsetUTF8Codec{}
+)
+
+func TestEmitUnpopulatedJSONCodec_Name(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "json", EmitUnpopulatedJSONCodec{}.Name())
+	assert.Equal(t, "json; charset=utf-8", EmitUnpopulatedJSONCharsetUTF8Codec{}.Name())
+}
+
+// TestEmitUnpopulatedJSONCodec_MarshalEmitsZeroValuedScalars locks the
+// regression that motivated this codec: the Hurl boundary contract on
+// EmitArticleUrlBackfill asserts every counter is present in the JSON
+// response even when its proto3 default value is zero. The default
+// protojson MarshalOptions{} drops those keys, which is what we are
+// fixing here.
+func TestEmitUnpopulatedJSONCodec_MarshalEmitsZeroValuedScalars(t *testing.T) {
+	t.Parallel()
+
+	resp := &knowledgehomev1.EmitArticleUrlBackfillResponse{}
+
+	data, err := EmitUnpopulatedJSONCodec{}.Marshal(resp)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	for _, key := range []string{
+		"articlesScanned",
+		"eventsAppended",
+		"skippedBlockedScheme",
+		"skippedDuplicate",
+		"moreRemaining",
+	} {
+		_, ok := got[key]
+		assert.Truef(t, ok, "expected JSON key %q to be present even at zero value, got %v", key, got)
+	}
+
+	assert.Equal(t, float64(0), got["articlesScanned"])
+	assert.Equal(t, float64(0), got["eventsAppended"])
+	assert.Equal(t, float64(0), got["skippedBlockedScheme"])
+	assert.Equal(t, float64(0), got["skippedDuplicate"])
+	assert.Equal(t, false, got["moreRemaining"])
+}
+
+func TestEmitUnpopulatedJSONCodec_MarshalNonProtoFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := EmitUnpopulatedJSONCodec{}.Marshal(struct{ Name string }{Name: "x"})
+	require.Error(t, err)
+}
+
+// TestEmitUnpopulatedJSONCodec_UnmarshalDiscardsUnknown ensures forward
+// compatibility: a request envelope that grew a field on the client
+// must still decode on the server.
+func TestEmitUnpopulatedJSONCodec_UnmarshalDiscardsUnknown(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"maxArticles": 12, "dryRun": true, "futureField": "ignored"}`)
+
+	req := &knowledgehomev1.EmitArticleUrlBackfillRequest{}
+	require.NoError(t, EmitUnpopulatedJSONCodec{}.Unmarshal(body, req))
+
+	assert.Equal(t, int32(12), req.MaxArticles)
+	assert.True(t, req.DryRun)
+}
+
+func TestEmitUnpopulatedJSONCodec_UnmarshalNonProtoFails(t *testing.T) {
+	t.Parallel()
+
+	var dst struct{ Name string }
+	err := EmitUnpopulatedJSONCodec{}.Unmarshal([]byte(`{"name":"x"}`), &dst)
+	require.Error(t, err)
+}
+
+// TestEmitUnpopulatedJSONCharsetUTF8Codec_DelegatesToBaseImplementation
+// confirms the charset variant is not a separate implementation — it
+// shares marshal/unmarshal semantics so request and response paths
+// behave identically regardless of the Content-Type the client sent.
+func TestEmitUnpopulatedJSONCharsetUTF8Codec_DelegatesToBaseImplementation(t *testing.T) {
+	t.Parallel()
+
+	resp := &knowledgehomev1.EmitArticleUrlBackfillResponse{}
+
+	base, err := EmitUnpopulatedJSONCodec{}.Marshal(resp)
+	require.NoError(t, err)
+	charset, err := EmitUnpopulatedJSONCharsetUTF8Codec{}.Marshal(resp)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(base), string(charset))
+}

--- a/alt-backend/app/connect/v2/server.go
+++ b/alt-backend/app/connect/v2/server.go
@@ -26,6 +26,7 @@ import (
 	"alt/connect/v2/admin_monitor"
 	"alt/connect/v2/articles"
 	"alt/connect/v2/augur"
+	"alt/connect/v2/codec"
 	"alt/connect/v2/feeds"
 	global_search "alt/connect/v2/global_search"
 	internalhandler "alt/connect/v2/internal"
@@ -177,6 +178,13 @@ func SetupConnectHandlers(mux *http.ServeMux, container *di.ApplicationComponent
 
 	// Register KnowledgeHomeAdminService (service-to-service API). Auth is
 	// established at the TLS transport layer (mTLS peer-identity).
+	//
+	// The custom JSON codec replaces Connect-RPC's default protojson
+	// marshaler so proto3 default-valued scalars (zero counters, false
+	// flags) stay present in the JSON response. The admin Hurl
+	// boundary contracts (e.g. 72-admin-emit-article-url-backfill.hurl)
+	// assert that every field of the response envelope round-trips,
+	// which is impossible if the wire encoder strips zero values.
 	adminOpts := connect.WithInterceptors(
 		cancelInterceptor.Interceptor(),
 	)
@@ -191,7 +199,12 @@ func SetupConnectHandlers(mux *http.ServeMux, container *di.ApplicationComponent
 		&cfg.KnowledgeHome,
 		logger,
 	)
-	khAdminPath, khAdminServiceHandler := knowledgehomev1connect.NewKnowledgeHomeAdminServiceHandler(khAdminHandler, adminOpts)
+	khAdminPath, khAdminServiceHandler := knowledgehomev1connect.NewKnowledgeHomeAdminServiceHandler(
+		khAdminHandler,
+		adminOpts,
+		connect.WithCodec(codec.EmitUnpopulatedJSONCodec{}),
+		connect.WithCodec(codec.EmitUnpopulatedJSONCharsetUTF8Codec{}),
+	)
 	mux.Handle(khAdminPath, khAdminServiceHandler)
 	logger.Info("Registered Connect-RPC KnowledgeHomeAdminService", "path", khAdminPath)
 

--- a/alt-backend/app/usecase/knowledge_url_backfill_usecase/usecase_test.go
+++ b/alt-backend/app/usecase/knowledge_url_backfill_usecase/usecase_test.go
@@ -37,10 +37,10 @@ func (m *mockArticlesPort) ListBackfillArticles(_ context.Context, _ *time.Time,
 // lets us assert the usecase's SkippedDuplicate counter is honest after
 // the AppendKnowledgeEventPort signature change (ADR-869 contract drift).
 type mockEventPort struct {
-	appended    []domain.KnowledgeEvent
-	seenDedupe  map[string]bool
-	nextSeq     int64
-	err         error
+	appended   []domain.KnowledgeEvent
+	seenDedupe map[string]bool
+	nextSeq    int64
+	err        error
 }
 
 func (m *mockEventPort) AppendKnowledgeEvent(_ context.Context, ev domain.KnowledgeEvent) (int64, error) {


### PR DESCRIPTION
The default Connect-RPC JSON codec marshals proto messages via protojson
with zero-valued MarshalOptions{}, which drops scalar fields holding
their proto3 default. The admin Hurl boundary contract for
EmitArticleUrlBackfill — and similar admin contracts to come — asserts
every field of the response envelope is present even when its value is
0 / false. Against the empty staging articles table all five counters
were default-valued, so the JSON body was {} and the Hurl jsonpath
assertions all returned `none`.

Add a custom connect.Codec that flips MarshalOptions.EmitUnpopulated to
true (Unmarshal keeps DiscardUnknown=true for forward compat) and
register it under both "json" and "json; charset=utf-8" on the
KnowledgeHomeAdminService handler only. Other Connect handlers keep the
default codec — their FE/BFF clients already tolerate proto3 omission
and there is no contract pressure on those paths today.