### PR TITLE
fix(alt-frontend-sv): harden against iOS Safari "could not connect" tab-restore failures

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -271,6 +271,10 @@ jobs:
           load: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(fromJSON('["recap-subworker","news-creator","recap-evaluator","tag-generator","recap-worker"]'), matrix.service) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Stable build identifier. alt-frontend-sv pins SvelteKit's app
+          # version to it (svelte.config.js); other Dockerfiles ignore it.
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
           # Registry cache: 常時 read/write 可 (GHCR ACL で保護)。
           # GHA cache: public repo だと fork PR から読める仕様のため、cache-from/to
           # とも main branch への push イベント限定。PR ビルドは registry のみ参照。

--- a/alt-frontend-sv/Dockerfile
+++ b/alt-frontend-sv/Dockerfile
@@ -22,6 +22,10 @@ RUN --mount=type=cache,id=bun-alt-frontend-sv,target=/root/.bun/install/cache \
 
 # ---------- Build ----------
 FROM base AS builder
+# Stable SvelteKit app version (see svelte.config.js). CI passes the commit SHA;
+# .git is dockerignored, so without this the build falls back to a timestamp.
+ARG GIT_COMMIT_SHA=""
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
 COPY --link --from=install /temp/dev/node_modules ./node_modules
 COPY --link . .
 ENV NODE_ENV=production

--- a/alt-frontend-sv/src/lib/hooks/safari-connection-recovery.test.ts
+++ b/alt-frontend-sv/src/lib/hooks/safari-connection-recovery.test.ts
@@ -12,8 +12,24 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
 	createSafariConnectionRecovery,
+	isNetworkFailureError,
+	performGuardedReload,
 	type SafariConnectionRecoveryOptions,
 } from "./safari-connection-recovery";
+
+function makeFakeStorage(initial: Record<string, string> = {}) {
+	const map = new Map<string, string>(Object.entries(initial));
+	return {
+		getItem: (k: string) => map.get(k) ?? null,
+		setItem: (k: string, v: string) => {
+			map.set(k, String(v));
+		},
+		removeItem: (k: string) => {
+			map.delete(k);
+		},
+		_map: map,
+	};
+}
 
 interface FakeDoc {
 	addEventListener: (type: string, listener: EventListener) => void;
@@ -227,5 +243,203 @@ describe("createSafariConnectionRecovery", () => {
 		expect(onRecoveryNeeded).toHaveBeenCalledTimes(2);
 
 		handle.dispose();
+	});
+
+	it("calls onRecoveryNeeded on Page Lifecycle resume after a long freeze", () => {
+		const onRecoveryNeeded = vi.fn();
+		const handle = createSafariConnectionRecovery({
+			thresholdMs: 30_000,
+			onRecoveryNeeded,
+			getNow: () => now,
+			document: fakeDoc.doc as unknown as Document,
+			storage: makeFakeStorage(),
+		});
+
+		fakeDoc.fire("freeze");
+		now += 120_000;
+		fakeDoc.fire("resume");
+
+		expect(onRecoveryNeeded).toHaveBeenCalledTimes(1);
+		expect(onRecoveryNeeded).toHaveBeenCalledWith({
+			reason: "resume",
+			hiddenDurationMs: 120_000,
+		});
+
+		handle.dispose();
+	});
+
+	it("does NOT call onRecoveryNeeded on resume after a short freeze", () => {
+		const onRecoveryNeeded = vi.fn();
+		const handle = createSafariConnectionRecovery({
+			thresholdMs: 30_000,
+			onRecoveryNeeded,
+			getNow: () => now,
+			document: fakeDoc.doc as unknown as Document,
+			storage: makeFakeStorage(),
+		});
+
+		fakeDoc.fire("freeze");
+		now += 5_000;
+		fakeDoc.fire("resume");
+
+		expect(onRecoveryNeeded).not.toHaveBeenCalled();
+
+		handle.dispose();
+	});
+
+	it("recovers on a non-persisted pageshow when sessionStorage shows a long background (Safari reloaded a discarded tab)", () => {
+		const onRecoveryNeeded = vi.fn();
+		// Simulate a hidden marker written by a previous page instance.
+		const storage = makeFakeStorage({
+			"alt:safari-recovery:hidden-at": String(now),
+		});
+		now += 300_000;
+		const handle = createSafariConnectionRecovery({
+			thresholdMs: 30_000,
+			onRecoveryNeeded,
+			getNow: () => now,
+			document: fakeDoc.doc as unknown as Document,
+			storage,
+		});
+
+		fakeDoc.fire("pageshow", { persisted: false });
+
+		expect(onRecoveryNeeded).toHaveBeenCalledTimes(1);
+		expect(onRecoveryNeeded).toHaveBeenCalledWith({
+			reason: "resume",
+			hiddenDurationMs: 300_000,
+		});
+		// Marker is consumed so a later pageshow does not re-trigger.
+		fakeDoc.fire("pageshow", { persisted: false });
+		expect(onRecoveryNeeded).toHaveBeenCalledTimes(1);
+
+		handle.dispose();
+	});
+
+	it("does NOT recover on a non-persisted pageshow without a stored hidden marker", () => {
+		const onRecoveryNeeded = vi.fn();
+		const handle = createSafariConnectionRecovery({
+			thresholdMs: 30_000,
+			onRecoveryNeeded,
+			getNow: () => now,
+			document: fakeDoc.doc as unknown as Document,
+			storage: makeFakeStorage(),
+		});
+
+		fakeDoc.fire("pageshow", { persisted: false });
+
+		expect(onRecoveryNeeded).not.toHaveBeenCalled();
+
+		handle.dispose();
+	});
+
+	it("dispose removes freeze and resume listeners too", () => {
+		const onRecoveryNeeded = vi.fn();
+		const handle = createSafariConnectionRecovery({
+			thresholdMs: 30_000,
+			onRecoveryNeeded,
+			getNow: () => now,
+			document: fakeDoc.doc as unknown as Document,
+			storage: makeFakeStorage(),
+		});
+
+		expect(fakeDoc.listenerCount("freeze")).toBe(1);
+		expect(fakeDoc.listenerCount("resume")).toBe(1);
+
+		handle.dispose();
+
+		expect(fakeDoc.listenerCount("freeze")).toBe(0);
+		expect(fakeDoc.listenerCount("resume")).toBe(0);
+
+		fakeDoc.fire("freeze");
+		now += 120_000;
+		fakeDoc.fire("resume");
+		expect(onRecoveryNeeded).not.toHaveBeenCalled();
+	});
+});
+
+describe("isNetworkFailureError", () => {
+	it("recognises Safari/Chromium/Firefox network failures", () => {
+		expect(isNetworkFailureError(new TypeError("Load failed"))).toBe(true);
+		expect(isNetworkFailureError(new TypeError("Failed to fetch"))).toBe(true);
+		expect(
+			isNetworkFailureError(
+				new TypeError("NetworkError when attempting to fetch resource."),
+			),
+		).toBe(true);
+	});
+
+	it("ignores aborts, HTTP/app errors, and non-errors", () => {
+		const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+		expect(isNetworkFailureError(abort)).toBe(false);
+		expect(isNetworkFailureError(new TypeError("x is not a function"))).toBe(
+			false,
+		);
+		expect(isNetworkFailureError(new Error("Load failed"))).toBe(false);
+		expect(isNetworkFailureError("Load failed")).toBe(false);
+		expect(isNetworkFailureError(undefined)).toBe(false);
+	});
+});
+
+describe("performGuardedReload", () => {
+	it("reloads once and records the timestamp", () => {
+		const reload = vi.fn();
+		const storage = makeFakeStorage();
+		const fakeWin = { location: { reload }, sessionStorage: undefined };
+
+		const result = performGuardedReload({
+			window: fakeWin as unknown as Window,
+			storage,
+			getNow: () => 1_000_000,
+			cooldownMs: 60_000,
+		});
+
+		expect(result).toBe(true);
+		expect(reload).toHaveBeenCalledTimes(1);
+		expect(storage.getItem("alt:safari-recovery:last-reload-at")).toBe(
+			"1000000",
+		);
+	});
+
+	it("does not reload again within the cooldown window", () => {
+		const reload = vi.fn();
+		const storage = makeFakeStorage({
+			"alt:safari-recovery:last-reload-at": "1000000",
+		});
+		const fakeWin = { location: { reload } };
+
+		const result = performGuardedReload({
+			window: fakeWin as unknown as Window,
+			storage,
+			getNow: () => 1_030_000, // 30s later, cooldown is 60s
+			cooldownMs: 60_000,
+		});
+
+		expect(result).toBe(false);
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it("reloads again once the cooldown has elapsed", () => {
+		const reload = vi.fn();
+		const storage = makeFakeStorage({
+			"alt:safari-recovery:last-reload-at": "1000000",
+		});
+		const fakeWin = { location: { reload } };
+
+		const result = performGuardedReload({
+			window: fakeWin as unknown as Window,
+			storage,
+			getNow: () => 1_120_000, // 120s later
+			cooldownMs: 60_000,
+		});
+
+		expect(result).toBe(true);
+		expect(reload).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns false when there is no usable location.reload", () => {
+		expect(performGuardedReload({ window: {} as unknown as Window })).toBe(
+			false,
+		);
 	});
 });

--- a/alt-frontend-sv/src/lib/hooks/safari-connection-recovery.ts
+++ b/alt-frontend-sv/src/lib/hooks/safari-connection-recovery.ts
@@ -1,28 +1,36 @@
 /**
  * Safari Connection Recovery Hook
  *
- * Safari aggressively drops network connections when tabs are backgrounded
- * for power-saving. This hook detects:
- * 1. Extended background periods via visibilitychange
- * 2. bfcache restore via pageshow
- * 3. Network reconnection via online event
+ * iOS Safari aggressively suspends or discards backgrounded tabs and drops their
+ * network connections to save power/memory. When the tab returns it may serve
+ * stale content, fail in-flight fetches with NSURLErrorDomain -1004 ("could not
+ * connect to server"), or — over HTTP/2 — fail the document reload outright with
+ * "サーバに接続できなかったため、ページを開けません。".
  *
- * When any of these conditions are met after prolonged inactivity, the
- * onRecoveryNeeded callback fires so the app can invalidate TanStack Query
- * caches and refetch stale data.
+ * This hook listens for every signal Safari actually emits on return-from-
+ * background — visibilitychange, pageshow (incl. bfcache), the Page Lifecycle
+ * `freeze`/`resume` pair, and `online` — and fires `onRecoveryNeeded` so the app
+ * can invalidate stale caches and refetch.
+ *
+ * The hidden timestamp is mirrored into sessionStorage so a long background
+ * period is still observable after a bfcache restore or a Safari-initiated
+ * document reload, where the in-memory `hiddenAt` would otherwise be lost.
  *
  * Safari-specific behavior:
  * - NSURLErrorDomain -1004: "Could not connect to server" after background
- * - WebSocket connections silently dropped when tab loses focus
- * - fetch requests may fail or stall after bfcache restore
+ * - dropped connections surface to fetch() as `TypeError: Load failed`
+ * - WebSocket connections silently dropped when the tab loses focus
+ * - bfcache restore: `pageshow` with `persisted === true`, all connections stale
  */
 
-export type RecoveryReason = "visibility" | "bfcache" | "online";
+export type RecoveryReason = "visibility" | "bfcache" | "online" | "resume";
 
 export interface RecoveryInfo {
 	reason: RecoveryReason;
 	hiddenDurationMs?: number;
 }
+
+type MinimalStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
 export interface SafariConnectionRecoveryOptions {
 	/** Minimum background duration (ms) before triggering recovery. Default 30s. */
@@ -37,32 +45,81 @@ export interface SafariConnectionRecoveryOptions {
 	navigator?: Navigator;
 	/** Injected for tests. Defaults to globalThis.window. */
 	window?: Window;
+	/** Injected for tests. Defaults to globalThis.sessionStorage (if available). */
+	storage?: MinimalStorage;
 }
 
 export interface SafariConnectionRecoveryHandle {
 	dispose(): void;
 }
 
+const HIDDEN_AT_KEY = "alt:safari-recovery:hidden-at";
+
+function resolveSessionStorage(): MinimalStorage | undefined {
+	try {
+		return globalThis.sessionStorage;
+	} catch {
+		// Safari throws on sessionStorage access in some private-browsing modes.
+		return undefined;
+	}
+}
+
 export function createSafariConnectionRecovery(
 	opts: SafariConnectionRecoveryOptions,
 ): SafariConnectionRecoveryHandle {
 	const doc = opts.document ?? globalThis.document;
-	const nav = opts.navigator ?? globalThis.navigator;
 	const win = opts.window ?? globalThis.window;
 	const getNow = opts.getNow ?? Date.now;
 	const thresholdMs = opts.thresholdMs;
+	const storage = opts.storage ?? resolveSessionStorage();
 
 	let hiddenAt: number | null = null;
 
-	const onVisibilityChange = () => {
+	const readStoredHiddenAt = (): number | null => {
+		try {
+			const raw = storage?.getItem(HIDDEN_AT_KEY);
+			if (!raw) return null;
+			const n = Number(raw);
+			return Number.isFinite(n) ? n : null;
+		} catch {
+			return null;
+		}
+	};
+
+	const writeStoredHiddenAt = (value: number | null): void => {
+		try {
+			if (value === null) storage?.removeItem(HIDDEN_AT_KEY);
+			else storage?.setItem(HIDDEN_AT_KEY, String(value));
+		} catch {
+			// sessionStorage may be unavailable (private mode / SSR) — ignore.
+		}
+	};
+
+	const markHidden = (): void => {
+		hiddenAt = getNow();
+		writeStoredHiddenAt(hiddenAt);
+	};
+
+	/**
+	 * If we are returning from a background period longer than the threshold,
+	 * return its duration; otherwise return null. Always clears the hidden marker.
+	 */
+	const consumeHiddenDuration = (): number | null => {
+		const startedAt = hiddenAt ?? readStoredHiddenAt();
+		hiddenAt = null;
+		writeStoredHiddenAt(null);
+		if (startedAt === null) return null;
+		const elapsed = getNow() - startedAt;
+		return elapsed > thresholdMs ? elapsed : null;
+	};
+
+	const onVisibilityChange = (): void => {
 		if (doc.visibilityState === "hidden") {
-			hiddenAt = getNow();
+			markHidden();
 			return;
 		}
-		if (hiddenAt === null) return;
-		const elapsed = getNow() - hiddenAt;
-		hiddenAt = null;
-		if (elapsed > thresholdMs) {
+		const elapsed = consumeHiddenDuration();
+		if (elapsed !== null) {
 			opts.onRecoveryNeeded({
 				reason: "visibility",
 				hiddenDurationMs: elapsed,
@@ -70,25 +127,116 @@ export function createSafariConnectionRecovery(
 		}
 	};
 
-	const onPageShow = (e: Event) => {
+	const onPageShow = (e: Event): void => {
 		const persisted = (e as { persisted?: boolean }).persisted === true;
-		if (!persisted) return;
-		opts.onRecoveryNeeded({ reason: "bfcache", hiddenDurationMs: undefined });
+		if (persisted) {
+			// bfcache restore — connections are definitely stale.
+			hiddenAt = null;
+			writeStoredHiddenAt(null);
+			opts.onRecoveryNeeded({ reason: "bfcache", hiddenDurationMs: undefined });
+			return;
+		}
+		// A non-persisted pageshow fires on every fresh load *and* when Safari
+		// reloads a tab it had discarded. Only the latter — detectable because
+		// sessionStorage shows we were backgrounded past the threshold — counts.
+		const elapsed = consumeHiddenDuration();
+		if (elapsed !== null) {
+			opts.onRecoveryNeeded({ reason: "resume", hiddenDurationMs: elapsed });
+		}
 	};
 
-	const onOnline = () => {
+	const onFreeze = (): void => {
+		markHidden();
+	};
+
+	const onResume = (): void => {
+		const elapsed = consumeHiddenDuration();
+		if (elapsed !== null) {
+			opts.onRecoveryNeeded({ reason: "resume", hiddenDurationMs: elapsed });
+		}
+	};
+
+	const onOnline = (): void => {
 		opts.onRecoveryNeeded({ reason: "online", hiddenDurationMs: undefined });
 	};
 
 	doc.addEventListener("visibilitychange", onVisibilityChange);
 	doc.addEventListener("pageshow", onPageShow);
+	doc.addEventListener("freeze", onFreeze);
+	doc.addEventListener("resume", onResume);
 	win?.addEventListener("online", onOnline);
 
 	return {
 		dispose() {
 			doc.removeEventListener("visibilitychange", onVisibilityChange);
 			doc.removeEventListener("pageshow", onPageShow);
+			doc.removeEventListener("freeze", onFreeze);
+			doc.removeEventListener("resume", onResume);
 			win?.removeEventListener("online", onOnline);
 		},
 	};
+}
+
+/**
+ * True if `error` looks like a browser network-layer failure rather than an
+ * application/HTTP error or a deliberate AbortController abort. Safari surfaces
+ * a dropped connection as `TypeError: Load failed`; Chromium as
+ * `TypeError: Failed to fetch`; Firefox as `TypeError: NetworkError ...`.
+ */
+export function isNetworkFailureError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	if (error.name === "AbortError") return false;
+	if (error.name !== "TypeError") return false;
+	return /load failed|failed to fetch|network ?error|networkerror/i.test(
+		error.message ?? "",
+	);
+}
+
+const RELOAD_GUARD_KEY = "alt:safari-recovery:last-reload-at";
+
+export interface GuardedReloadOptions {
+	/** Injected for tests. Defaults to globalThis. */
+	window?: Pick<Window, "location"> & { sessionStorage?: Storage };
+	/** Injected for tests. Defaults to globalThis.sessionStorage (if available). */
+	storage?: Pick<Storage, "getItem" | "setItem">;
+	/** Injected for tests. Defaults to Date.now. */
+	getNow?: () => number;
+	/** Minimum gap between automatic reloads, ms. Default 60s. */
+	cooldownMs?: number;
+}
+
+/**
+ * Reload the document at most once per cooldown window. Returns true if a reload
+ * was actually triggered. Use as an escape hatch when, shortly after a recovery
+ * event, fetches keep failing with network errors — i.e. Safari is holding a
+ * dead connection that only a fresh navigation will clear. The cooldown
+ * (persisted in sessionStorage) prevents reload loops if the failure is
+ * server-side rather than a stale connection.
+ */
+export function performGuardedReload(opts: GuardedReloadOptions = {}): boolean {
+	const win =
+		opts.window ?? (globalThis as unknown as GuardedReloadOptions["window"]);
+	if (!win?.location || typeof win.location.reload !== "function") return false;
+	const getNow = opts.getNow ?? Date.now;
+	const cooldownMs = opts.cooldownMs ?? 60_000;
+	const storage = opts.storage ?? win.sessionStorage ?? resolveSessionStorage();
+
+	let lastReloadAt = 0;
+	try {
+		const raw = storage?.getItem(RELOAD_GUARD_KEY);
+		if (raw) lastReloadAt = Number(raw) || 0;
+	} catch {
+		// ignore
+	}
+
+	const now = getNow();
+	if (now - lastReloadAt < cooldownMs) return false;
+
+	try {
+		storage?.setItem(RELOAD_GUARD_KEY, String(now));
+	} catch {
+		// ignore
+	}
+	win.location.reload();
+	return true;
 }

--- a/alt-frontend-sv/src/lib/stores/connection-recovery.svelte.ts
+++ b/alt-frontend-sv/src/lib/stores/connection-recovery.svelte.ts
@@ -29,6 +29,8 @@ export interface ConnectionRecoveryStore {
 	readonly recoveryCount: number;
 	/** Last recovery info, if any. */
 	readonly lastRecoveryInfo: RecoveryInfo | null;
+	/** True if a recovery event fired within the last `windowMs`. */
+	wasRecentlyRecovered(windowMs: number): boolean;
 }
 
 const RECOVERY_THRESHOLD_MS = 30_000; // 30 seconds background triggers recovery
@@ -36,12 +38,14 @@ const RECOVERY_THRESHOLD_MS = 30_000; // 30 seconds background triggers recovery
 export function createConnectionRecoveryStore(): ConnectionRecoveryStore {
 	let recoveryCount = $state(0);
 	let lastRecoveryInfo = $state<RecoveryInfo | null>(null);
+	let lastRecoveryAt = $state<number | null>(null);
 	const callbacks = new Set<RecoveryCallback>();
 	let handle: SafariConnectionRecoveryHandle | null = null;
 
 	function notifySubscribers(info: RecoveryInfo) {
 		recoveryCount++;
 		lastRecoveryInfo = info;
+		lastRecoveryAt = Date.now();
 		for (const cb of callbacks) {
 			try {
 				cb(info);
@@ -70,6 +74,9 @@ export function createConnectionRecoveryStore(): ConnectionRecoveryStore {
 		},
 		get lastRecoveryInfo() {
 			return lastRecoveryInfo;
+		},
+		wasRecentlyRecovered(windowMs: number) {
+			return lastRecoveryAt !== null && Date.now() - lastRecoveryAt <= windowMs;
 		},
 	};
 }

--- a/alt-frontend-sv/src/routes/+layout.svelte
+++ b/alt-frontend-sv/src/routes/+layout.svelte
@@ -2,7 +2,11 @@
 import { onMount, setContext } from "svelte";
 import "./layout.css";
 import favicon from "$lib/assets/favicon.svg";
-import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+import {
+	QueryCache,
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/svelte-query";
 import { page } from "$app/state";
 import { createAuthStore, AUTH_STORE_KEY } from "$lib/stores/auth.svelte";
 import {
@@ -13,6 +17,10 @@ import {
 	createConnectionRecoveryStore,
 	CONNECTION_RECOVERY_KEY,
 } from "$lib/stores/connection-recovery.svelte";
+import {
+	isNetworkFailureError,
+	performGuardedReload,
+} from "$lib/hooks/safari-connection-recovery";
 
 const { children } = $props();
 
@@ -40,8 +48,20 @@ onMount(() => {
 	document.body.classList.add("hydrated");
 });
 
-// Create QueryClient for TanStack Query with Safari-friendly defaults
+// Create QueryClient for TanStack Query with Safari-friendly defaults.
+// If a query still fails with a network error shortly after a connection
+// recovery event, Safari is almost certainly holding a dead connection that
+// only a fresh navigation will clear — do one guarded full reload.
 const queryClient = new QueryClient({
+	queryCache: new QueryCache({
+		onError: (error) => {
+			if (typeof window === "undefined") return;
+			if (navigator?.onLine === false) return;
+			if (!isNetworkFailureError(error)) return;
+			if (!connectionRecovery.wasRecentlyRecovered(20_000)) return;
+			performGuardedReload();
+		},
+	}),
 	defaultOptions: {
 		queries: {
 			staleTime: 1000 * 60 * 5, // 5 minutes

--- a/alt-frontend-sv/svelte.config.js
+++ b/alt-frontend-sv/svelte.config.js
@@ -1,5 +1,32 @@
 import adapter from "@sveltejs/adapter-node";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import { execSync } from "node:child_process";
+
+// SvelteKit falls back to a full-page navigation whenever the client's app
+// version differs from the server's. The framework default for `version.name`
+// is a build timestamp, so *every* rebuild — even a no-op CI rebuild — looks
+// like a new deploy and forces extra full document loads on the next client
+// navigation. On iOS Safari each of those reloads is another chance to hit the
+// "could not connect to the server" stale-connection failure. Pin the version
+// to an identifier that only changes when the code actually changes: an
+// explicit build id, then the git commit SHA (CI passes it as an env var
+// because `.git` is dockerignored), then the timestamp as a last resort.
+function resolveVersionName() {
+	const fromEnv =
+		process.env.PUBLIC_BUILD_ID ??
+		process.env.GIT_COMMIT_SHA ??
+		process.env.GITHUB_SHA;
+	if (fromEnv && fromEnv.trim()) return fromEnv.trim();
+	try {
+		return execSync("git rev-parse --short=12 HEAD", {
+			stdio: ["ignore", "pipe", "ignore"],
+		})
+			.toString()
+			.trim();
+	} catch {
+		return Date.now().toString();
+	}
+}
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -16,7 +43,7 @@ const config = {
 			base: "",
 		},
 		version: {
-			name: Date.now().toString(),
+			name: resolveVersionName(),
 		},
 	},
 };

--- a/compose/core.yaml
+++ b/compose/core.yaml
@@ -63,6 +63,8 @@ services:
     build:
       context: ../alt-frontend-sv
       dockerfile: Dockerfile
+      args:
+        GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-}
     environment:
       - PORT=4173
       - ORIGIN=${ORIGIN:-http://localhost:4173}


### PR DESCRIPTION
iOS Safari discards backgrounded tabs and drops their connections; on return it
reloads the document and may reuse a dead pooled HTTP/2 connection, surfacing
"サーバに接続できなかったため、ページを開けません。" on any page until a manual reload.

- pin SvelteKit version.name to a stable build id (env GIT_COMMIT_SHA → git SHA
  → timestamp) so no-op rebuilds stop forcing extra full reloads; CI/compose
  pass the commit SHA as a build arg (.git is dockerignored)
- extend safari-connection-recovery: listen for Page Lifecycle freeze/resume,
  mirror the hidden timestamp into sessionStorage so a long background is still
  detectable after a bfcache restore or a Safari-initiated reload
- add isNetworkFailureError + performGuardedReload (once-per-60s, sessionStorage
  guarded) and wire them into the QueryClient's QueryCache.onError so a network
  failure shortly after a recovery event triggers one clean reload

TanStack supply-chain check: only @tanstack/svelte-query@6.1.28 (+ query-core
5.100.9) is used; the @tanstack/query* family is confirmed clean — none of the
compromised @tanstack/*-router packages are present.

https://claude.ai/code/session_01DfqcgajwYcR5StcAu2AjVu