### PR TITLE
feat(knowledge-trail): link footprints to the in-app article reader b…

### DIFF
--- a/alt-frontend-sv/src/lib/api/client/articles.ts
+++ b/alt-frontend-sv/src/lib/api/client/articles.ts
@@ -109,6 +109,20 @@ export async function getFeedContentOnTheFlyClient(
 }
 
 /**
+ * Resolve an article's canonical source URL by id (server-side, via
+ * GetArticleSourceURL). Used by id-only entry points such as the Knowledge Trail
+ * spine, so the URL is looked up from the trusted store by id and never travels
+ * in the client URL bar.
+ */
+export async function getArticleSourceURLClient(
+	articleId: string,
+): Promise<string> {
+	const transport = createClientTransport();
+	const { getArticleSourceURL } = await import("$lib/connect/articles");
+	return getArticleSourceURL(transport, articleId);
+}
+
+/**
  * Archive content (クライアントサイド)
  * Connect-RPC を使用
  */

--- a/alt-frontend-sv/src/lib/components/knowledge-trail/Footprint.svelte
+++ b/alt-frontend-sv/src/lib/components/knowledge-trail/Footprint.svelte
@@ -16,6 +16,12 @@ const VERB_LABEL: Record<string, string> = {
 };
 
 const verbLabel = $derived(VERB_LABEL[footprint.verb] ?? footprint.verb);
+// Link to the in-app article reader by id only. The reader resolves the source
+// URL from the id server-side (GetArticleSourceURL) — no URL in the link, no
+// external href, no client-supplied URL.
+const articleId = $derived(
+	footprint.itemKey.startsWith("article:") ? footprint.itemKey.slice(8) : null,
+);
 const wear = $derived(
 	footprint.wear === "deep" || footprint.wear === "worn"
 		? footprint.wear
@@ -44,7 +50,11 @@ function formatTime(iso: string): string {
 				<span class="fp-note">{footprint.note}</span>
 			{/if}
 		</div>
-		<div class="fp-title">{footprint.title || footprint.itemKey}</div>
+		{#if articleId}
+			<a class="fp-title fp-title-link" href="/articles/{articleId}" data-testid="footprint-link">{footprint.title || footprint.itemKey}</a>
+		{:else}
+			<div class="fp-title">{footprint.title || footprint.itemKey}</div>
+		{/if}
 		{#if footprint.excerpt}
 			<p class="fp-excerpt">{footprint.excerpt}</p>
 		{/if}
@@ -149,6 +159,15 @@ function formatTime(iso: string): string {
 		line-height: 1.3;
 		margin-top: 0.2rem;
 		color: var(--alt-charcoal, #1a1a1a);
+	}
+	.fp-title-link {
+		display: block;
+		text-decoration: none;
+		cursor: pointer;
+	}
+	.fp-title-link:hover {
+		text-decoration: underline;
+		color: var(--interactive-text, #2f4f4f);
 	}
 	.fp-excerpt {
 		font-size: 0.84rem;

--- a/alt-frontend-sv/src/lib/components/knowledge-trail/Footprint.svelte.test.ts
+++ b/alt-frontend-sv/src/lib/components/knowledge-trail/Footprint.svelte.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-svelte";
+import type { FootprintData } from "$lib/connect/knowledge_trail";
+import Footprint from "./Footprint.svelte";
+
+function makeFootprint(overrides: Partial<FootprintData> = {}): FootprintData {
+	return {
+		footprintKey: "open:article:abc",
+		verb: "read",
+		itemKey: "article:11111111-2222-3333-4444-555555555555",
+		title: "Hunting Submarines",
+		excerpt: "An article about gravity.",
+		tags: ["submarine"],
+		note: "",
+		occurredAt: "2026-06-11T13:00:00Z",
+		wear: "thin",
+		...overrides,
+	};
+}
+
+describe("Footprint", () => {
+	it("links the title to the in-app article reader by id only (no url)", async () => {
+		render(Footprint, { props: { footprint: makeFootprint() } });
+		const link = page.getByTestId("footprint-link");
+		await expect.element(link).toBeInTheDocument();
+		// id-only: the article id (after the `article:` prefix), no `?url=`.
+		await expect
+			.element(link)
+			.toHaveAttribute(
+				"href",
+				"/articles/11111111-2222-3333-4444-555555555555",
+			);
+	});
+
+	it("renders a plain title (no link) for non-article items", async () => {
+		render(Footprint, {
+			props: { footprint: makeFootprint({ itemKey: "digest:2026-06-11" }) },
+		});
+		expect(page.getByTestId("footprint-link").elements()).toHaveLength(0);
+	});
+});

--- a/alt-frontend-sv/src/routes/(app)/articles/[id]/+page.svelte
+++ b/alt-frontend-sv/src/routes/(app)/articles/[id]/+page.svelte
@@ -11,7 +11,10 @@ import { onDestroy } from "svelte";
 import { MediaQuery } from "svelte/reactivity";
 import { goto } from "$app/navigation";
 import { page } from "$app/state";
-import { getFeedContentOnTheFlyClient } from "$lib/api/client/articles";
+import {
+	getArticleSourceURLClient,
+	getFeedContentOnTheFlyClient,
+} from "$lib/api/client/articles";
 import RenderFeedDetails from "$lib/components/mobile/RenderFeedDetails.svelte";
 import ArticleOverflowMenu from "$lib/components/mobile/tts/ArticleOverflowMenu.svelte";
 import TtsSetupSheet from "$lib/components/mobile/tts/TtsSetupSheet.svelte";
@@ -31,8 +34,30 @@ const articleId = $derived(page.params.id);
 // canonical Loop ACT fix the projector + FE only ever produce public HTTPS
 // URLs here, but a hand-typed share URL or external linker could still
 // arrive with a hostile scheme — defense-in-depth.
-const articleUrl = $derived(safeArticleHref(page.url.searchParams.get("url")));
+// Primary source: a `?url=` handoff (home / recall / search). Sanitized before
+// any consumer sees it.
+const paramUrl = $derived(safeArticleHref(page.url.searchParams.get("url")));
+// id-only entry (e.g. the Knowledge Trail spine) passes no URL — it is resolved
+// from the article id server-side (GetArticleSourceURL), so the URL never
+// travels in the client URL bar and is never client-supplied.
+let resolvedUrl = $state<string | null>(null);
+const articleUrl = $derived(paramUrl ?? resolvedUrl);
 const articleTitle = $derived(page.url.searchParams.get("title"));
+
+$effect(() => {
+	if (paramUrl || resolvedUrl || !articleId) return;
+	let cancelled = false;
+	void getArticleSourceURLClient(articleId)
+		.then((u) => {
+			if (!cancelled) resolvedUrl = safeArticleHref(u);
+		})
+		.catch(() => {
+			// Leave resolvedUrl null — the page falls back to its empty state.
+		});
+	return () => {
+		cancelled = true;
+	};
+});
 
 let isFetching = $state(false);
 let articleContent = $state<string | null>(null);

--- a/alt-frontend-sv/src/routes/(app)/articles/[id]/page.svelte.test.ts
+++ b/alt-frontend-sv/src/routes/(app)/articles/[id]/page.svelte.test.ts
@@ -16,9 +16,12 @@ vi.mock("$app/navigation", () => ({
 }));
 
 const mockGetFeedContent = vi.fn();
+const mockGetArticleSourceURL = vi.fn().mockResolvedValue("");
 vi.mock("$lib/api/client/articles", () => ({
 	getFeedContentOnTheFlyClient: (...args: unknown[]) =>
 		mockGetFeedContent(...args),
+	getArticleSourceURLClient: (...args: unknown[]) =>
+		mockGetArticleSourceURL(...args),
 }));
 
 const mockSummarizerReset = vi.fn();


### PR DESCRIPTION
…y id only

Each footprint title now links to /articles/<id> using only the article id (derived from item_key) — never the source URL, and never an external href. When the reader is opened without a url handoff in the query string (the id-only entry from the spine), it resolves the canonical URL from the id server-side via GetArticleSourceURL. The URL is looked up from the trusted store by id and never travels in the client URL bar, avoiding the url-in-querystring attack surface (scheme injection / SSRF) that safeArticleHref otherwise has to defend against.