### PR TITLE
fix(alt-backend): remediate code scanning SSRF, G115, and G118 alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+name: "Alt Go CodeQL"
+packs:
+  - ./.github/codeql

--- a/.github/codeql/models/ssrf-barriers.yml
+++ b/.github/codeql/models/ssrf-barriers.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/go-all
+      extensible: barrierModel
+    data:
+      # CanonicalRequestURL validates + reconstructs; return value is safe for request-forgery sinks.
+      - ["alt/utils/security", "SSRFValidator", True, "CanonicalRequestURL", "", "", "ReturnValue[0]", "request-forgery", "manual"]

--- a/.github/codeql/qlpack.yml
+++ b/.github/codeql/qlpack.yml
@@ -1,0 +1,7 @@
+name: alt/codeql-go-models
+version: 0.0.1
+library: true
+extensionTargets:
+  codeql/go-all: "*"
+dataExtensions:
+  - models/**/*.yml

--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -128,6 +128,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
           # 解析対象をさらに絞りたい場合は、以下を調整してください
           # paths: alt-backend,pre-processor,pre-processor-sidecar,search-indexer,auth-hub
           # paths-ignore: tmp,dist,vendor

--- a/alt-backend/app/dataplane/connect/internalapi/handler.go
+++ b/alt-backend/app/dataplane/connect/internalapi/handler.go
@@ -24,6 +24,7 @@ import (
 	"alt/shared/port/event_publisher_port"
 	"alt/shared/port/knowledge_event_port"
 	"alt/shared/usecase/create_summary_version_usecase"
+	"alt/utils/safeconv"
 	"fmt"
 )
 
@@ -1114,9 +1115,9 @@ func (h *Handler) ListRecapArticles(
 
 	resp := &backendv1.ListRecapArticlesResponse{
 		Range:    &backendv1.RecapArticleRange{From: from.UTC().Format(time.RFC3339), To: to.UTC().Format(time.RFC3339)},
-		Total:    int32(page.Total),
-		Page:     int32(page.Page),
-		PageSize: int32(page.PageSize),
+		Total:    safeconv.Int32(page.Total),
+		Page:     safeconv.Int32(page.Page),
+		PageSize: safeconv.Int32(page.PageSize),
 		HasMore:  page.HasMore,
 		Articles: articles,
 	}
@@ -1147,7 +1148,7 @@ func (h *Handler) FetchTagCloud(ctx context.Context, req *connect.Request[backen
 	for _, item := range items {
 		tags = append(tags, &backendv1.TagCloudInternalItem{
 			TagName:      item.TagName,
-			ArticleCount: int32(item.ArticleCount),
+			ArticleCount: safeconv.Int32(item.ArticleCount),
 		})
 	}
 

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler.go
@@ -34,6 +34,7 @@ import (
 	"alt/shared/usecase/fetch_articles_by_tag_usecase"
 	"alt/shared/usecase/fetch_tag_cloud_usecase"
 	"alt/utils/perf"
+	"alt/utils/safeconv"
 	"alt/utils/url_validator"
 
 	"google.golang.org/protobuf/proto"
@@ -579,7 +580,7 @@ func (h *Handler) FetchTagCloud(
 	for _, item := range items {
 		protoItems = append(protoItems, &articlesv2.TagCloudItem{
 			TagName:      item.TagName,
-			ArticleCount: int32(item.ArticleCount),
+			ArticleCount: safeconv.Int32(item.ArticleCount),
 			PositionX:    float32(item.PositionX),
 			PositionY:    float32(item.PositionY),
 			PositionZ:    float32(item.PositionZ),
@@ -588,7 +589,7 @@ func (h *Handler) FetchTagCloud(
 
 	return connect.NewResponse(&articlesv2.FetchTagCloudResponse{
 		Tags:      protoItems,
-		TotalTags: int32(len(protoItems)),
+		TotalTags: safeconv.Int32(len(protoItems)),
 	}), nil
 }
 
@@ -638,11 +639,12 @@ func (h *Handler) BatchPrefetchImages(
 		})
 	}
 
-	// Warm cache for images in background
+	// Warm cache for images in background. WithoutCancel keeps request values
+	// (trace/auth metadata) while allowing work to finish after the RPC returns.
 	for _, ogURL := range ogURLs {
 		ogURLCopy := ogURL
 		go func() {
-			warmCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			warmCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
 			defer cancel()
 			h.deps.ImageProxy.WarmCache(warmCtx, ogURLCopy)
 		}()
@@ -718,8 +720,8 @@ func (h *Handler) FetchArticleSummary(
 		if len(items) > 0 {
 			return connect.NewResponse(&articlesv2.FetchArticleSummaryResponse{
 				MatchedArticles: items,
-				TotalMatched:    int32(len(items)),
-				RequestedCount:  int32(len(feedUrls)),
+				TotalMatched:    safeconv.Int32(len(items)),
+				RequestedCount:  safeconv.Int32(len(feedUrls)),
 			}), nil
 		}
 	}
@@ -749,8 +751,8 @@ func (h *Handler) FetchArticleSummary(
 
 	return connect.NewResponse(&articlesv2.FetchArticleSummaryResponse{
 		MatchedArticles: items,
-		TotalMatched:    int32(len(items)),
-		RequestedCount:  int32(len(feedUrls)),
+		TotalMatched:    safeconv.Int32(len(items)),
+		RequestedCount:  safeconv.Int32(len(feedUrls)),
 	}), nil
 }
 

--- a/alt-backend/app/orchestrator/connect/v2/feeds/feed_read.go
+++ b/alt-backend/app/orchestrator/connect/v2/feeds/feed_read.go
@@ -13,6 +13,7 @@ import (
 	"alt/connect/errorhandler"
 	"alt/connect/v2/middleware"
 	"alt/utils/perf"
+	"alt/utils/safeconv"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -350,7 +351,7 @@ func (h *Handler) SearchFeeds(
 	// Compute next cursor
 	var nextCursor *int32
 	if hasMore {
-		next := int32(offset + len(results))
+		next := safeconv.Int32(offset + len(results))
 		nextCursor = &next
 	}
 

--- a/alt-backend/app/orchestrator/connect/v2/global_search/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/global_search/handler.go
@@ -13,6 +13,7 @@ import (
 	searchv2 "alt/gen/proto/alt/search/v2"
 	"alt/gen/proto/alt/search/v2/searchv2connect"
 	"alt/orchestrator/usecase/global_search_usecase"
+	"alt/utils/safeconv"
 )
 
 // Handler implements the GlobalSearchService Connect-RPC handler.
@@ -123,7 +124,7 @@ func toRecapSection(s *domain.RecapSearchSection) *searchv2.RecapSection {
 			Summary:    h.Summary,
 			TopTerms:   topTerms,
 			Tags:       tags,
-			WindowDays: int32(h.WindowDays),
+			WindowDays: safeconv.Int32(h.WindowDays),
 			ExecutedAt: h.ExecutedAt,
 		}
 	}
@@ -139,7 +140,7 @@ func toTagSection(s *domain.TagSearchSection) *searchv2.TagSection {
 	for i, h := range s.Hits {
 		hits[i] = &searchv2.GlobalTagHit{
 			TagName:      h.TagName,
-			ArticleCount: int32(h.ArticleCount),
+			ArticleCount: safeconv.Int32(h.ArticleCount),
 		}
 	}
 	return &searchv2.TagSection{

--- a/alt-backend/app/orchestrator/connect/v2/knowledge_home/home_query.go
+++ b/alt-backend/app/orchestrator/connect/v2/knowledge_home/home_query.go
@@ -12,6 +12,7 @@ import (
 
 	"alt/connect/errorhandler"
 	"alt/connect/v2/middleware"
+	"alt/utils/safeconv"
 
 	"github.com/google/uuid"
 )
@@ -79,13 +80,13 @@ func (h *Handler) GetKnowledgeHome(
 	// Map digest from usecase (needToKnowCount is backend-authoritative, not page-scanned)
 	digest := &knowledgehomev1.TodayDigest{
 		Date:                  result.Digest.DigestDate.Format("2006-01-02"),
-		NewArticles:           int32(result.Digest.NewArticles),
-		SummarizedArticles:    int32(result.Digest.SummarizedArticles),
-		UnsummarizedArticles:  int32(result.Digest.UnsummarizedArticles),
+		NewArticles:           safeconv.Int32(result.Digest.NewArticles),
+		SummarizedArticles:    safeconv.Int32(result.Digest.SummarizedArticles),
+		UnsummarizedArticles:  safeconv.Int32(result.Digest.UnsummarizedArticles),
 		TopTags:               result.Digest.TopTags,
 		WeeklyRecapAvailable:  result.Digest.WeeklyRecapAvailable,
 		EveningPulseAvailable: result.Digest.EveningPulseAvailable,
-		NeedToKnowCount:       int32(result.Digest.NeedToKnowCount),
+		NeedToKnowCount:       safeconv.Int32(result.Digest.NeedToKnowCount),
 		DigestFreshness:       result.Digest.DigestFreshness,
 	}
 	if result.Digest.LastProjectedAt != nil {

--- a/alt-backend/app/orchestrator/connect/v2/knowledge_home_admin/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/knowledge_home_admin/handler.go
@@ -18,6 +18,7 @@ import (
 	"alt/orchestrator/usecase/knowledge_backfill_usecase"
 	"alt/orchestrator/usecase/knowledge_projection_health_usecase"
 	"alt/orchestrator/usecase/knowledge_url_backfill_usecase"
+	"alt/utils/safeconv"
 )
 
 // ReprojectUsecase defines the reproject operations interface.
@@ -134,10 +135,10 @@ func (h *Handler) EmitArticleUrlBackfill(
 	)
 
 	return connect.NewResponse(&knowledgehomev1.EmitArticleUrlBackfillResponse{
-		ArticlesScanned:      int32(res.ArticlesScanned),
-		EventsAppended:       int32(res.EventsAppended),
-		SkippedBlockedScheme: int32(res.SkippedBlockedScheme),
-		SkippedDuplicate:     int32(res.SkippedDuplicate),
+		ArticlesScanned:      safeconv.Int32(res.ArticlesScanned),
+		EventsAppended:       safeconv.Int32(res.EventsAppended),
+		SkippedBlockedScheme: safeconv.Int32(res.SkippedBlockedScheme),
+		SkippedDuplicate:     safeconv.Int32(res.SkippedDuplicate),
 		MoreRemaining:        res.MoreRemaining,
 	}), nil
 }
@@ -241,7 +242,7 @@ func (h *Handler) GetProjectionHealth(
 	}
 
 	return connect.NewResponse(&knowledgehomev1.GetProjectionHealthResponse{
-		ActiveVersion: int32(health.ActiveVersion),
+		ActiveVersion: safeconv.Int32(health.ActiveVersion),
 		CheckpointSeq: health.CheckpointSeq,
 		LastUpdated:   health.LastUpdated.Format(time.RFC3339),
 		BackfillJobs:  protoJobs,
@@ -257,7 +258,7 @@ func (h *Handler) GetFeatureFlags(
 		EnableHomePage:     h.cfg.EnableHomePage,
 		EnableTracking:     h.cfg.EnableTracking,
 		EnableProjectionV2: h.cfg.EnableProjectionV2,
-		RolloutPercentage:  int32(h.cfg.RolloutPercentage),
+		RolloutPercentage:  safeconv.Int32(h.cfg.RolloutPercentage),
 		// EnableRecallRail intentionally absent — ADR-000913 §D-9
 		// retired the flag once the recall rail merged into the
 		// canonical Home payload. The proto field stays in the wire
@@ -468,7 +469,7 @@ func (h *Handler) GetSLOStatus(
 	return connect.NewResponse(&knowledgehomev1.GetSLOStatusResponse{
 		OverallHealth:         status.OverallHealth,
 		Slis:                  protoSLIs,
-		ErrorBudgetWindowDays: int32(status.ErrorBudgetWindowDays),
+		ErrorBudgetWindowDays: safeconv.Int32(status.ErrorBudgetWindowDays),
 		ActiveAlerts:          protoAlerts,
 		ComputedAt:            status.ComputedAt.Format(time.RFC3339),
 	}), nil
@@ -504,8 +505,8 @@ func (h *Handler) RunProjectionAudit(
 			ProjectionName:    audit.ProjectionName,
 			ProjectionVersion: audit.ProjectionVersion,
 			CheckedAt:         audit.CheckedAt.Format(time.RFC3339),
-			SampleSize:        int32(audit.SampleSize),
-			MismatchCount:     int32(audit.MismatchCount),
+			SampleSize:        safeconv.Int32(audit.SampleSize),
+			MismatchCount:     safeconv.Int32(audit.MismatchCount),
 			DetailsJson:       string(audit.DetailsJSON),
 		},
 	}), nil
@@ -602,9 +603,9 @@ func convertBackfillJob(job *domain.KnowledgeBackfillJob) *knowledgehomev1.Backf
 	proto := &knowledgehomev1.BackfillJob{
 		JobId:             job.JobID.String(),
 		Status:            job.Status,
-		ProjectionVersion: int32(job.ProjectionVersion),
-		TotalEvents:       int32(job.TotalEvents),
-		ProcessedEvents:   int32(job.ProcessedEvents),
+		ProjectionVersion: safeconv.Int32(job.ProjectionVersion),
+		TotalEvents:       safeconv.Int32(job.TotalEvents),
+		ProcessedEvents:   safeconv.Int32(job.ProcessedEvents),
 		ErrorMessage:      job.ErrorMessage,
 		CreatedAt:         job.CreatedAt.Format(time.RFC3339),
 	}

--- a/alt-backend/app/orchestrator/connect/v2/morning_letter/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/morning_letter/handler.go
@@ -12,6 +12,7 @@ import (
 	morningletterv2 "alt/gen/proto/alt/morning_letter/v2"
 	"alt/gen/proto/alt/morning_letter/v2/morningletterv2connect"
 	"alt/orchestrator/port/morning_letter_port"
+	"alt/utils/safeconv"
 )
 
 // Handler implements both MorningLetterServiceHandler (StreamChat) and
@@ -249,7 +250,7 @@ func (h *Handler) GetLetterSources(
 			SectionKey: s.SectionKey,
 			ArticleId:  s.ArticleID.String(),
 			SourceType: mapSourceType(s.SourceType),
-			Position:   int32(s.Position),
+			Position:   safeconv.Int32(s.Position),
 		}
 	}
 
@@ -304,7 +305,7 @@ func domainToProto(doc *domain.MorningLetterDocument) *morningletterv2.MorningLe
 
 	var windowDays *int32
 	if doc.Body.SourceRecapWindowDays != nil {
-		d := int32(*doc.Body.SourceRecapWindowDays)
+		d := safeconv.Int32(*doc.Body.SourceRecapWindowDays)
 		windowDays = &d
 	}
 
@@ -328,8 +329,8 @@ func domainToProto(doc *domain.MorningLetterDocument) *morningletterv2.MorningLe
 		TargetDate:         doc.TargetDate,
 		EditionTimezone:    doc.EditionTimezone,
 		IsDegraded:         doc.IsDegraded,
-		SchemaVersion:      int32(doc.SchemaVersion),
-		GenerationRevision: int32(doc.GenerationRevision),
+		SchemaVersion:      safeconv.Int32(doc.SchemaVersion),
+		GenerationRevision: safeconv.Int32(doc.GenerationRevision),
 		Model:              doc.Model,
 		CreatedAt:          timestamppb.New(doc.CreatedAt),
 		Etag:               doc.Etag,

--- a/alt-backend/app/orchestrator/connect/v2/recap/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/recap/handler.go
@@ -17,6 +17,7 @@ import (
 	"alt/domain"
 	recapinternal "alt/internal/recap"
 	recap_usecase "alt/orchestrator/usecase/recap_usecase"
+	"alt/utils/safeconv"
 )
 
 // Handler implements the RecapService Connect-RPC service.
@@ -158,8 +159,8 @@ func domainToProtoThreeDays(recap *domain.RecapSummary) *recapv2.GetThreeDayReca
 			Genre:         g.Genre,
 			Summary:       g.Summary,
 			TopTerms:      g.TopTerms,
-			ArticleCount:  int32(g.ArticleCount),
-			ClusterCount:  int32(g.ClusterCount),
+			ArticleCount:  safeconv.Int32(g.ArticleCount),
+			ClusterCount:  safeconv.Int32(g.ClusterCount),
 			EvidenceLinks: evidenceLinksToProto(g.EvidenceLinks),
 			Bullets:       g.Bullets,
 			References:    referencesToProto(g.References),
@@ -171,7 +172,7 @@ func domainToProtoThreeDays(recap *domain.RecapSummary) *recapv2.GetThreeDayReca
 		ExecutedAt:    recap.ExecutedAt.Format(time.RFC3339),
 		WindowStart:   recap.WindowStart.Format(time.RFC3339),
 		WindowEnd:     recap.WindowEnd.Format(time.RFC3339),
-		TotalArticles: int32(recap.TotalArticles),
+		TotalArticles: safeconv.Int32(recap.TotalArticles),
 		Genres:        genres,
 	}
 }
@@ -184,8 +185,8 @@ func domainToProto(recap *domain.RecapSummary) *recapv2.GetSevenDayRecapResponse
 			Genre:         g.Genre,
 			Summary:       g.Summary,
 			TopTerms:      g.TopTerms,
-			ArticleCount:  int32(g.ArticleCount),
-			ClusterCount:  int32(g.ClusterCount),
+			ArticleCount:  safeconv.Int32(g.ArticleCount),
+			ClusterCount:  safeconv.Int32(g.ClusterCount),
 			EvidenceLinks: evidenceLinksToProto(g.EvidenceLinks),
 			Bullets:       g.Bullets,
 			References:    referencesToProto(g.References),
@@ -197,7 +198,7 @@ func domainToProto(recap *domain.RecapSummary) *recapv2.GetSevenDayRecapResponse
 		ExecutedAt:    recap.ExecutedAt.Format(time.RFC3339),
 		WindowStart:   recap.WindowStart.Format(time.RFC3339),
 		WindowEnd:     recap.WindowEnd.Format(time.RFC3339),
-		TotalArticles: int32(recap.TotalArticles),
+		TotalArticles: safeconv.Int32(recap.TotalArticles),
 		Genres:        genres,
 	}
 }
@@ -222,7 +223,7 @@ func referencesToProto(refs []domain.Reference) []*recapv2.Reference {
 	result := make([]*recapv2.Reference, len(refs))
 	for i, r := range refs {
 		result[i] = &recapv2.Reference{
-			Id:     int32(r.ID),
+			Id:     safeconv.Int32(r.ID),
 			Url:    r.URL,
 			Domain: r.Domain,
 		}
@@ -239,8 +240,8 @@ func clusterDraftToProto(draft *domain.ClusterDraft) *recapv2.ClusterDraft {
 	for i, g := range draft.Genres {
 		genres[i] = &recapv2.ClusterGenre{
 			Genre:        g.Genre,
-			SampleSize:   int32(g.SampleSize),
-			ClusterCount: int32(g.ClusterCount),
+			SampleSize:   safeconv.Int32(g.SampleSize),
+			ClusterCount: safeconv.Int32(g.ClusterCount),
 			Clusters:     clusterSegmentsToProto(g.Clusters),
 		}
 	}
@@ -250,7 +251,7 @@ func clusterDraftToProto(draft *domain.ClusterDraft) *recapv2.ClusterDraft {
 		Description:  draft.Description,
 		Source:       draft.Source,
 		GeneratedAt:  draft.GeneratedAt.Format(time.RFC3339),
-		TotalEntries: int32(draft.TotalEntries),
+		TotalEntries: safeconv.Int32(draft.TotalEntries),
 		Genres:       genres,
 	}
 }
@@ -262,7 +263,7 @@ func clusterSegmentsToProto(segments []domain.ClusterSegment) []*recapv2.Cluster
 		result[i] = &recapv2.ClusterSegment{
 			ClusterId:                s.ClusterID,
 			Label:                    s.Label,
-			Count:                    int32(s.Count),
+			Count:                    safeconv.Int32(s.Count),
 			MarginMean:               s.MarginMean,
 			MarginStd:                s.MarginStd,
 			TopBoostMean:             s.TopBoostMean,
@@ -285,8 +286,8 @@ func clusterArticlesToProto(articles []domain.ClusterArticle) []*recapv2.Cluster
 			Margin:         a.Margin,
 			TopBoost:       a.TopBoost,
 			Strategy:       a.Strategy,
-			TagCount:       int32(a.TagCount),
-			CandidateCount: int32(a.CandidateCount),
+			TagCount:       safeconv.Int32(a.TagCount),
+			CandidateCount: safeconv.Int32(a.CandidateCount),
 			TopTags:        a.TopTags,
 		}
 	}
@@ -334,8 +335,8 @@ func eveningPulseDomainToProto(pulse *domain.EveningPulse) *recapv2.GetEveningPu
 			Role:                   topicRoleToProto(t.Role),
 			Title:                  t.Title,
 			Rationale:              rationaleToProto(t.Rationale),
-			ArticleCount:           int32(t.ArticleCount),
-			SourceCount:            int32(t.SourceCount),
+			ArticleCount:           safeconv.Int32(t.ArticleCount),
+			SourceCount:            safeconv.Int32(t.SourceCount),
 			TimeAgo:                t.TimeAgo,
 			ArticleIds:             t.ArticleIDs,
 			RepresentativeArticles: representativeArticlesToProto(t.RepresentativeArticles),
@@ -343,7 +344,7 @@ func eveningPulseDomainToProto(pulse *domain.EveningPulse) *recapv2.GetEveningPu
 			SourceNames:            t.SourceNames,
 		}
 		if t.Tier1Count != nil {
-			tier1 := int32(*t.Tier1Count)
+			tier1 := safeconv.Int32(*t.Tier1Count)
 			topics[i].Tier1Count = &tier1
 		}
 		if t.TrendMultiplier != nil {
@@ -480,7 +481,7 @@ func (h *Handler) SearchRecapsByTag(
 		protoResults[i] = &recapv2.RecapSearchResultItem{
 			JobId:      r.JobID,
 			ExecutedAt: r.ExecutedAt,
-			WindowDays: int32(r.WindowDays),
+			WindowDays: safeconv.Int32(r.WindowDays),
 			Genre:      r.Genre,
 			Summary:    r.Summary,
 			TopTerms:   r.TopTerms,

--- a/alt-backend/app/orchestrator/connect/v2/rss/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/rss/handler.go
@@ -21,6 +21,7 @@ import (
 	"alt/connect/v2/middleware"
 	"alt/di"
 	"alt/domain"
+	"alt/utils/safeconv"
 	"alt/utils/url_validator"
 )
 
@@ -108,7 +109,7 @@ func (h *Handler) ListRSSFeedLinks(
 			HealthStatus: string(link.GetHealthStatus()),
 		}
 		if link.Availability != nil {
-			protoLink.ConsecutiveFailures = int32(link.Availability.ConsecutiveFailures)
+			protoLink.ConsecutiveFailures = safeconv.Int32(link.Availability.ConsecutiveFailures)
 			protoLink.IsActive = link.Availability.IsActive
 			if link.Availability.LastFailureReason != nil {
 				protoLink.LastFailureReason = *link.Availability.LastFailureReason

--- a/alt-backend/app/orchestrator/driver/search_indexer_connect/client.go
+++ b/alt-backend/app/orchestrator/driver/search_indexer_connect/client.go
@@ -11,6 +11,7 @@ import (
 	searchv2 "alt/gen/proto/services/search/v2"
 	"alt/gen/proto/services/search/v2/searchv2connect"
 	"alt/orchestrator/port/search_indexer_port"
+	"alt/utils/safeconv"
 )
 
 // ConnectSearchIndexerDriver implements SearchIndexerPort using Connect-RPC.
@@ -64,8 +65,8 @@ func (d *ConnectSearchIndexerDriver) SearchArticlesWithPagination(ctx context.Co
 	resp, err := d.client.SearchArticles(ctx, connect.NewRequest(&searchv2.SearchArticlesRequest{
 		Query:  query,
 		UserId: userID,
-		Offset: int32(offset),
-		Limit:  int32(limit),
+		Offset: safeconv.Int32(offset),
+		Limit:  safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, 0, err
@@ -89,7 +90,7 @@ func (d *ConnectSearchIndexerDriver) SearchArticlesWithPagination(ctx context.Co
 func (d *ConnectSearchIndexerDriver) SearchRecapsByTag(ctx context.Context, tagName string, limit int) ([]*domain.RecapSearchResult, error) {
 	resp, err := d.client.SearchRecaps(ctx, connect.NewRequest(&searchv2.SearchRecapsRequest{
 		TagName: tagName,
-		Limit:   int32(limit),
+		Limit:   safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, err
@@ -117,7 +118,7 @@ func (d *ConnectSearchIndexerDriver) SearchRecapsByQuery(ctx context.Context, qu
 	q := &query
 	resp, err := d.client.SearchRecaps(ctx, connect.NewRequest(&searchv2.SearchRecapsRequest{
 		Query: q,
-		Limit: int32(limit),
+		Limit: safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, 0, err

--- a/alt-backend/app/orchestrator/gateway/article_content_cache_gateway/gateway.go
+++ b/alt-backend/app/orchestrator/gateway/article_content_cache_gateway/gateway.go
@@ -45,8 +45,10 @@ func (g *Gateway) GetArticles(ctx context.Context, articleIDs []uuid.UUID) ([]*d
 		if article, state := g.cache.Peek(id); state == cache.CacheStateFresh || state == cache.CacheStateStale {
 			results[id] = article
 			if state == cache.CacheStateStale {
+				// Detach cancellation so refresh outlives the request, but keep
+				// request-derived values (trace/baggage) via WithoutCancel.
+				refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 				go func(id uuid.UUID) {
-					refreshCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 					defer cancel()
 					if _, err := g.cache.Refresh(refreshCtx, id); err != nil {
 						slog.Default().Error("article content cache background refresh failed",

--- a/alt-backend/app/orchestrator/gateway/fetch_article_gateway/fetch_article_gateway.go
+++ b/alt-backend/app/orchestrator/gateway/fetch_article_gateway/fetch_article_gateway.go
@@ -86,33 +86,23 @@ func (g *FetchArticleGateway) FetchArticleContents(ctx context.Context, articleU
 	if err != nil {
 		return nil, fmt.Errorf("parse url failed for %q: %w", articleURL, err)
 	}
-	// SSRF Protection: Comprehensive multi-layer validation performed here
-	// - Validates URL scheme (HTTP/HTTPS only)
-	// - Blocks cloud metadata endpoints (AWS/GCP/Azure/etc)
-	// - Blocks private IP ranges (RFC1918: 10.x, 172.16-31.x, 192.168.x)
-	// - Blocks loopback and link-local addresses
-	// - Validates DNS resolution to prevent DNS rebinding attacks
-	// - Blocks internal domain suffixes (.local, .internal, .cluster.local, etc)
-	// - Validates ports (only 80, 443, 8080, 8443 allowed)
-	// - Prevents path traversal and Unicode/Punycode bypass attacks
-	if err := g.ssrfValidator.ValidateURL(ctx, parsedURL); err != nil {
+	// SSRF: validate + reconstruct request URL (scheme/host/path/query only).
+	safeURL, err := g.ssrfValidator.CanonicalRequestURL(ctx, parsedURL)
+	if err != nil {
 		return nil, fmt.Errorf("ssrf validation failed for %q: %w", parsedURL.String(), err)
 	}
 
 	// Build request with context and safe client
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, safeURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create request failed for %q: %w", parsedURL.String(), err)
+		return nil, fmt.Errorf("create request failed for %q: %w", safeURL, err)
 	}
 	req.Header.Set("User-Agent", "Alt-Article-Fetcher/1.0")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	// Do NOT set Accept-Encoding manually to allow Go transport to auto-decompress
 
-	// SSRF Protection: The httpClient used here is a secure client created by SSRFValidator
-	// that performs connection-time IP validation (second layer defense against DNS rebinding)
-	// and blocks all HTTP redirects to prevent redirect-based SSRF attacks.
-	// See: SSRFValidator.CreateSecureHTTPClient() for implementation details.
-	// codeql[go/request-forgery] - False positive: URL is validated by SSRFValidator before this call
+	// SSRF: CanonicalRequestURL + CreateSecureHTTPClient (connection-time IP + redirect checks).
+	// codeql[go/request-forgery] - URL reconstructed by SSRFValidator.CanonicalRequestURL
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http request failed for %q: %w", parsedURL.String(), err)

--- a/alt-backend/app/orchestrator/gateway/image_fetch_gateway/image_fetch_gateway.go
+++ b/alt-backend/app/orchestrator/gateway/image_fetch_gateway/image_fetch_gateway.go
@@ -244,7 +244,8 @@ func (g *ImageFetchGateway) fetchImageWithTestingOverride(ctx context.Context, i
 			},
 		)
 	}
-	// Validate proxy configuration if using proxy
+	// Validate proxy configuration if using proxy; otherwise re-validate the final request URL.
+	var safeReqURL string
 	if g.proxyStrategy != nil && g.proxyStrategy.Enabled {
 		proxyBase, err := url.Parse(g.proxyStrategy.BaseURL)
 		if err != nil {
@@ -270,16 +271,31 @@ func (g *ImageFetchGateway) fetchImageWithTestingOverride(ctx context.Context, i
 				},
 			)
 		}
+		// Proxy host is allowlisted; still drop userinfo/fragment via reconstruction.
+		safeReqURL = (&url.URL{
+			Scheme:   strings.ToLower(parsedReqURL.Scheme),
+			Host:     parsedReqURL.Host,
+			Path:     parsedReqURL.EscapedPath(),
+			RawQuery: parsedReqURL.RawQuery,
+		}).String()
+	} else {
+		canonical, err := g.ssrfValidator.CanonicalRequestURL(ctx, parsedReqURL)
+		if err != nil {
+			return nil, errors.NewValidationContextError(
+				fmt.Sprintf("request URL validation failed: %v", err),
+				"gateway",
+				"ImageFetchGateway",
+				"validate_request_url",
+				map[string]interface{}{
+					"url": parsedReqURL.String(),
+				},
+			)
+		}
+		safeReqURL = canonical
 	}
-	// SSRF Protection: Second layer - Connection-time validation
-	// The httpClient (created by SSRFValidator.CreateSecureHTTPClient) performs real-time
-	// IP validation at the syscall.Control hook level during actual connection establishment.
-	// This prevents DNS rebinding attacks where DNS resolves to a safe IP during validation
-	// but changes to a dangerous IP before connection. All redirects are also blocked.
-	// See: SSRFValidator.validateConnectionAddress() for implementation details.
 
 	// Create HTTP request with proper headers
-	req, err := http.NewRequestWithContext(ctx, "GET", parsedReqURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", safeReqURL, nil)
 	if err != nil {
 		return nil, errors.NewExternalAPIContextError(
 			"failed to create HTTP request",
@@ -306,12 +322,8 @@ func (g *ImageFetchGateway) fetchImageWithTestingOverride(ctx context.Context, i
 	req.Header.Set("Accept", "image/webp, image/jpeg, image/png, image/gif")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	// SSRF Protection Summary: Multi-layer defense implemented
-	// Layer 1: URL validation at lines 393-413 (SSRFValidator.ValidateURL)
-	// Layer 2: Proxy allowlist validation at lines 441-467 (if proxy enabled)
-	// Layer 3: Connection-time IP validation (via secure httpClient created at line 207)
-	// Layer 4: Redirect blocking (httpClient.CheckRedirect blocks all redirects)
-	// codeql[go/request-forgery] - False positive: URL validated by comprehensive SSRF protection
+	// SSRF: CanonicalRequestURL / proxy allowlist + CreateSecureHTTPClient dial checks.
+	// codeql[go/request-forgery] - URL reconstructed by SSRFValidator.CanonicalRequestURL or proxy allowlist
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		// Check if it's a timeout error

--- a/alt-backend/app/orchestrator/gateway/robots_txt_gateway/robots_txt_gateway.go
+++ b/alt-backend/app/orchestrator/gateway/robots_txt_gateway/robots_txt_gateway.go
@@ -61,12 +61,13 @@ func (g *RobotsTxtGateway) FetchRobotsTxt(ctx context.Context, domainName, schem
 		return nil, fmt.Errorf("invalid robots.txt URL: %w", err)
 	}
 
-	// SSRF protection
-	if err := g.ssrfValidator.ValidateURL(ctx, parsedURL); err != nil {
+	// SSRF protection: validate + reconstruct so the request URL is policy-gated.
+	safeURL, err := g.ssrfValidator.CanonicalRequestURL(ctx, parsedURL)
+	if err != nil {
 		return nil, fmt.Errorf("ssrf validation failed: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, safeURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -74,9 +75,8 @@ func (g *RobotsTxtGateway) FetchRobotsTxt(ctx context.Context, domainName, schem
 	req.Header.Set("User-Agent", "Alt-RSS-Reader/1.0 (+https://alt.example.com)")
 	req.Header.Set("Accept", "text/plain")
 
-	// SSRF protection: URL validated by SSRFValidator.ValidateURL() above (line 65).
-	// httpClient created via SSRFValidator.CreateSecureHTTPClient() validates IPs at connection time.
-	// codeql[go/request-forgery]
+	// SSRF: CanonicalRequestURL + CreateSecureHTTPClient (connection-time IP checks).
+	// codeql[go/request-forgery] - URL reconstructed by SSRFValidator.CanonicalRequestURL
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch robots.txt: %w", err)

--- a/alt-backend/app/shared/driver/alt_db/upsert_article_tags_driver.go
+++ b/alt-backend/app/shared/driver/alt_db/upsert_article_tags_driver.go
@@ -1,6 +1,7 @@
 package alt_db
 
 import (
+	"alt/utils/safeconv"
 	"context"
 	"fmt"
 
@@ -57,7 +58,7 @@ func (r *TagRepository) UpsertArticleTags(ctx context.Context, articleID string,
 		return 0, fmt.Errorf("commit tx: %w", err)
 	}
 
-	return int32(len(tags)), nil
+	return safeconv.Int32(len(tags)), nil
 }
 
 // BatchUpsertArticleTags upserts tags for multiple articles in a single transaction.
@@ -106,7 +107,7 @@ func (r *TagRepository) BatchUpsertArticleTags(ctx context.Context, items []Batc
 		return 0, fmt.Errorf("commit tx: %w", err)
 	}
 
-	return int32(totalTags), nil
+	return safeconv.Int32(totalTags), nil
 }
 
 // TagUpsertItem represents a tag to upsert.

--- a/alt-backend/app/shared/driver/sovereign_client/backfill_client.go
+++ b/alt-backend/app/shared/driver/sovereign_client/backfill_client.go
@@ -3,6 +3,7 @@ package sovereign_client
 import (
 	"alt/domain"
 	sovereignv1 "alt/gen/proto/services/sovereign/v1"
+	"alt/utils/safeconv"
 	"context"
 	"fmt"
 	"time"
@@ -85,9 +86,9 @@ func domainBackfillJobToProto(j domain.KnowledgeBackfillJob) *sovereignv1.Backfi
 		JobId:             j.JobID.String(),
 		Status:            j.Status,
 		Kind:              j.Kind,
-		ProjectionVersion: int32(j.ProjectionVersion),
-		TotalEvents:       int32(j.TotalEvents),
-		ProcessedEvents:   int32(j.ProcessedEvents),
+		ProjectionVersion: safeconv.Int32(j.ProjectionVersion),
+		TotalEvents:       safeconv.Int32(j.TotalEvents),
+		ProcessedEvents:   safeconv.Int32(j.ProcessedEvents),
 		ErrorMessage:      j.ErrorMessage,
 		CreatedAt:         timeToProto(j.CreatedAt),
 		UpdatedAt:         timeToProto(j.UpdatedAt),

--- a/alt-backend/app/shared/driver/sovereign_client/read_client.go
+++ b/alt-backend/app/shared/driver/sovereign_client/read_client.go
@@ -3,6 +3,7 @@ package sovereign_client
 import (
 	"alt/domain"
 	sovereignv1 "alt/gen/proto/services/sovereign/v1"
+	"alt/utils/safeconv"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,7 +24,7 @@ func (c *Client) GetKnowledgeHomeItems(ctx context.Context, userID uuid.UUID, cu
 	req := &sovereignv1.GetKnowledgeHomeItemsRequest{
 		UserId: userID.String(),
 		Cursor: cursor,
-		Limit:  int32(limit),
+		Limit:  safeconv.Int32(limit),
 	}
 	if filter != nil {
 		sourceIDs := make([]string, len(filter.SourceIDs))
@@ -59,7 +60,7 @@ func (c *Client) GetTrailFootprints(ctx context.Context, userID uuid.UUID, curso
 	resp, err := c.client.GetTrailFootprints(ctx, connect.NewRequest(&sovereignv1.GetTrailFootprintsRequest{
 		UserId:     userID.String(),
 		Cursor:     cursor,
-		Limit:      int32(limit),
+		Limit:      safeconv.Int32(limit),
 		FilterTags: filterTags,
 	}))
 	if err != nil {
@@ -150,7 +151,7 @@ func (c *Client) GetRecallCandidates(ctx context.Context, userID uuid.UUID, limi
 		return nil, nil
 	}
 	resp, err := c.client.GetRecallCandidates(ctx, connect.NewRequest(&sovereignv1.GetRecallCandidatesRequest{
-		UserId: userID.String(), Limit: int32(limit),
+		UserId: userID.String(), Limit: safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("sovereign GetRecallCandidates: %w", err)
@@ -240,7 +241,7 @@ func (c *Client) ListKnowledgeEventsSince(ctx context.Context, afterSeq int64, l
 		return nil, nil
 	}
 	resp, err := c.client.ListKnowledgeEvents(ctx, connect.NewRequest(&sovereignv1.ListKnowledgeEventsRequest{
-		AfterSeq: afterSeq, Limit: int32(limit),
+		AfterSeq: afterSeq, Limit: safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("sovereign ListKnowledgeEventsSince: %w", err)
@@ -254,7 +255,7 @@ func (c *Client) ListKnowledgeEventsSinceForUser(ctx context.Context, tenantID, 
 	}
 	resp, err := c.client.ListKnowledgeEvents(ctx, connect.NewRequest(&sovereignv1.ListKnowledgeEventsRequest{
 		AfterSeq: afterSeq,
-		Limit:    int32(limit),
+		Limit:    safeconv.Int32(limit),
 		UserId:   userID.String(),
 		TenantId: tenantID.String(),
 	}))
@@ -395,7 +396,7 @@ func (c *Client) ActivateProjectionVersion(ctx context.Context, version int) err
 		return nil
 	}
 	_, err := c.client.ActivateProjectionVersion(ctx, connect.NewRequest(&sovereignv1.ActivateProjectionVersionRequest{
-		Version: int32(version),
+		Version: safeconv.Int32(version),
 	}))
 	if err != nil {
 		return fmt.Errorf("sovereign ActivateProjectionVersion: %w", err)
@@ -616,7 +617,7 @@ func protoToProjectionVersion(pb *sovereignv1.ProjectionVersion) *domain.Knowled
 
 func domainToProtoVersion(v domain.KnowledgeProjectionVersion) *sovereignv1.ProjectionVersion {
 	pb := &sovereignv1.ProjectionVersion{
-		Version:     int32(v.Version),
+		Version:     safeconv.Int32(v.Version),
 		Description: v.Description,
 		Status:      v.Status,
 		CreatedAt:   timeToProto(v.CreatedAt),

--- a/alt-backend/app/shared/driver/sovereign_client/reproject_client.go
+++ b/alt-backend/app/shared/driver/sovereign_client/reproject_client.go
@@ -3,6 +3,7 @@ package sovereign_client
 import (
 	"alt/domain"
 	sovereignv1 "alt/gen/proto/services/sovereign/v1"
+	"alt/utils/safeconv"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -68,7 +69,7 @@ func (c *Client) ListReprojectRuns(ctx context.Context, statusFilter string, lim
 
 	resp, err := c.client.ListReprojectRuns(ctx, connect.NewRequest(&sovereignv1.ListReprojectRunsRequest{
 		StatusFilter: statusFilter,
-		Limit:        int32(limit),
+		Limit:        safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("sovereign ListReprojectRuns: %w", err)
@@ -119,8 +120,8 @@ func (c *Client) CreateProjectionAudit(ctx context.Context, audit *domain.Projec
 			ProjectionName:    audit.ProjectionName,
 			ProjectionVersion: audit.ProjectionVersion,
 			CheckedAt:         timeToProto(audit.CheckedAt),
-			SampleSize:        int32(audit.SampleSize),
-			MismatchCount:     int32(audit.MismatchCount),
+			SampleSize:        safeconv.Int32(audit.SampleSize),
+			MismatchCount:     safeconv.Int32(audit.MismatchCount),
 			DetailsJson:       audit.DetailsJSON,
 		},
 	}))
@@ -137,7 +138,7 @@ func (c *Client) ListProjectionAudits(ctx context.Context, projectionName string
 
 	resp, err := c.client.ListProjectionAudits(ctx, connect.NewRequest(&sovereignv1.ListProjectionAuditsRequest{
 		ProjectionName: projectionName,
-		Limit:          int32(limit),
+		Limit:          safeconv.Int32(limit),
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("sovereign ListProjectionAudits: %w", err)

--- a/alt-backend/app/shared/driver/sovereign_client/signal_client.go
+++ b/alt-backend/app/shared/driver/sovereign_client/signal_client.go
@@ -3,6 +3,7 @@ package sovereign_client
 import (
 	"alt/domain"
 	sovereignv1 "alt/gen/proto/services/sovereign/v1"
+	"alt/utils/safeconv"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -47,7 +48,7 @@ func (c *Client) ListRecallSignalsByUser(ctx context.Context, userID uuid.UUID, 
 
 	resp, err := c.client.ListRecallSignals(ctx, connect.NewRequest(&sovereignv1.ListRecallSignalsRequest{
 		UserId:    userID.String(),
-		SinceDays: int32(sinceDays),
+		SinceDays: safeconv.Int32(sinceDays),
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("sovereign ListRecallSignalsByUser: %w", err)

--- a/alt-backend/app/utils/safeconv/safeconv.go
+++ b/alt-backend/app/utils/safeconv/safeconv.go
@@ -1,0 +1,48 @@
+// Package safeconv provides overflow-safe integer conversions for protobuf and API boundaries.
+package safeconv
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// Int32 converts v to int32, clamping to the int32 range.
+// Use for response counts/lengths where saturation is preferable to failure.
+func Int32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
+
+// Int32FromInt64 converts v to int32, clamping to the int32 range.
+func Int32FromInt64(v int64) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
+
+// Int32Exact converts v to int32 or returns an error on overflow.
+func Int32Exact(v int) (int32, error) {
+	if v > math.MaxInt32 || v < math.MinInt32 {
+		return 0, fmt.Errorf("value %d overflows int32", v)
+	}
+	return int32(v), nil
+}
+
+// ParseInt32 parses s as a base-10 int32 (rejects values outside int32).
+func ParseInt32(s string) (int32, error) {
+	v, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int32(v), nil
+}

--- a/alt-backend/app/utils/safeconv/safeconv_test.go
+++ b/alt-backend/app/utils/safeconv/safeconv_test.go
@@ -1,0 +1,49 @@
+package safeconv
+
+import (
+	"math"
+	"testing"
+)
+
+func TestInt32(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   int
+		want int32
+	}{
+		{0, 0},
+		{42, 42},
+		{-1, -1},
+		{math.MaxInt32, math.MaxInt32},
+		{math.MinInt32, math.MinInt32},
+		{math.MaxInt32 + 1, math.MaxInt32},
+		{math.MinInt32 - 1, math.MinInt32},
+	}
+	for _, tc := range cases {
+		if got := Int32(tc.in); got != tc.want {
+			t.Fatalf("Int32(%d)=%d want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestInt32Exact(t *testing.T) {
+	t.Parallel()
+	if _, err := Int32Exact(math.MaxInt32 + 1); err == nil {
+		t.Fatal("expected overflow error")
+	}
+	got, err := Int32Exact(7)
+	if err != nil || got != 7 {
+		t.Fatalf("Int32Exact(7)=%d,%v", got, err)
+	}
+}
+
+func TestParseInt32(t *testing.T) {
+	t.Parallel()
+	got, err := ParseInt32("123")
+	if err != nil || got != 123 {
+		t.Fatalf("ParseInt32(123)=%d,%v", got, err)
+	}
+	if _, err := ParseInt32("2147483648"); err == nil {
+		t.Fatal("expected overflow for MaxInt32+1")
+	}
+}

--- a/alt-backend/app/utils/security/ssrf_validator.go
+++ b/alt-backend/app/utils/security/ssrf_validator.go
@@ -75,6 +75,28 @@ func (v *SSRFValidator) SetTestingMode(enabled bool) {
 	v.allowTestingLocalhost = enabled
 }
 
+// CanonicalRequestURL validates u under the SSRF policy and returns a reconstructed
+// URL string built only from allowed components (scheme, host, path, query).
+// Callers must use the returned string (not the original raw input) for http.NewRequest.
+func (v *SSRFValidator) CanonicalRequestURL(ctx context.Context, u *url.URL) (string, error) {
+	if u == nil {
+		return "", &ValidationError{Message: "URL is nil", Type: "NIL_URL"}
+	}
+	if err := v.ValidateURL(ctx, u); err != nil {
+		return "", err
+	}
+	safe := &url.URL{
+		Scheme:   strings.ToLower(u.Scheme),
+		Host:     u.Host,
+		Path:     u.EscapedPath(),
+		RawQuery: u.RawQuery,
+	}
+	if safe.Path == "" {
+		safe.Path = "/"
+	}
+	return safe.String(), nil
+}
+
 // ValidateURL performs comprehensive URL validation including DNS rebinding protection
 func (v *SSRFValidator) ValidateURL(ctx context.Context, u *url.URL) error {
 	if err := v.basicValidation(u); err != nil {

--- a/alt-backend/app/utils/security/ssrf_validator_test.go
+++ b/alt-backend/app/utils/security/ssrf_validator_test.go
@@ -820,6 +820,24 @@ func TestIsPrivateHost(t *testing.T) {
 	}
 }
 
+func TestSSRFValidator_CanonicalRequestURL(t *testing.T) {
+	validator := NewSSRFValidator()
+	validator.SetTestingMode(true)
+
+	u, err := url.Parse("https://example.com/a/b?x=1#frag")
+	require.NoError(t, err)
+
+	got, err := validator.CanonicalRequestURL(context.Background(), u)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/a/b?x=1", got)
+	assert.NotContains(t, got, "#frag")
+
+	bad, err := url.Parse("http://10.0.0.1/secret")
+	require.NoError(t, err)
+	_, err = validator.CanonicalRequestURL(context.Background(), bad)
+	require.Error(t, err)
+}
+
 // BenchmarkIsPrivateIPAddress benchmarks the exported function
 func BenchmarkIsPrivateIPAddress(b *testing.B) {
 	ip := net.ParseIP("192.168.1.1")


### PR DESCRIPTION
## Summary
- Clear Code Scanning alerts: SSRF, G115, G118
- Source: https://github.com/Kaikei-e/Alt/security/code-scanning

## Test plan
- [ ] `cd alt-backend/app && go test ./...`