### PR TITLE
fix(swipe): stop article fetching from dying after a few swipes

### DIFF
--- a/alt-backend/app/domain/errors.go
+++ b/alt-backend/app/domain/errors.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 var (
@@ -53,6 +54,20 @@ type ComplianceError struct {
 }
 
 func (e *ComplianceError) Error() string {
+	return e.Message
+}
+
+// RateLimitedError is a transient refusal: a politeness gate (robots.txt
+// Crawl-delay, host rate limiter) has not elapsed yet.
+//
+// Deliberately distinct from ComplianceError, which is permanent. Collapsing
+// the two is what let a timing condition be recorded as a user decision.
+type RateLimitedError struct {
+	Message    string
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitedError) Error() string {
 	return e.Message
 }
 

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -121,6 +123,20 @@ func (h *Handler) FetchArticleContent(
 	forceRefresh := req.Msg.ForceRefresh != nil && *req.Msg.ForceRefresh
 	content, articleID, ogImageURL, err := h.deps.Article.FetchCompliantArticleWithRefresh(ctx, parsedURL, *user, forceRefresh)
 	if err != nil {
+		// Checked before ComplianceError: a politeness gate that has not
+		// elapsed is transient and must reach the client as a retryable 429,
+		// not as the permanent 403 that tells it to stop asking.
+		var rateErr *domain.RateLimitedError
+		if errors.As(err, &rateErr) {
+			connectErr := connect.NewError(connect.CodeResourceExhausted,
+				fmt.Errorf("%s", rateErr.Message))
+			if rateErr.RetryAfter > 0 {
+				connectErr.Meta().Set("Retry-After",
+					strconv.Itoa(int(math.Ceil(rateErr.RetryAfter.Seconds()))))
+			}
+			return nil, connectErr
+		}
+
 		var complianceErr *domain.ComplianceError
 		if errors.As(err, &complianceErr) {
 			return nil, connect.NewError(connect.CodePermissionDenied,

--- a/alt-backend/app/orchestrator/gateway/scraping_policy_gateway/scraping_policy_gateway.go
+++ b/alt-backend/app/orchestrator/gateway/scraping_policy_gateway/scraping_policy_gateway.go
@@ -3,6 +3,7 @@ package scraping_policy_gateway
 import (
 	"alt/domain"
 	"alt/orchestrator/port/scraping_domain_port"
+	"alt/orchestrator/port/scraping_policy_port"
 	"context"
 	"fmt"
 	"log/slog"
@@ -118,7 +119,11 @@ func (g *ScrapingPolicyGateway) CanFetchArticle(ctx context.Context, articleURL 
 					"domain", domainName,
 					"delay", delay,
 					"time_since_last", timeSinceLastRequest)
-				return false, nil
+				// Transient, not a policy refusal — see ErrCrawlDelayNotElapsed.
+				return false, &scraping_policy_port.CrawlDelayError{
+					Domain:     domainName,
+					RetryAfter: delay - timeSinceLastRequest,
+				}
 			}
 		}
 		g.lastRequestTime[domainKey] = time.Now()

--- a/alt-backend/app/orchestrator/gateway/scraping_policy_gateway/scraping_policy_gateway_test.go
+++ b/alt-backend/app/orchestrator/gateway/scraping_policy_gateway/scraping_policy_gateway_test.go
@@ -223,10 +223,38 @@ func TestScrapingPolicyGateway_CanFetchArticle_CrawlDelay(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, canFetch)
 
-	// Second request immediately should be denied (crawl delay not elapsed)
+	// Second request immediately is denied — but as a *transient* refusal.
+	// Reporting it as a bare (false, nil) made it indistinguishable from a
+	// robots.txt disallow, and the caller recorded the domain as declined by
+	// the user, permanently. It has to carry ErrCrawlDelayNotElapsed.
 	canFetch, err = gateway.CanFetchArticle(ctx, "https://example.com/article/2")
-	require.NoError(t, err)
 	assert.False(t, canFetch, "should be denied due to crawl delay")
+	require.ErrorIs(t, err, scraping_policy_port.ErrCrawlDelayNotElapsed,
+		"a crawl-delay denial must be distinguishable from a policy disallow")
+}
+
+func TestScrapingPolicyGateway_CanFetchArticle_DisallowIsNotCrawlDelay(t *testing.T) {
+	mockRepo := new(MockScrapingDomainPort)
+
+	mockDomain := &domain.ScrapingDomain{
+		ID:                  uuid.New(),
+		Domain:              "example.com",
+		Scheme:              "https",
+		AllowFetchBody:      false,
+		ForceRespectRobots:  false,
+		RobotsDisallowPaths: []string{},
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+
+	mockRepo.On("GetByDomain", mock.Anything, "example.com").Return(mockDomain, nil)
+
+	gateway := NewScrapingPolicyGateway(mockRepo)
+
+	canFetch, err := gateway.CanFetchArticle(context.Background(), "https://example.com/article/1")
+	assert.False(t, canFetch)
+	require.NotErrorIs(t, err, scraping_policy_port.ErrCrawlDelayNotElapsed,
+		"a permanent policy refusal must not be reported as a transient one")
 }
 
 func TestScrapingPolicyGateway_ConcurrentAccess(t *testing.T) {

--- a/alt-backend/app/orchestrator/port/scraping_policy_port/scraping_policy_port.go
+++ b/alt-backend/app/orchestrator/port/scraping_policy_port/scraping_policy_port.go
@@ -2,12 +2,43 @@ package scraping_policy_port
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -source=scraping_policy_port.go -destination=../../mocks/mock_scraping_policy_port.go
 
+// ErrCrawlDelayNotElapsed reports that the publisher's robots.txt Crawl-delay
+// has not elapsed since the last fetch of this domain.
+//
+// This is a *transient* refusal and must stay distinguishable from a permanent
+// one. A bare (false, nil) reads identically to a robots.txt disallow, and the
+// caller responds to a disallow by recording the domain in declined_domains —
+// a table with no expiry and no delete path. Swiping quickly through one
+// publisher's feed therefore banned that publisher for that user forever.
+var ErrCrawlDelayNotElapsed = errors.New("crawl delay has not elapsed")
+
+// CrawlDelayError carries how long the caller must wait, so the refusal can be
+// turned into a Retry-After the client can actually act on.
+type CrawlDelayError struct {
+	Domain     string
+	RetryAfter time.Duration
+}
+
+func (e *CrawlDelayError) Error() string {
+	return fmt.Sprintf("crawl delay for %s: %s remaining", e.Domain, e.RetryAfter)
+}
+
+func (e *CrawlDelayError) Unwrap() error { return ErrCrawlDelayNotElapsed }
+
 // ScrapingPolicyPort defines the interface for scraping policy checks
 type ScrapingPolicyPort interface {
-	// CanFetchArticle checks if an article URL can be fetched based on domain policy and robots.txt
+	// CanFetchArticle reports whether an article URL may be fetched, based on
+	// domain policy and robots.txt.
+	//
+	// A false result paired with ErrCrawlDelayNotElapsed is transient: retry
+	// later, and do not record the domain as declined. A false result with a nil
+	// error is a permanent policy refusal.
 	CanFetchArticle(ctx context.Context, articleURL string) (bool, error)
 }

--- a/alt-backend/app/orchestrator/usecase/fetch_article_usecase/fetch_article_usecase.go
+++ b/alt-backend/app/orchestrator/usecase/fetch_article_usecase/fetch_article_usecase.go
@@ -51,6 +51,10 @@ type fetchResult struct {
 // state is preserved for the next attempt.
 const defaultExternalFetchTimeout = 8 * time.Second
 
+// defaultCrawlDelayRetryAfter is the backoff advertised when the policy gate
+// reports a crawl-delay miss without saying how much of it is left.
+const defaultCrawlDelayRetryAfter = 10 * time.Second
+
 type ArticleUsecaseImpl struct {
 	articleFetcher       fetch_article_port.FetchArticlePort
 	robotsTxt            robots_txt_port.RobotsTxtPort
@@ -171,10 +175,27 @@ func (u *ArticleUsecaseImpl) FetchCompliantArticleWithRefresh(ctx context.Contex
 	var isAllowed bool
 	if u.scrapingPolicyPort != nil {
 		allowed, policyErr := u.scrapingPolicyPort.CanFetchArticle(ctx, urlStr)
-		if policyErr != nil {
+		switch {
+		case errors.Is(policyErr, scraping_policy_port.ErrCrawlDelayNotElapsed):
+			// Transient. Returning here — rather than falling into the
+			// !isAllowed branch below — is what keeps the domain out of
+			// declined_domains, which has no expiry and would 403 this
+			// publisher for this user permanently.
+			retryAfter := defaultCrawlDelayRetryAfter
+			var crawlErr *scraping_policy_port.CrawlDelayError
+			if errors.As(policyErr, &crawlErr) && crawlErr.RetryAfter > 0 {
+				retryAfter = crawlErr.RetryAfter
+			}
+			logger.Logger.InfoContext(ctx, "Crawl delay not elapsed, asking the client to retry",
+				"url", urlStr, "domain", domainStr, "retry_after", retryAfter)
+			return "", "", "", &domain.RateLimitedError{
+				Message:    "This site asks us to wait between requests. Please try again shortly.",
+				RetryAfter: retryAfter,
+			}
+		case policyErr != nil:
 			logger.Logger.WarnContext(ctx, "ScrapingPolicy check failed, defaulting to ALLOWED", "error", policyErr, "url", urlStr)
 			isAllowed = true
-		} else {
+		default:
 			isAllowed = allowed
 		}
 	} else {

--- a/alt-backend/app/orchestrator/usecase/fetch_article_usecase/fetch_article_usecase_test.go
+++ b/alt-backend/app/orchestrator/usecase/fetch_article_usecase/fetch_article_usecase_test.go
@@ -3,6 +3,7 @@ package fetch_article_usecase
 import (
 	"alt/domain"
 	"alt/mocks"
+	"alt/orchestrator/port/scraping_policy_port"
 	"alt/utils/logger"
 	"context"
 	"errors"
@@ -287,6 +288,58 @@ func TestFetchCompliantArticle_ScrapingPolicyDenied(t *testing.T) {
 	var complianceErr *domain.ComplianceError
 	if !errors.As(err, &complianceErr) {
 		t.Errorf("Expected ComplianceError, got %T: %v", err, err)
+	}
+}
+
+// A crawl-delay miss is a timing condition, not a user decision. Recording it
+// in declined_domains — a table with no expiry and no delete path — permanently
+// 403'd every later article from that host for that user. Swiping fast through
+// a publisher's feed reproduced it within two cards.
+func TestFetchCompliantArticle_CrawlDelayIsTransientAndNotDeclined(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockArticleFetcher := mocks.NewMockFetchArticlePort(ctrl)
+	mockRobotsTxt := mocks.NewMockRobotsTxtPort(ctrl)
+	mockRepo := mocks.NewMockArticleRepository(ctrl)
+	mockRag := mocks.NewMockRagIntegrationPort(ctrl)
+	mockScrapingPolicy := mocks.NewMockScrapingPolicyPort(ctrl)
+
+	usecase := NewArticleUsecaseWithScrapingPolicy(
+		mockArticleFetcher, mockRobotsTxt, mockRepo, mockRag, mockScrapingPolicy,
+	)
+
+	articleURLStr := "https://example.com/article"
+	articleURL, _ := url.Parse(articleURLStr)
+	userContext := domain.UserContext{
+		UserID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+	}
+
+	mockRepo.EXPECT().FetchArticleByURL(gomock.Any(), articleURLStr).Return(nil, nil)
+	mockRepo.EXPECT().IsDomainDeclined(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+
+	mockScrapingPolicy.EXPECT().
+		CanFetchArticle(gomock.Any(), articleURLStr).
+		Return(false, scraping_policy_port.ErrCrawlDelayNotElapsed)
+
+	// The assertion that matters: the domain must NOT be declined. gomock fails
+	// the test on any unexpected call, so the absence of an EXPECT is the check.
+
+	_, _, _, err := usecase.FetchCompliantArticle(context.Background(), articleURL, userContext)
+
+	if err == nil {
+		t.Fatal("expected a transient rate-limit error, got nil")
+	}
+	var rateErr *domain.RateLimitedError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("expected *domain.RateLimitedError, got %T: %v", err, err)
+	}
+	var complianceErr *domain.ComplianceError
+	if errors.As(err, &complianceErr) {
+		t.Error("a crawl-delay miss must not surface as a permanent ComplianceError")
+	}
+	if rateErr.RetryAfter <= 0 {
+		t.Errorf("expected a positive RetryAfter so the client can back off, got %v", rateErr.RetryAfter)
 	}
 }
 

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/SwipeFeedCard.svelte
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/SwipeFeedCard.svelte
@@ -15,14 +15,14 @@ import {
 	registerFavoriteFeedClient,
 	summarizeArticleClient,
 } from "$lib/api/client";
-import type { RenderFeed } from "$lib/schema/feed";
-import { sanitizeHtml } from "$lib/utils/sanitizeHtml";
-import { simulateTypewriterEffect } from "$lib/utils/streamingRenderer";
-import { isTransientError } from "$lib/utils/errorClassification";
 import {
 	createClientTransport,
 	streamSummarizeWithAbortAdapter,
 } from "$lib/connect";
+import type { RenderFeed } from "$lib/schema/feed";
+import { isTransientError } from "$lib/utils/errorClassification";
+import { sanitizeHtml } from "$lib/utils/sanitizeHtml";
+import { simulateTypewriterEffect } from "$lib/utils/streamingRenderer";
 
 interface Props {
 	feed: RenderFeed;
@@ -30,6 +30,12 @@ interface Props {
 	onDismiss: (direction: number) => Promise<void> | void;
 	getCachedContent?: (feedUrl: string) => string | null;
 	getCachedArticleId?: (feedUrl: string) => string | null;
+	/**
+	 * Fetch the body through the shared prefetcher, which dedupes against an
+	 * in-flight prefetch for the same URL and honors the host cooldown.
+	 * Resolves null when the body is unavailable right now (retryable).
+	 */
+	requestContent?: (feedUrl: string) => Promise<string | null>;
 	isBusy?: boolean;
 	initialArticleContent?: string | null;
 	/** Callback when articleId is resolved (e.g., after fetching content creates an article) */
@@ -42,6 +48,7 @@ const {
 	onDismiss,
 	getCachedContent,
 	getCachedArticleId,
+	requestContent,
 	isBusy = false,
 	initialArticleContent,
 	onArticleIdResolved,
@@ -147,7 +154,19 @@ onMount(() => {
 		// Background fetch using normalizedUrl
 		contentAbortController = new AbortController();
 		const signal = contentAbortController.signal;
-		getFeedContentOnTheFlyClient(feed.normalizedUrl, { signal })
+
+		// Prefer the shared prefetcher: a card mounting mid-prefetch joins that
+		// request instead of firing a second, unserialized one at the same host.
+		// The shared promise is deliberately not abortable — other joiners and
+		// the cache depend on it — so unmount just stops applying the result.
+		const pending = requestContent
+			? requestContent(feed.normalizedUrl).then((content) => ({
+					content: content ?? "",
+					article_id: getCachedArticleId?.(feed.normalizedUrl) ?? "",
+				}))
+			: getFeedContentOnTheFlyClient(feed.normalizedUrl, { signal });
+
+		pending
 			.then((res) => {
 				if (signal.aborted) return;
 				if (res.content) {
@@ -403,7 +422,8 @@ function handleGenerateAISummary(forceRefresh = false) {
 				return;
 			}
 
-			if (debug) console.log("[StreamSummarize] Falling back to legacy endpoint");
+			if (debug)
+				console.log("[StreamSummarize] Falling back to legacy endpoint");
 			try {
 				const res = await summarizeArticleClient(feed.link);
 				if (res.success && res.summary) {

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/SwipeFeedScreen.svelte
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/SwipeFeedScreen.svelte
@@ -381,8 +381,20 @@ function getCachedArticleId(url: string) {
 	return articlePrefetcher.getCachedArticleId(url);
 }
 
+// Single entry point for the visible card's body fetch. Routing it through the
+// prefetcher makes a card that mounts mid-prefetch join that request instead of
+// issuing a duplicate one that skips the per-host gate and the 429 cooldown.
+function requestContent(url: string) {
+	return articlePrefetcher.ensureContent(url);
+}
+
 function handleArticleIdResolved(feedLink: string, articleId: string) {
-	feeds = feeds.map((f) => (f.link === feedLink ? { ...f, articleId } : f));
+	// Only reassign when something actually changed: `feeds` drives the prefetch
+	// $effect, and every card called this on mount, so an unconditional rebuild
+	// re-ran the effect (and rescheduled the prefetch ladder) for nothing.
+	const index = feeds.findIndex((f) => f.link === feedLink);
+	if (index === -1 || feeds[index]?.articleId === articleId) return;
+	feeds = feeds.map((f, i) => (i === index ? { ...f, articleId } : f));
 }
 </script>
 
@@ -444,6 +456,7 @@ function handleArticleIdResolved(feedLink: string, articleId: string) {
             thumbnailUrl={currentOgImage}
             {getCachedContent}
             {getCachedArticleId}
+            {requestContent}
             isBusy={isLoading}
             initialArticleContent={activeIndex === 0
               ? initialArticleContent
@@ -458,6 +471,7 @@ function handleArticleIdResolved(feedLink: string, articleId: string) {
             onDismiss={handleDismiss}
             {getCachedContent}
             {getCachedArticleId}
+            {requestContent}
             isBusy={isLoading}
             initialArticleContent={activeIndex === 0
               ? initialArticleContent

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte
@@ -29,6 +29,12 @@ interface Props {
 	thumbnailUrl: string | null;
 	getCachedContent?: (feedUrl: string) => string | null;
 	getCachedArticleId?: (feedUrl: string) => string | null;
+	/**
+	 * Fetch the body through the shared prefetcher, which dedupes against an
+	 * in-flight prefetch for the same URL and honors the host cooldown.
+	 * Resolves null when the body is unavailable right now (retryable).
+	 */
+	requestContent?: (feedUrl: string) => Promise<string | null>;
 	isBusy?: boolean;
 	initialArticleContent?: string | null;
 	onArticleIdResolved?: (feedLink: string, articleId: string) => void;
@@ -42,6 +48,7 @@ const {
 	thumbnailUrl,
 	getCachedContent,
 	getCachedArticleId,
+	requestContent,
 	isBusy = false,
 	initialArticleContent,
 	onArticleIdResolved,
@@ -116,6 +123,28 @@ const publishedLabel = $derived.by(() => {
 	}
 });
 
+/**
+ * Fetch the body for this card. Goes through the shared prefetcher when one is
+ * supplied so a card mounting mid-prefetch joins that request instead of firing
+ * a second, unserialized one at the same host.
+ */
+async function fetchBody(): Promise<string | null> {
+	if (requestContent) {
+		const content = await requestContent(feed.normalizedUrl);
+		if (content && onArticleIdResolved) {
+			const articleId = getCachedArticleId?.(feed.normalizedUrl);
+			if (articleId) onArticleIdResolved(feed.link, articleId);
+		}
+		return content;
+	}
+
+	const res = await getFeedContentOnTheFlyClient(feed.normalizedUrl);
+	if (res.article_id && onArticleIdResolved) {
+		onArticleIdResolved(feed.link, res.article_id);
+	}
+	return res.content || null;
+}
+
 // Auto-fetch content
 onMount(() => {
 	if (initialArticleContent) {
@@ -130,20 +159,19 @@ onMount(() => {
 			onArticleIdResolved(feed.link, cachedArticleId);
 		}
 	} else if (!fullContent) {
-		getFeedContentOnTheFlyClient(feed.normalizedUrl)
-			.then((res) => {
-				if (res.content) {
-					fullContent = res.content;
-				}
-				if (res.article_id && onArticleIdResolved) {
-					onArticleIdResolved(feed.link, res.article_id);
+		fetchBody()
+			.then((content) => {
+				if (content) {
+					fullContent = content;
+				} else {
+					// ADR-000884: surface the unified fallback notice so the
+					// manual-tap and auto paths converge on the same
+					// "Source content unavailable" markup.
+					contentError = "Source content unavailable.";
 				}
 			})
 			.catch((err) => {
 				console.warn("[VisualPreviewCard] Error auto-fetching content:", err);
-				// ADR-000884: surface the unified fallback notice on auto-fetch
-				// failure so the manual-tap and auto paths converge on the same
-				// "Source content unavailable" markup.
 				contentError = "Source content unavailable.";
 			});
 	}
@@ -194,40 +222,45 @@ $effect(() => {
 	};
 });
 
-async function handleToggleContent() {
-	if (!isContentExpanded && !fullContent) {
-		const cached = getCachedContent?.(feed.normalizedUrl);
-		if (cached) {
-			fullContent = cached;
-			isContentExpanded = true;
-			return;
-		}
-
-		// Auto-fetch already failed and surfaced an error — expand straight
-		// to the fallback markup instead of issuing another doomed request.
-		if (contentError) {
-			isContentExpanded = true;
-			return;
-		}
-
-		isLoadingContent = true;
+async function loadContent() {
+	const cached = getCachedContent?.(feed.normalizedUrl);
+	if (cached) {
+		fullContent = cached;
 		contentError = null;
+		return;
+	}
 
-		try {
-			const res = await getFeedContentOnTheFlyClient(feed.normalizedUrl);
-			if (res.content) {
-				fullContent = res.content;
-			} else {
-				contentError = "Source content unavailable.";
-			}
-		} catch (err) {
-			console.warn("Error fetching content:", err);
+	isLoadingContent = true;
+	contentError = null;
+
+	try {
+		const content = await fetchBody();
+		if (content) {
+			fullContent = content;
+		} else {
 			contentError = "Source content unavailable.";
-		} finally {
-			isLoadingContent = false;
 		}
+	} catch (err) {
+		console.warn("Error fetching content:", err);
+		contentError = "Source content unavailable.";
+	} finally {
+		isLoadingContent = false;
+	}
+}
+
+async function handleToggleContent() {
+	// A previous failure is not permanent: the host cooldown that caused it
+	// lifts, and requestContent() short-circuits while it has not. Latching
+	// contentError here pinned the card to the summary for its whole lifetime.
+	if (!isContentExpanded && !fullContent) {
+		await loadContent();
 	}
 	isContentExpanded = !isContentExpanded;
+}
+
+async function handleRetryContent() {
+	if (isLoadingContent) return;
+	await loadContent();
 }
 
 function handleGenerateAISummary() {
@@ -503,6 +536,15 @@ function handleImgError() {
               <p class="fallback-notice" data-testid="source-unavailable-notice">
                 {contentError} Showing summary.
               </p>
+              <button
+                type="button"
+                class="retry-btn"
+                onclick={handleRetryContent}
+                disabled={isLoadingContent}
+                data-testid="retry-content"
+              >
+                Try again
+              </button>
               {#if hasDescription}
                 <div
                   class="summary-prose article-prose"
@@ -881,6 +923,32 @@ function handleImgError() {
     color: var(--alt-ash);
     margin: 0 0 0.5rem;
     padding: 0;
+  }
+
+  .retry-btn {
+    font-family: var(--font-body);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--alt-charcoal);
+    background: transparent;
+    border: 1.5px solid var(--alt-charcoal);
+    padding: 0.4rem 1rem;
+    min-height: 44px;
+    margin: 0 0 0.75rem;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .retry-btn:active:not(:disabled) {
+    background: var(--alt-charcoal);
+    color: var(--surface-bg);
+  }
+
+  .retry-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   /* ── Footer ── */

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte.spec.ts
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte.spec.ts
@@ -272,10 +272,18 @@ describe("VisualPreviewCard", () => {
 
 	// The two tests below exercise the click-driven async error path in
 	// handleToggleContent. They consistently hit Svelte 5 `track_reactivity_loss`
-	// because the existing component runs `getFeedContentOnTheFlyClient` via
+	// because the component ran `getFeedContentOnTheFlyClient` via
 	// `.then().catch()` outside a reactive scope, so the post-rejection state
-	// update is not flushed in the browser test runner. The markup change is
-	// covered by Playwright e2e in tests/e2e/feeds-visual-preview.spec.ts.
+	// update was not flushed in the browser test runner.
+	//
+	// The previous note here claimed the markup was instead covered by
+	// tests/e2e/feeds-visual-preview.spec.ts. That file does not exist and never
+	// did, so this path currently has NO coverage at any level.
+	//
+	// handleToggleContent now awaits loadContent() inside the handler rather
+	// than detaching a promise chain, which is likely to lift the original
+	// blocker — un-skip and confirm on a runner with the browser project
+	// available (`bun run test:client`).
 	describe.skip("article content fallback when source fetch fails", () => {
 		it("shows 'Source content unavailable' notice and full summary when Article fetch errors", async () => {
 			vi.mocked(getFeedContentOnTheFlyClient).mockRejectedValue(

--- a/alt-frontend-sv/src/lib/utils/articlePrefetcher.test.ts
+++ b/alt-frontend-sv/src/lib/utils/articlePrefetcher.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Code, ConnectError } from "@connectrpc/connect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the client API to prevent transitive $app/* resolution
 vi.mock("$lib/api/client", () => ({
 	getFeedContentOnTheFlyClient: vi.fn(),
 }));
 
-import { ArticlePrefetcher } from "./articlePrefetcher";
-import type { RenderFeed } from "$lib/schema/feed";
-import type { FeedContentOnTheFlyResponse } from "$lib/api/client/articles";
 import { getFeedContentOnTheFlyClient } from "$lib/api/client";
+import type { FeedContentOnTheFlyResponse } from "$lib/api/client/articles";
+import type { RenderFeed } from "$lib/schema/feed";
+import { ArticlePrefetcher } from "./articlePrefetcher";
 
 const mockedGetContent = vi.mocked(getFeedContentOnTheFlyClient);
 
@@ -409,6 +409,229 @@ describe("ArticlePrefetcher", () => {
 			});
 
 			expect(callback).not.toHaveBeenCalled();
+		});
+	});
+
+	// Regression: swiping a few cards stopped fetching article bodies for the
+	// rest of the session. SwipeFeedScreen's batch-image path seeds the cache
+	// with `getCachedContent(url) || ""` for feeds it has never fetched, which
+	// wrote an empty body. `contentCache.has()` then reported a hit and
+	// suppressed every future prefetch, while getCachedContent() kept reporting
+	// a miss — so the card fell back to "Source content unavailable" forever.
+	describe("empty-body cache poisoning", () => {
+		it("does not treat an image-only seed as cached content", () => {
+			const url = "https://example.com/image-only";
+
+			// This is exactly what triggerBatchImagePrefetch passes for a feed
+			// whose body has never been fetched.
+			prefetcher.seedCache(url, "", "art-1", null, "https://proxy/1.jpg");
+
+			expect(prefetcher.getCachedContent(url)).toBeNull();
+			// The image metadata is the point of that seed and must survive.
+			expect(prefetcher.getCachedOgImage(url)).toBe("https://proxy/1.jpg");
+		});
+
+		it("still prefetches a feed whose image metadata was seeded first", async () => {
+			const url = "https://example.com/image-only";
+			prefetcher.seedCache(url, "", "art-1", null, "https://proxy/1.jpg");
+
+			mockedGetContent.mockResolvedValueOnce({
+				content: "<p>Body</p>",
+				article_id: "art-1",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", url),
+			];
+			prefetcher.triggerPrefetch(feeds, 0, 1);
+			await vi.advanceTimersByTimeAsync(600);
+
+			await vi.waitFor(() => {
+				expect(prefetcher.getCachedContent(url)).toBe("<p>Body</p>");
+			});
+		});
+
+		it("never overwrites a real body with an empty one", () => {
+			const url = "https://example.com/article";
+			prefetcher.seedCache(url, "<p>Real</p>", "art-1", null);
+			prefetcher.seedCache(url, "", "art-1", null, "https://proxy/1.jpg");
+
+			expect(prefetcher.getCachedContent(url)).toBe("<p>Real</p>");
+		});
+	});
+
+	describe("ensureContent (visible-card fetch)", () => {
+		it("joins an in-flight prefetch instead of issuing a duplicate request", async () => {
+			let resolveFetch: (value: FeedContentOnTheFlyResponse) => void = () => {};
+			mockedGetContent.mockImplementationOnce(
+				() =>
+					new Promise<FeedContentOnTheFlyResponse>((resolve) => {
+						resolveFetch = resolve;
+					}),
+			);
+
+			const url = "https://zenn.dev/article-1";
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", url),
+			];
+
+			prefetcher.triggerPrefetch(feeds, 0, 1);
+			await vi.advanceTimersByTimeAsync(600);
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+
+			// The card mounts while the prefetch is still in flight. Before the
+			// fix it saw getCachedContent() === null (the "loading" sentinel
+			// reads as a miss) and fired its own request into the host limiter.
+			const fromCard = prefetcher.ensureContent(url);
+
+			resolveFetch({
+				content: "<p>Body</p>",
+				article_id: "art-1",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			await expect(fromCard).resolves.toBe("<p>Body</p>");
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns cached content without touching the network", async () => {
+			const url = "https://example.com/cached";
+			prefetcher.seedCache(url, "<p>Cached</p>", "art-1", null);
+
+			await expect(prefetcher.ensureContent(url)).resolves.toBe(
+				"<p>Cached</p>",
+			);
+			expect(mockedGetContent).not.toHaveBeenCalled();
+		});
+
+		it("resolves null during a host cooldown instead of issuing a doomed request", async () => {
+			mockedGetContent.mockRejectedValueOnce(
+				new ConnectError("rate limited", Code.ResourceExhausted),
+			);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", "https://dev.to/article-1"),
+			];
+			prefetcher.triggerPrefetch(feeds, 0, 1);
+			await vi.advanceTimersByTimeAsync(600);
+			await vi.waitFor(() => {
+				expect(mockedGetContent).toHaveBeenCalledTimes(1);
+			});
+
+			await expect(
+				prefetcher.ensureContent("https://dev.to/article-2"),
+			).resolves.toBeNull();
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+		});
+
+		it("fetches when nothing is cached or in flight", async () => {
+			mockedGetContent.mockResolvedValueOnce({
+				content: "<p>Fresh</p>",
+				article_id: "art-1",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			await expect(
+				prefetcher.ensureContent("https://example.com/fresh"),
+			).resolves.toBe("<p>Fresh</p>");
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("triggerPrefetch scheduling", () => {
+		it("does not starve a scheduled prefetch when re-triggered inside the delay window", async () => {
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Body</p>",
+				article_id: "art-1",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", "https://example.com/next-1"),
+			];
+
+			// SwipeFeedScreen's prefetch $effect re-runs on every `feeds`
+			// reassignment (handleArticleIdResolved rebuilds the array), which
+			// happens more often than PREFETCH_DELAY. Clearing and re-arming the
+			// timer each time meant it never fired.
+			for (let i = 0; i < 5; i++) {
+				prefetcher.triggerPrefetch(feeds, 0, 1);
+				await vi.advanceTimersByTimeAsync(400);
+			}
+
+			await vi.waitFor(() => {
+				expect(mockedGetContent).toHaveBeenCalledWith(
+					"https://example.com/next-1",
+				);
+			});
+		});
+
+		it("cancels a scheduled prefetch once its feed leaves the lookahead window", async () => {
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Body</p>",
+				article_id: "art-1",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/a"),
+				makeFeed("1", "https://example.com/b"),
+				makeFeed("2", "https://example.com/c"),
+			];
+
+			prefetcher.triggerPrefetch(feeds, 0, 1); // schedules /b
+			await vi.advanceTimersByTimeAsync(100);
+			prefetcher.triggerPrefetch(feeds, 1, 1); // window moves to /c
+			await vi.advanceTimersByTimeAsync(1_000);
+
+			await vi.waitFor(() => {
+				expect(mockedGetContent).toHaveBeenCalledWith("https://example.com/c");
+			});
+			expect(mockedGetContent).not.toHaveBeenCalledWith(
+				"https://example.com/b",
+			);
+		});
+	});
+
+	describe("eviction", () => {
+		it("evicts the oldest entry once the cache exceeds its cap", () => {
+			for (let i = 0; i < 31; i++) {
+				prefetcher.seedCache(
+					`https://example.com/feed-${i}`,
+					`<p>Feed ${i}</p>`,
+					`art-${i}`,
+					`https://og/${i}.png`,
+				);
+			}
+
+			expect(
+				prefetcher.getCachedContent("https://example.com/feed-0"),
+			).toBeNull();
+			expect(prefetcher.getCachedContent("https://example.com/feed-30")).toBe(
+				"<p>Feed 30</p>",
+			);
+		});
+
+		it("evicts the article id alongside the body it belongs to", () => {
+			for (let i = 0; i < 31; i++) {
+				prefetcher.seedCache(
+					`https://example.com/feed-${i}`,
+					`<p>Feed ${i}</p>`,
+					`art-${i}`,
+					`https://og/${i}.png`,
+				);
+			}
+
+			// articleIdCache grew unbounded because eviction only pruned
+			// contentCache and ogImageCache.
+			expect(
+				prefetcher.getCachedArticleId("https://example.com/feed-0"),
+			).toBeNull();
 		});
 	});
 });

--- a/alt-frontend-sv/src/lib/utils/articlePrefetcher.ts
+++ b/alt-frontend-sv/src/lib/utils/articlePrefetcher.ts
@@ -15,12 +15,18 @@ export class ArticlePrefetcher {
 	private contentCache = new Map<string, string | "loading">();
 	private articleIdCache = new Map<string, string>();
 	private ogImageCache = new Map<string, string | null>();
-	private prefetchTimeouts: ReturnType<typeof setTimeout>[] = [];
+	// Keyed by cache key, not a flat list: re-arming a timer that is still
+	// wanted restarts its delay, and the driving $effect fires more often than
+	// PREFETCH_DELAY, which starved the far lookahead slots entirely.
+	private prefetchTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 	private dismissedArticles = new Set<string>();
 	private dismissalTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 	// Per-host promise chain: a new prefetch on the same host awaits the
 	// previous one before issuing the actual HTTP call. Serialization, not skip.
 	private hostInflight = new Map<string, Promise<void>>();
+	// Per-URL in-flight fetches, so the visible card joins the prefetch already
+	// running for its own URL instead of racing it into the host rate limiter.
+	private inflight = new Map<string, Promise<string | null>>();
 	// Per-host cooldown (epoch ms when the cooldown ends). Set on 429.
 	private hostCooldown = new Map<string, number>();
 	private onContentFetched:
@@ -56,7 +62,7 @@ export class ArticlePrefetcher {
 
 		if (!cacheKey) return Promise.resolve();
 		if (this.dismissedArticles.has(cacheKey)) return Promise.resolve();
-		if (this.contentCache.has(cacheKey)) return Promise.resolve();
+		if (this.hasBodyOrPending(cacheKey)) return Promise.resolve();
 
 		let host: string;
 		try {
@@ -74,7 +80,9 @@ export class ArticlePrefetcher {
 
 		// Serialize per-host: chain after any in-flight prefetch on this host.
 		const previous = this.hostInflight.get(host) ?? Promise.resolve();
-		const next = previous.then(() => this.runPrefetch(cacheKey, host));
+		const next = previous.then(() =>
+			this.fetchContent(cacheKey, host).then(() => undefined),
+		);
 		this.hostInflight.set(host, next);
 		void next.finally(() => {
 			if (this.hostInflight.get(host) === next) {
@@ -84,13 +92,87 @@ export class ArticlePrefetcher {
 		return next;
 	}
 
-	private async runPrefetch(cacheKey: string, host: string): Promise<void> {
+	/**
+	 * Fetch the body for a URL the reader is looking at right now.
+	 *
+	 * Cards used to call the RPC directly on mount. The prefetcher's "loading"
+	 * sentinel reads as a cache miss, so a card that mounted mid-prefetch fired
+	 * a second request for the same URL — unserialized, ignoring the host
+	 * cooldown, and doubling the load the host rate limiter sees. Routing the
+	 * card through here makes that a no-op join.
+	 *
+	 * Resolves to null when the body is unavailable right now (empty response,
+	 * failed request, or an active host cooldown). Null is retryable: callers
+	 * should offer the reader a retry rather than latching an error.
+	 */
+	public ensureContent(feedUrl: string): Promise<string | null> {
+		if (!feedUrl) return Promise.resolve(null);
+
+		const cached = this.readBody(feedUrl);
+		if (cached) return Promise.resolve(cached);
+
+		const pending = this.inflight.get(feedUrl);
+		if (pending) return pending;
+
+		let host: string;
+		try {
+			host = new URL(feedUrl).host;
+		} catch {
+			return Promise.resolve(null);
+		}
+
+		const cooldownUntil = this.hostCooldown.get(host);
+		if (cooldownUntil !== undefined) {
+			if (Date.now() < cooldownUntil) return Promise.resolve(null);
+			this.hostCooldown.delete(host);
+		}
+
+		// The visible card does not queue behind the lookahead prefetches — it
+		// is what the reader is waiting on. It still registers on the host chain
+		// so those prefetches fall in behind it instead of racing it.
+		const run = this.fetchContent(feedUrl, host);
+		const gate = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		const previous = this.hostInflight.get(host);
+		const chained = previous ? previous.then(() => gate) : gate;
+		this.hostInflight.set(host, chained);
+		void chained.finally(() => {
+			if (this.hostInflight.get(host) === chained) {
+				this.hostInflight.delete(host);
+			}
+		});
+
+		return run;
+	}
+
+	/** Single in-flight request per URL, shared by prefetch and visible card. */
+	private fetchContent(cacheKey: string, host: string): Promise<string | null> {
+		const pending = this.inflight.get(cacheKey);
+		if (pending) return pending;
+
+		const run = this.runFetch(cacheKey, host);
+		this.inflight.set(cacheKey, run);
+		void run.finally(() => {
+			if (this.inflight.get(cacheKey) === run) {
+				this.inflight.delete(cacheKey);
+			}
+		});
+		return run;
+	}
+
+	private async runFetch(
+		cacheKey: string,
+		host: string,
+	): Promise<string | null> {
 		// A cooldown may have been set by a peer chained behind us — re-check
 		// once the chain reaches our turn so we do not issue a doomed call.
 		const cooldownUntil = this.hostCooldown.get(host);
-		if (cooldownUntil !== undefined && Date.now() < cooldownUntil) return;
+		if (cooldownUntil !== undefined && Date.now() < cooldownUntil) return null;
 		// Another path may have populated the cache while we waited.
-		if (this.contentCache.has(cacheKey)) return;
+		const cached = this.readBody(cacheKey);
+		if (cached) return cached;
 
 		try {
 			this.contentCache.set(cacheKey, "loading");
@@ -113,6 +195,7 @@ export class ArticlePrefetcher {
 			this.onOgImageFetched?.();
 
 			this.evictOldEntries();
+			return response.content || null;
 		} catch (error) {
 			this.contentCache.delete(cacheKey);
 			const connectErr = ConnectError.from(error);
@@ -127,7 +210,27 @@ export class ArticlePrefetcher {
 				`[ArticlePrefetcher] Failed to prefetch content: ${cacheKey}`,
 				error,
 			);
+			return null;
 		}
+	}
+
+	/** A real body, or null for "absent", "empty" and the loading sentinel. */
+	private readBody(cacheKey: string): string | null {
+		const cached = this.contentCache.get(cacheKey);
+		if (cached === undefined || cached === "loading" || cached === "") {
+			return null;
+		}
+		return cached;
+	}
+
+	/**
+	 * Whether a fetch would be redundant. Deliberately not `contentCache.has()`:
+	 * an empty-string entry answered `has()` with true and `readBody()` with
+	 * null, which permanently suppressed prefetch for a URL nothing had fetched.
+	 */
+	private hasBodyOrPending(cacheKey: string): boolean {
+		const cached = this.contentCache.get(cacheKey);
+		return cached === "loading" || (cached !== undefined && cached !== "");
 	}
 
 	/**
@@ -138,21 +241,35 @@ export class ArticlePrefetcher {
 		activeIndex: number,
 		prefetchAhead: number = 2,
 	) {
-		// Clear pending timeouts
-		this.prefetchTimeouts.forEach((timeout) => {
-			clearTimeout(timeout);
-		});
-		this.prefetchTimeouts = [];
+		const wanted = new Set<string>();
+		for (let i = 1; i <= prefetchAhead; i++) {
+			const key = feeds[activeIndex + i]?.normalizedUrl;
+			if (key) wanted.add(key);
+		}
+
+		// Cancel only the timers whose feed left the lookahead window. Clearing
+		// every timer on each call restarted the 500ms ladder from zero, and the
+		// caller re-runs this more often than that, so the far slots never fired.
+		for (const [key, timeout] of this.prefetchTimeouts) {
+			if (!wanted.has(key)) {
+				clearTimeout(timeout);
+				this.prefetchTimeouts.delete(key);
+			}
+		}
 
 		// Prefetch next N articles
 		for (let i = 1; i <= prefetchAhead; i++) {
 			const nextFeed = feeds[activeIndex + i];
-			if (nextFeed) {
-				const timeout = setTimeout(() => {
-					void this.prefetchContent(nextFeed);
-				}, PREFETCH_DELAY * i);
-				this.prefetchTimeouts.push(timeout);
-			}
+			const cacheKey = nextFeed?.normalizedUrl;
+			if (!nextFeed || !cacheKey) continue;
+			if (this.prefetchTimeouts.has(cacheKey)) continue;
+			if (this.hasBodyOrPending(cacheKey)) continue;
+
+			const timeout = setTimeout(() => {
+				this.prefetchTimeouts.delete(cacheKey);
+				void this.prefetchContent(nextFeed);
+			}, PREFETCH_DELAY * i);
+			this.prefetchTimeouts.set(cacheKey, timeout);
 		}
 	}
 
@@ -160,8 +277,7 @@ export class ArticlePrefetcher {
 	 * Get cached content for a feed URL
 	 */
 	public getCachedContent(feedUrl: string): string | null {
-		const cached = this.contentCache.get(feedUrl);
-		return cached === "loading" ? null : cached || null;
+		return this.readBody(feedUrl);
 	}
 
 	/**
@@ -189,20 +305,36 @@ export class ArticlePrefetcher {
 		ogImageUrl: string | null,
 		ogImageProxyUrl?: string | null,
 	): void {
-		this.contentCache.set(feedUrl, content);
-		this.articleIdCache.set(feedUrl, articleId);
+		if (!feedUrl) return;
+
+		// Image-only seeds pass "" for the body. Writing that entry made
+		// `has()` report a hit — suppressing every future prefetch for the URL —
+		// while every reader still saw a miss, so the card fell back to the
+		// summary for the rest of the session. Only a real body is cacheable.
+		if (content) {
+			this.contentCache.set(feedUrl, content);
+		}
+		if (articleId) {
+			this.articleIdCache.set(feedUrl, articleId);
+		}
 		this.ogImageCache.set(feedUrl, ogImageProxyUrl || ogImageUrl);
 		this.onOgImageFetched?.();
 		this.evictOldEntries();
 	}
 
 	private evictOldEntries(): void {
-		while (this.contentCache.size > MAX_CACHE_SIZE) {
-			const oldestKey = this.contentCache.keys().next().value;
-			if (oldestKey !== undefined) {
-				this.contentCache.delete(oldestKey);
-				this.ogImageCache.delete(oldestKey);
-			}
+		if (this.contentCache.size <= MAX_CACHE_SIZE) return;
+
+		for (const key of [...this.contentCache.keys()]) {
+			if (this.contentCache.size <= MAX_CACHE_SIZE) break;
+			// Never drop the "loading" sentinel of a fetch still in flight:
+			// the next caller would see a miss and issue a duplicate request.
+			if (this.contentCache.get(key) === "loading") continue;
+			this.contentCache.delete(key);
+			this.ogImageCache.delete(key);
+			// The article id belongs to the body it was extracted from; leaving
+			// it behind grew articleIdCache without bound.
+			this.articleIdCache.delete(key);
 		}
 	}
 


### PR DESCRIPTION
Swiping past the third card in the visual-preview ("PHOTO WIRE") surface
left every subsequent article stuck on "Source content unavailable.
Showing summary.", permanently. Four independent defects stacked up.

Client — empty-body cache poisoning (primary):
seedCache() wrote whatever it was handed, and triggerBatchImagePrefetch
hands it `getCachedContent(url) || ""` for feeds whose body has never
been fetched. contentCache.has() then answered "hit" — suppressing every
future prefetch for that URL — while getCachedContent() kept answering
"miss". SSR ships 3 feeds, loadMore poisons the next 10 about a second
later, so the symptom starts on card 3. seedCache now refuses to cache an
empty body, and the dedupe guard treats "" as a miss like every reader
does.

Client — duplicate, ungated requests:
The "loading" sentinel reads as a cache miss, so a card mounting
mid-prefetch fired its own request for the same URL, skipping the
per-host serialization chain and the 429 cooldown. Cards now go through
ArticlePrefetcher.ensureContent(), which joins the in-flight fetch.

Client — starved lookahead and a latched error:
triggerPrefetch cleared and re-armed every timer on each call, and its
driving $effect fires more often than the 500ms ladder, so the far slots
never ran. Timers are now keyed by URL and only cancelled when their feed
leaves the window. VisualPreviewCard's contentError was terminal; it now
retries and offers a Try again affordance. Eviction also prunes
articleIdCache and never drops a "loading" sentinel.

Backend — transient refusal recorded as permanent (primary):
CanFetchArticle returned a bare (false, nil) when robots.txt Crawl-delay
had not elapsed, which is indistinguishable from a robots.txt disallow.
The usecase responds to a disallow by writing the domain into
declined_domains — a table with no expiry and no delete path — so two
quick swipes through one publisher 403'd that publisher for that user
forever. The gate now reports CrawlDelayError, the usecase returns a
transient domain.RateLimitedError without declining anything, and the
handler maps it to ResourceExhausted with a Retry-After the client can
act on.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LfTRNJ7Dbk5tb1xuM1ymKq