### PR TITLE
Disambiguate CodeUnavailable via X-Alt-Failure-Scope header

### DIFF
--- a/alt-backend/app/orchestrator/connect/v2/articles/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler.go
@@ -89,6 +89,35 @@ func NewHandler(deps ArticleHandlerDeps, cfg *config.Config, logger *slog.Logger
 // Verify interface implementation at compile time.
 var _ articlesv2connect.ArticleServiceHandler = (*Handler)(nil)
 
+const (
+	// FailureScopeHeader names how far a failure reaches. Connect error
+	// metadata is merged into the unary response headers, so it survives the
+	// BFF's transparent proxy and reaches connect-es as ConnectError.metadata.
+	//
+	// It exists because CodeUnavailable is issued by two parties that mean
+	// opposite things by it: alt-backend for a single publisher that did not
+	// answer, and the BFF for a breaker that is open against every host. A
+	// client that cannot tell them apart must guess, and guessing "global"
+	// let one dead link black the whole reader out for a full cooldown.
+	FailureScopeHeader = "X-Alt-Failure-Scope"
+
+	// FailureScopeHost means the failure belongs to one third-party host.
+	// Every other host is still reachable and alt-backend is healthy, so this
+	// must not charge a shared failure budget or pause unrelated work.
+	//
+	// Only stamp it on errors positively attributed to a publisher. Our own
+	// politeness gate is not a publisher's health, and an unclassified fault
+	// is still ours — excusing either from the breaker would hide a real
+	// outage behind "the site is slow".
+	FailureScopeHost = "host"
+)
+
+// withFailureScope stamps the blast radius onto a Connect error.
+func withFailureScope(err *connect.Error, scope string) *connect.Error {
+	err.Meta().Set(FailureScopeHeader, scope)
+	return err
+}
+
 // FetchArticleContent fetches and extracts compliant article content.
 // Replaces GET /v1/articles/fetch/content
 func (h *Handler) FetchArticleContent(
@@ -142,21 +171,25 @@ func (h *Handler) FetchArticleContent(
 				fmt.Errorf("%s", complianceErr.Message))
 		}
 
+		// The publisher answered, just not with what we wanted. Whatever the
+		// status, the verdict is about that one site — hence FailureScopeHost
+		// on every branch, including the CodeUnavailable default that is
+		// otherwise indistinguishable from the BFF's own breaker rejection.
 		var httpErr *domain.ExternalHTTPError
 		if errors.As(err, &httpErr) {
 			switch {
 			case httpErr.StatusCode == 404 || httpErr.StatusCode == 410:
-				return nil, connect.NewError(connect.CodeNotFound,
-					fmt.Errorf("article not found"))
+				return nil, withFailureScope(connect.NewError(connect.CodeNotFound,
+					fmt.Errorf("article not found")), FailureScopeHost)
 			case httpErr.StatusCode == 403 || httpErr.StatusCode == 401:
-				return nil, connect.NewError(connect.CodePermissionDenied,
-					fmt.Errorf("access denied by external site"))
+				return nil, withFailureScope(connect.NewError(connect.CodePermissionDenied,
+					fmt.Errorf("access denied by external site")), FailureScopeHost)
 			case httpErr.StatusCode == 429:
-				return nil, connect.NewError(connect.CodeResourceExhausted,
-					fmt.Errorf("rate limited by external site"))
+				return nil, withFailureScope(connect.NewError(connect.CodeResourceExhausted,
+					fmt.Errorf("rate limited by external site")), FailureScopeHost)
 			default:
-				return nil, connect.NewError(connect.CodeUnavailable,
-					fmt.Errorf("external site returned %d", httpErr.StatusCode))
+				return nil, withFailureScope(connect.NewError(connect.CodeUnavailable,
+					fmt.Errorf("external site returned %d", httpErr.StatusCode)), FailureScopeHost)
 			}
 		}
 
@@ -169,8 +202,9 @@ func (h *Handler) FetchArticleContent(
 				"url", upstreamErr.URL,
 				"cause", upstreamErr.Cause,
 				"operation", "FetchArticleContent")
-			return nil, connect.NewError(connect.CodeUnavailable,
-				fmt.Errorf("the source site did not respond; please try again later"))
+			return nil, withFailureScope(connect.NewError(connect.CodeUnavailable,
+				fmt.Errorf("the source site did not respond; please try again later")),
+				FailureScopeHost)
 		}
 
 		return nil, errorhandler.HandleUpstreamError(ctx, h.logger, err, "FetchArticleContent")

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler_test.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler_test.go
@@ -914,7 +914,7 @@ func TestFailureScope_ReachesTheWireAsAResponseHeader(t *testing.T) {
 		strings.NewReader(`{"url":"https://example.com/article"}`),
 	)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// A transparent proxy sees exactly this much: the status and the headers.
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler_test.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler_test.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -807,6 +810,115 @@ func TestFetchArticleContent_ExternalHTTPError_500_ReturnsUnavailable(t *testing
 	var connectErr *connect.Error
 	require.ErrorAs(t, err, &connectErr)
 	assert.Equal(t, connect.CodeUnavailable, connectErr.Code())
+}
+
+// TestFetchArticleContent_PublisherAttributableErrors_CarryHostFailureScope pins
+// the wire signal that tells downstream how far a failure reaches.
+//
+// CodeUnavailable alone is ambiguous: alt-backend emits it when one publisher
+// did not answer, and the BFF emits it when its own breaker is open for every
+// host. A client that cannot tell the two apart has to guess, and guessing
+// "global" turned a single dead link into a 30-second blackout of the whole
+// reader. The header names the blast radius so nobody has to guess.
+func TestFetchArticleContent_PublisherAttributableErrors_CarryHostFailureScope(t *testing.T) {
+	const articleURL = "https://example.com/article"
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"publisher never answered", &domain.UpstreamFetchError{URL: articleURL, Cause: context.DeadlineExceeded}},
+		{"publisher returned 500", &domain.ExternalHTTPError{StatusCode: 500, URL: articleURL}},
+		{"publisher returned 406", &domain.ExternalHTTPError{StatusCode: 406, URL: articleURL}},
+		{"publisher removed the article", &domain.ExternalHTTPError{StatusCode: 404, URL: articleURL}},
+		{"publisher denied access", &domain.ExternalHTTPError{StatusCode: 403, URL: articleURL}},
+		{"publisher rate limited us", &domain.ExternalHTTPError{StatusCode: 429, URL: articleURL}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUsecase := &mockArticleUsecase{err: fmt.Errorf("fetch failed: %w", tt.err)}
+			handler := NewHandler(ArticleHandlerDeps{Article: mockUsecase}, &config.Config{}, slog.Default())
+
+			req := connect.NewRequest(&articlesv2.FetchArticleContentRequest{Url: articleURL})
+			_, err := handler.FetchArticleContent(createAuthContext(), req)
+
+			require.Error(t, err)
+			var connectErr *connect.Error
+			require.ErrorAs(t, err, &connectErr)
+			assert.Equal(t, FailureScopeHost, connectErr.Meta().Get(FailureScopeHeader))
+		})
+	}
+}
+
+// TestFetchArticleContent_OurOwnFailures_CarryNoFailureScope is the safety half
+// of the signal. The header excuses a failure from the BFF's circuit-breaker
+// budget, so stamping it on anything we have not positively attributed to a
+// publisher would hide a real alt-backend outage behind "the site is slow".
+//
+// The politeness gate is ours too: it is already a retryable 429 that no
+// breaker counts, and claiming a host's health for our own scheduling decision
+// would be a lie in the one place the client trusts us to be literal.
+func TestFetchArticleContent_OurOwnFailures_CarryNoFailureScope(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"unclassified fault", errors.New("boom")},
+		{"our host slot was busy", &domain.RateLimitedError{Message: "busy", RetryAfter: 10 * time.Second}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUsecase := &mockArticleUsecase{err: fmt.Errorf("fetch failed: %w", tt.err)}
+			handler := NewHandler(ArticleHandlerDeps{Article: mockUsecase}, &config.Config{}, slog.Default())
+
+			req := connect.NewRequest(&articlesv2.FetchArticleContentRequest{Url: "https://example.com/article"})
+			_, err := handler.FetchArticleContent(createAuthContext(), req)
+
+			require.Error(t, err)
+			var connectErr *connect.Error
+			require.ErrorAs(t, err, &connectErr)
+			assert.Empty(t, connectErr.Meta().Get(FailureScopeHeader))
+		})
+	}
+}
+
+// TestFailureScope_ReachesTheWireAsAResponseHeader verifies the assumption the
+// whole signal rests on: that Connect error metadata leaves the process as an
+// ordinary HTTP response header.
+//
+// It is asserted rather than assumed because the failure this fixes was itself
+// an unverified wire assumption — the BFF's SCREAMING_SNAKE error code, which
+// connect-es silently dropped (ADR-000959). A header the proxy cannot read is
+// a signal that does not exist, and nothing else in the chain would say so.
+func TestFailureScope_ReachesTheWireAsAResponseHeader(t *testing.T) {
+	handler := connect.NewUnaryHandler(
+		"/test.v1.Service/Method",
+		func(context.Context, *connect.Request[articlesv2.FetchArticleContentRequest]) (*connect.Response[articlesv2.FetchArticleContentResponse], error) {
+			return nil, withFailureScope(
+				connect.NewError(connect.CodeUnavailable, errors.New("the source site did not respond")),
+				FailureScopeHost,
+			)
+		},
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("/test.v1.Service/Method", handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := server.Client().Post(
+		server.URL+"/test.v1.Service/Method",
+		"application/json",
+		strings.NewReader(`{"url":"https://example.com/article"}`),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// A transparent proxy sees exactly this much: the status and the headers.
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, FailureScopeHost, resp.Header.Get(FailureScopeHeader))
 }
 
 // =============================================================================

--- a/alt-butterfly-facade/internal/handler/bff_handler.go
+++ b/alt-butterfly-facade/internal/handler/bff_handler.go
@@ -328,7 +328,7 @@ func (h *BFFHandler) serveStreaming(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	h.recordOutcome(endpoint, resp.StatusCode)
+	h.recordOutcome(endpoint, resp.StatusCode, resp.Header)
 
 	// Error-normalization only ever rewrites the initial status; once we
 	// decide to stream (below), the body is copied verbatim and untouched.
@@ -396,7 +396,7 @@ func (h *BFFHandler) executeRequest(r *http.Request, userID, endpoint string, bo
 	defer resp.Body.Close()
 
 	// Record success/failure for the endpoint's dependency-class circuit breaker
-	h.recordOutcome(endpoint, resp.StatusCode)
+	h.recordOutcome(endpoint, resp.StatusCode, resp.Header)
 	h.invalidateUnreadProjectionOnMutation(userID, endpoint, resp.StatusCode)
 
 	// Read response body
@@ -566,6 +566,11 @@ func (h *BFFHandler) handleCircuitOpen(w http.ResponseWriter, endpoint, requestI
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Retry-After", strconv.Itoa(int(h.openTimeoutFor(endpoint).Seconds())))
+	// The one condition that really does reach every host: a breaker rejection
+	// is a state of this gateway, and no publisher can be routed around it.
+	// Declaring it lets the client stop inferring the same thing from a bare
+	// CodeUnavailable, which a single dead article also produces.
+	w.Header().Set(FailureScopeHeader, FailureScopeGlobal)
 	w.Header().Set("X-Request-Id", requestID)
 	w.WriteHeader(http.StatusServiceUnavailable)
 	jsonBytes, _ := connectErr.ToJSON()
@@ -612,9 +617,15 @@ func (h *BFFHandler) openTimeoutFor(endpoint string) time.Duration {
 // rate-limited or paywalled publisher opens the breaker for every endpoint in
 // the class; recorded as a success, it resets consecFailures and masks a real
 // backend outage.
-func (h *BFFHandler) recordOutcome(endpoint string, statusCode int) {
+//
+// A 5xx the backend attributed to a publisher gets that same neutrality, and
+// for the same reason. The status code alone cannot tell "the site never
+// answered" from "alt-backend fell over" — both are 503 — so without the
+// attribution header the commonest failure a feed reader meets was charged to
+// alt-backend's budget, which is the budget ADR-000959 set out to protect.
+func (h *BFFHandler) recordOutcome(endpoint string, statusCode int, respHeader http.Header) {
 	switch {
-	case IsDependencyFailure(statusCode):
+	case IsDependencyFailure(statusCode) && !IsUpstreamAttributed(respHeader):
 		h.recordFailure(endpoint)
 	case !IsErrorResponse(statusCode):
 		h.recordSuccess(endpoint)

--- a/alt-butterfly-facade/internal/handler/bff_handler_test.go
+++ b/alt-butterfly-facade/internal/handler/bff_handler_test.go
@@ -1500,3 +1500,117 @@ func telemetryHealthRecords(t *testing.T, buf *bytes.Buffer, msg string) []map[s
 	}
 	return out
 }
+
+// TestBFFHandler_UpstreamAttributed5xx_DoesNotChargeTheBreaker closes the half
+// of ADR-000959 §1 that the 4xx rule left open.
+//
+// That decision made client errors neutral so one paywalled publisher could
+// not open the class breaker. But a publisher that never answers at all — the
+// commonest failure a feed reader meets — reaches the client as CodeUnavailable,
+// which is a 5xx, so it kept charging the very budget the ADR meant to protect.
+// The status code cannot distinguish "the site is dead" from "alt-backend is
+// dead"; only the attribution header can.
+func TestBFFHandler_UpstreamAttributed5xx_DoesNotChargeTheBreaker(t *testing.T) {
+	mockBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(FailureScopeHeader, FailureScopeHost)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer mockBackend.Close()
+
+	secret := []byte("test-secret-key")
+	config := BFFConfig{
+		EnableCircuitBreaker:              true,
+		CBFailureThreshold:                2,
+		CBSuccessThreshold:                1,
+		CBOpenTimeout:                     30 * time.Second,
+		CBExternalContentFailureThreshold: 2,
+		CBExternalContentOpenTimeout:      5 * time.Second,
+	}
+	handler := createTestBFFHandlerWithBackend(t, mockBackend.URL, secret, config)
+	token := createTestToken(t, secret)
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("POST", "/alt.articles.v2.ArticleService/FetchArticleContent", bytes.NewReader([]byte(`{}`)))
+		req.Header.Set("X-Alt-Backend-Token", token)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+			"the reader still learns this article is unavailable")
+	}
+
+	stats := handler.externalContentCB.Stats()
+	assert.Equal(t, int64(0), stats.TotalFailures,
+		"five dead publishers are not evidence that alt-backend is unhealthy")
+	assert.Equal(t, int64(0), stats.TotalSuccesses,
+		"nor may they reset the budget and mask a real outage")
+	assert.Equal(t, resilience.StateClosed, handler.externalContentCB.State())
+}
+
+// TestBFFHandler_Unattributed5xx_StillChargesTheBreaker is the safety half.
+// The header excuses a failure from the budget, so an unstamped 5xx has to
+// keep counting — otherwise a backend that stopped stamping, or one broken in
+// a way it cannot classify, would look healthy right up until it fell over.
+func TestBFFHandler_Unattributed5xx_StillChargesTheBreaker(t *testing.T) {
+	mockBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mockBackend.Close()
+
+	secret := []byte("test-secret-key")
+	config := BFFConfig{
+		EnableCircuitBreaker:              true,
+		CBFailureThreshold:                2,
+		CBSuccessThreshold:                1,
+		CBOpenTimeout:                     30 * time.Second,
+		CBExternalContentFailureThreshold: 2,
+		CBExternalContentOpenTimeout:      5 * time.Second,
+	}
+	handler := createTestBFFHandlerWithBackend(t, mockBackend.URL, secret, config)
+	token := createTestToken(t, secret)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("POST", "/alt.articles.v2.ArticleService/FetchArticleContent", bytes.NewReader([]byte(`{}`)))
+		req.Header.Set("X-Alt-Backend-Token", token)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	assert.Equal(t, resilience.StateOpen, handler.externalContentCB.State())
+}
+
+// TestBFFHandler_CircuitOpen_DeclaresGlobalFailureScope names the one condition
+// that genuinely reaches every host, so the client can stop guessing.
+//
+// The frontend pauses all hosts on this and only this: a breaker rejection is
+// a state of the gateway, and no other publisher can be routed around it. A
+// per-article failure wearing the same CodeUnavailable must never trigger it.
+func TestBFFHandler_CircuitOpen_DeclaresGlobalFailureScope(t *testing.T) {
+	mockBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mockBackend.Close()
+
+	secret := []byte("test-secret-key")
+	config := BFFConfig{
+		EnableCircuitBreaker:              true,
+		EnableErrorNormalization:          true,
+		CBFailureThreshold:                2,
+		CBSuccessThreshold:                1,
+		CBOpenTimeout:                     30 * time.Second,
+		CBExternalContentFailureThreshold: 2,
+		CBExternalContentOpenTimeout:      5 * time.Second,
+	}
+	handler := createTestBFFHandlerWithBackend(t, mockBackend.URL, secret, config)
+	token := createTestToken(t, secret)
+
+	var rec *httptest.ResponseRecorder
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("POST", "/alt.articles.v2.ArticleService/FetchArticleContent", bytes.NewReader([]byte(`{}`)))
+		req.Header.Set("X-Alt-Backend-Token", token)
+		rec = httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+	}
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, FailureScopeGlobal, rec.Header().Get(FailureScopeHeader))
+	assert.Equal(t, "5", rec.Header().Get("Retry-After"))
+}

--- a/alt-butterfly-facade/internal/handler/error_normalizer.go
+++ b/alt-butterfly-facade/internal/handler/error_normalizer.go
@@ -160,6 +160,40 @@ func IsDependencyFailure(statusCode int) bool {
 	return statusCode >= 500
 }
 
+const (
+	// FailureScopeHeader carries how far a failure reaches. alt-backend stamps
+	// it on Connect errors via error metadata, which the unary protocol merges
+	// into the response headers, so it arrives here as an ordinary header and
+	// travels on to the client untouched.
+	//
+	// It exists because CodeUnavailable is issued by two parties that mean
+	// opposite things by it. This BFF returns it when its own breaker is open
+	// against every host; alt-backend returns it when one publisher did not
+	// answer. Nothing in the status code separates them.
+	FailureScopeHeader = "X-Alt-Failure-Scope"
+
+	// FailureScopeHost means the failure belongs to one third-party publisher.
+	FailureScopeHost = "host"
+
+	// FailureScopeGlobal means the failure is a state of this gateway and no
+	// host can be routed around it. Only a breaker rejection qualifies.
+	FailureScopeGlobal = "global"
+)
+
+// IsUpstreamAttributed reports whether the backend named a third-party
+// publisher as the party at fault. Such a response says nothing about
+// alt-backend's health, so it is neutral for circuit-breaker accounting for
+// exactly the reason a 4xx is: charging it opens the class breaker on one dead
+// link, and crediting it resets the budget and masks a real outage.
+//
+// Only the exact host claim counts. The header can excuse a failure from a
+// budget but never charge one, so anything absent, unknown, or malformed has
+// to read as unattributed and keep counting as ours — a backend that stopped
+// stamping must look broken, not healthy.
+func IsUpstreamAttributed(header http.Header) bool {
+	return header.Get(FailureScopeHeader) == FailureScopeHost
+}
+
 // ConnectError is the Connect protocol's unary error body. It is not
 // NormalizedError: connect-es resolves the JSON `code` with codeFromString,
 // which accepts only the protocol's lowercase snake_case names, so

--- a/alt-butterfly-facade/internal/handler/error_normalizer_test.go
+++ b/alt-butterfly-facade/internal/handler/error_normalizer_test.go
@@ -277,3 +277,31 @@ func TestIsDependencyFailure(t *testing.T) {
 		})
 	}
 }
+
+// TestIsUpstreamAttributed reads the blast-radius header alt-backend stamps on
+// errors it has positively attributed to a third-party publisher.
+//
+// The header is a claim about whose health the response reports, and it is
+// only ever believed downward: it can excuse a failure from a budget, never
+// charge one. Anything unrecognized therefore has to read as "not attributed"
+// so an unstamped or garbled response keeps counting as our own failure.
+func TestIsUpstreamAttributed(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   http.Header
+		expected bool
+	}{
+		{"absent", http.Header{}, false},
+		{"nil header", nil, false},
+		{"host", http.Header{FailureScopeHeader: []string{FailureScopeHost}}, true},
+		{"global", http.Header{FailureScopeHeader: []string{"global"}}, false},
+		{"unknown value", http.Header{FailureScopeHeader: []string{"planet"}}, false},
+		{"empty value", http.Header{FailureScopeHeader: []string{""}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsUpstreamAttributed(tt.header))
+		})
+	}
+}

--- a/alt-frontend-sv/src/app-html.source.spec.ts
+++ b/alt-frontend-sv/src/app-html.source.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source-level gate for the parts of `app.html` that only fail in production.
+ *
+ * The deployed origin sits behind Cloudflare Access; the E2E stack has no such
+ * edge. Every assertion in `tests/e2e/mobile/pwa/installability.spec.ts` runs
+ * against a stack where nothing intercepts the manifest request — the one
+ * condition under which the bug guarded here cannot reproduce. A constraint
+ * that only the unreachable environment can check is a comment, so it is
+ * checked on the text instead, the same way `service-worker.source.spec.ts`
+ * pins the push-only worker.
+ */
+
+const appHtml = readFileSync(
+	fileURLToPath(new URL("./app.html", import.meta.url)),
+	"utf-8",
+);
+
+describe("app.html head behind an authenticating edge", () => {
+	it("fetches the manifest with credentials", () => {
+		// Chromium decides this fetch's credentials mode from the crossorigin
+		// attribute string alone and never consults same-origin-ness:
+		// ManifestManager::ManifestUseCredentials() tests the attribute for the
+		// literal "use-credentials", and manifest_fetcher.cc maps that to
+		// kInclude and everything else to kOmit. So an unadorned link sends no
+		// cookie even to our own origin, Cloudflare Access answers it the way it
+		// answers any anonymous request — a redirect to *.cloudflareaccess.com —
+		// and the browser never parses a manifest. Android then offers a
+		// bookmark shortcut instead of installing a WebAPK.
+		//
+		// (The WHATWG HTML text for `rel=manifest` routes through the generic
+		// CORS settings attribute table, which would make a bare attribute mean
+		// "same-origin" and send the cookie. Chromium does not implement that,
+		// and Chromium is what installs the app.)
+		//
+		// The attribute widens nothing. The URL is same-origin and already
+		// served anonymously as a static asset; this only attaches a cookie the
+		// browser already holds for this origin, and Access still decides.
+		// Same-origin requests never reach Fetch's CORS check, so no
+		// Access-Control-Allow-Origin is needed and nginx is unchanged.
+		const link = /<link[^>]*rel="manifest"[^>]*>/.exec(appHtml)?.[0];
+
+		expect(link, "app.html must link a manifest").toBeTruthy();
+		expect(
+			link,
+			"without crossorigin=use-credentials the manifest request reaches Cloudflare Access unauthenticated and is redirected to the login domain",
+		).toMatch(/crossorigin=["']use-credentials["']/);
+	});
+});

--- a/alt-frontend-sv/src/app.html
+++ b/alt-frontend-sv/src/app.html
@@ -13,7 +13,18 @@
 		     but are kept because a chrome-ful launch on an older device would
 		     disable notifications with no error anywhere; `mobile-web-app-capable`
 		     is the non-prefixed form Chrome asks for. -->
-		<link rel="manifest" href="/manifest.webmanifest" />
+		<!-- crossorigin="use-credentials" is what makes this reachable behind
+		     Cloudflare Access. Chromium picks this fetch's credentials mode from
+		     the attribute alone and never from same-origin-ness
+		     (ManifestManager::ManifestUseCredentials tests for the literal
+		     string; manifest_fetcher.cc maps anything else to kOmit), so a bare
+		     link sends no cookie even to our own origin. Access answers that the
+		     way it answers any anonymous request — a redirect to its login
+		     domain — and the browser never parses a manifest, so Android offers
+		     a bookmark shortcut instead of installing a WebAPK. The attribute
+		     widens nothing: same-origin, already served anonymously as a static
+		     asset, and Access still decides. -->
+		<link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
 		<link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
 		<meta name="mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte
@@ -249,13 +249,26 @@ async function loadContent() {
 }
 
 async function handleToggleContent() {
+	if (isContentExpanded) {
+		isContentExpanded = false;
+		return;
+	}
+
+	// Open first, then fetch. Awaiting the body before expanding meant the
+	// panel's loading state could never be reached on a first tap: the reader
+	// waited on a disabled button and the panel arrived already in its final
+	// state. When that state was the fallback, the card read as permanently
+	// broken from the instant it appeared, with nothing to show an attempt had
+	// been made at all.
+	isContentExpanded = true;
+
 	// A previous failure is not permanent: the host cooldown that caused it
-	// lifts, and requestContent() short-circuits while it has not. Latching
-	// contentError here pinned the card to the summary for its whole lifetime.
-	if (!isContentExpanded && !fullContent) {
+	// lifts, and requestContent() rations rather than refuses while it has not.
+	// Latching contentError here pinned the card to the summary for its whole
+	// lifetime.
+	if (!fullContent) {
 		await loadContent();
 	}
-	isContentExpanded = !isContentExpanded;
 }
 
 async function handleRetryContent() {

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte.spec.ts
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte.spec.ts
@@ -270,21 +270,55 @@ describe("VisualPreviewCard", () => {
 		});
 	});
 
-	// The two tests below exercise the click-driven async error path in
-	// handleToggleContent. They consistently hit Svelte 5 `track_reactivity_loss`
-	// because the component ran `getFeedContentOnTheFlyClient` via
-	// `.then().catch()` outside a reactive scope, so the post-rejection state
-	// update was not flushed in the browser test runner.
-	//
-	// The previous note here claimed the markup was instead covered by
-	// tests/e2e/feeds-visual-preview.spec.ts. That file does not exist and never
-	// did, so this path currently has NO coverage at any level.
-	//
-	// handleToggleContent now awaits loadContent() inside the handler rather
-	// than detaching a promise chain, which is likely to lift the original
-	// blocker — un-skip and confirm on a runner with the browser project
-	// available (`bun run test:client`).
-	describe.skip("article content fallback when source fetch fails", () => {
+	describe("expanding the article panel", () => {
+		// The panel used to be opened only after the fetch settled, so its
+		// loading state could not be reached on a first tap: the reader waited
+		// on a disabled button and then got a panel that was already in its
+		// final state. When that state was the fallback, the card looked
+		// permanently broken the instant it appeared, with no sign anything had
+		// been attempted — which is how a few seconds of backoff read as a dead
+		// article.
+		it("opens on its loading state instead of after the fetch settles", async () => {
+			let settle: (value: { content: string; article_id: string }) => void =
+				() => {};
+			vi.mocked(getFeedContentOnTheFlyClient).mockImplementation(
+				() =>
+					new Promise((resolve) => {
+						settle = resolve as typeof settle;
+					}),
+			);
+
+			render(VisualPreviewCard, {
+				props: {
+					...defaultProps,
+					initialArticleContent: null,
+					getCachedContent: () => null,
+				},
+			});
+
+			await page.getByRole("button", { name: /^article$/i }).click();
+
+			await expect
+				.element(page.getByTestId("content-section"))
+				.toBeInTheDocument();
+			await expect
+				.element(page.getByText(/loading article/i))
+				.toBeInTheDocument();
+
+			settle({ content: "<p>Full body.</p>", article_id: "article-123" });
+
+			await expect.element(page.getByText("Full body.")).toBeInTheDocument();
+		});
+	});
+
+	// These exercise the click-driven async error path in handleToggleContent.
+	// They were skipped after hitting Svelte 5 `track_reactivity_loss`: the
+	// component ran `getFeedContentOnTheFlyClient` through a detached
+	// `.then().catch()` chain, so the post-rejection state update was not
+	// flushed in the browser runner. The handler awaits inside the handler now,
+	// and the panel opens before the fetch rather than after it, so both the
+	// notice and the summary are reachable from a first tap.
+	describe("article content fallback when source fetch fails", () => {
 		it("shows 'Source content unavailable' notice and full summary when Article fetch errors", async () => {
 			vi.mocked(getFeedContentOnTheFlyClient).mockRejectedValue(
 				new Error("[unavailable] HTTP 500"),

--- a/alt-frontend-sv/src/lib/utils/articlePrefetcher.test.ts
+++ b/alt-frontend-sv/src/lib/utils/articlePrefetcher.test.ts
@@ -328,15 +328,20 @@ describe("ArticlePrefetcher", () => {
 		});
 	});
 
-	// A 503 from the BFF means its circuit breaker is open (or the backend is
-	// down): nothing the client asks for can be served, whatever the host. The
-	// per-host 429 cooldown would have let every other host through and burned
-	// the whole lookahead ladder against the open breaker.
+	// A breaker rejection from the BFF means nothing the client asks for can be
+	// served, whatever the host. The per-host 429 cooldown would have let every
+	// other host through and burned the whole lookahead ladder against the open
+	// breaker.
+	//
+	// It has to say so, though. CodeUnavailable on its own does not mean this —
+	// alt-backend returns the same code for a single publisher that never
+	// answered — so the pause is armed by the declared scope, not by the code.
 	describe("global pause on Unavailable (circuit breaker / 503)", () => {
 		const breakerError = () =>
 			new ConnectError(
 				"Service temporarily unavailable due to circuit breaker",
 				Code.Unavailable,
+				new Headers({ "X-Alt-Failure-Scope": "global" }),
 			);
 
 		it("pauses prefetch on every host, not just the one that returned 503", async () => {
@@ -358,7 +363,7 @@ describe("ArticlePrefetcher", () => {
 			expect(mockedGetContent).toHaveBeenCalledWith("https://dev.to/article-a");
 		});
 
-		it("retries an article queued during the pause once it lifts", async () => {
+		it("holds a queued article for the whole window, then fires it", async () => {
 			mockedGetContent.mockRejectedValueOnce(breakerError());
 			mockedGetContent.mockResolvedValue({
 				content: "<p>Later</p>",
@@ -376,11 +381,13 @@ describe("ArticlePrefetcher", () => {
 			await vi.advanceTimersByTimeAsync(1_100);
 			expect(mockedGetContent).toHaveBeenCalledTimes(1);
 
+			await vi.advanceTimersByTimeAsync(15_000);
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+
 			// No further triggerPrefetch(): the queued article must come back on
 			// its own rather than latch into the card's error state until the
 			// reader happens to swipe again.
-			await vi.advanceTimersByTimeAsync(35_000);
-
+			await vi.advanceTimersByTimeAsync(20_000);
 			await vi.waitFor(() => {
 				expect(prefetcher.getCachedContent("https://zenn.dev/article-b")).toBe(
 					"<p>Later</p>",
@@ -388,30 +395,104 @@ describe("ArticlePrefetcher", () => {
 			});
 		});
 
-		it("resolves ensureContent null during the pause instead of issuing a doomed request", async () => {
-			mockedGetContent.mockRejectedValueOnce(breakerError());
+		it("honors a Retry-After shorter than the default pause", async () => {
+			const meta = new Headers({
+				"Retry-After": "2",
+				"X-Alt-Failure-Scope": "global",
+			});
+			mockedGetContent.mockRejectedValueOnce(
+				new ConnectError("breaker open", Code.Unavailable, meta),
+			);
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Back</p>",
+				article_id: "art-back",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", "https://dev.to/article-a"),
+				makeFeed("2", "https://zenn.dev/article-b"),
+			];
+			prefetcher.triggerPrefetch(feeds, 0, 2);
+			await vi.advanceTimersByTimeAsync(1_100);
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+
+			// Well inside the 30s default, but past the 2s the gateway asked for.
+			await vi.advanceTimersByTimeAsync(3_000);
+			await vi.waitFor(() => {
+				expect(prefetcher.getCachedContent("https://zenn.dev/article-b")).toBe(
+					"<p>Back</p>",
+				);
+			});
+		});
+	});
+
+	// The other half of Unavailable, and by far the commoner one: a publisher
+	// that did not answer. alt-backend maps that to CodeUnavailable too, so
+	// arming the all-hosts pause on the code alone let a single dead link black
+	// the reader out for a full cooldown — every card after it fell straight to
+	// "Source content unavailable" without a request ever being sent.
+	describe("host-scoped Unavailable (one publisher, not the gateway)", () => {
+		const publisherError = (headers?: Record<string, string>) =>
+			new ConnectError(
+				"the source site did not respond; please try again later",
+				Code.Unavailable,
+				new Headers({ "X-Alt-Failure-Scope": "host", ...headers }),
+			);
+
+		it("keeps prefetching other hosts when only the publisher failed", async () => {
+			mockedGetContent.mockRejectedValueOnce(publisherError());
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Other host</p>",
+				article_id: "art-b",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", "https://dev.to/article-a"),
+				makeFeed("2", "https://zenn.dev/article-b"),
+			];
+
+			prefetcher.triggerPrefetch(feeds, 0, 2);
+			await vi.advanceTimersByTimeAsync(1_100);
+
+			await vi.waitFor(() => {
+				expect(prefetcher.getCachedContent("https://zenn.dev/article-b")).toBe(
+					"<p>Other host</p>",
+				);
+			});
+			expect(mockedGetContent).toHaveBeenCalledWith(
+				"https://zenn.dev/article-b",
+			);
+		});
+
+		it("still holds off the host that failed", async () => {
+			mockedGetContent.mockRejectedValue(publisherError());
 
 			const feeds = [
 				makeFeed("0", "https://example.com/active"),
 				makeFeed("1", "https://dev.to/article-a"),
 			];
+
 			prefetcher.triggerPrefetch(feeds, 0, 1);
 			await vi.advanceTimersByTimeAsync(600);
-			await vi.waitFor(() => {
-				expect(mockedGetContent).toHaveBeenCalledTimes(1);
-			});
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
 
-			await expect(
-				prefetcher.ensureContent("https://unrelated.example/article"),
-			).resolves.toBeNull();
+			// A second article on the same host must wait out that host's
+			// cooldown rather than walk into the same refusal.
+			const more = [...feeds, makeFeed("2", "https://dev.to/article-b")];
+			prefetcher.triggerPrefetch(more, 1, 1);
+			await vi.advanceTimersByTimeAsync(1_000);
 			expect(mockedGetContent).toHaveBeenCalledTimes(1);
 		});
 
-		it("serves the visible card again once the pause window has elapsed", async () => {
-			mockedGetContent.mockRejectedValueOnce(breakerError());
+		it("serves a different host's card immediately", async () => {
+			mockedGetContent.mockRejectedValueOnce(publisherError());
 			mockedGetContent.mockResolvedValue({
-				content: "<p>Back</p>",
-				article_id: "art-back",
+				content: "<p>Elsewhere</p>",
+				article_id: "art-elsewhere",
 				og_image_url: null,
 			} as unknown as FeedContentOnTheFlyResponse);
 
@@ -423,22 +504,41 @@ describe("ArticlePrefetcher", () => {
 			await vi.advanceTimersByTimeAsync(600);
 			expect(mockedGetContent).toHaveBeenCalledTimes(1);
 
-			await vi.advanceTimersByTimeAsync(15_000);
 			await expect(
 				prefetcher.ensureContent("https://unrelated.example/article"),
-			).resolves.toBeNull();
-			expect(mockedGetContent).toHaveBeenCalledTimes(1);
-
-			await vi.advanceTimersByTimeAsync(16_000);
-			await expect(
-				prefetcher.ensureContent("https://unrelated.example/article"),
-			).resolves.toBe("<p>Back</p>");
+			).resolves.toBe("<p>Elsewhere</p>");
 		});
 
-		it("honors a Retry-After shorter than the default pause", async () => {
-			const meta = new Headers({ "Retry-After": "2" });
+		it("treats an Unavailable that declares no scope as host-scoped", async () => {
+			// Nothing downstream can tell an unstamped CodeUnavailable apart from
+			// a per-article one, so the ambiguous case takes the cheaper mistake:
+			// pausing one host wrongly costs one card, pausing every host wrongly
+			// costs the session — and the BFF's breaker still bounds the load.
 			mockedGetContent.mockRejectedValueOnce(
-				new ConnectError("breaker open", Code.Unavailable, meta),
+				new ConnectError("external site returned 503", Code.Unavailable),
+			);
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Elsewhere</p>",
+				article_id: "art-elsewhere",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			const feeds = [
+				makeFeed("0", "https://example.com/active"),
+				makeFeed("1", "https://dev.to/article-a"),
+			];
+			prefetcher.triggerPrefetch(feeds, 0, 1);
+			await vi.advanceTimersByTimeAsync(600);
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+
+			await expect(
+				prefetcher.ensureContent("https://unrelated.example/article"),
+			).resolves.toBe("<p>Elsewhere</p>");
+		});
+
+		it("honors a Retry-After on the host cooldown", async () => {
+			mockedGetContent.mockRejectedValueOnce(
+				publisherError({ "Retry-After": "2" }),
 			);
 			mockedGetContent.mockResolvedValue({
 				content: "<p>Back</p>",
@@ -454,16 +554,143 @@ describe("ArticlePrefetcher", () => {
 			await vi.advanceTimersByTimeAsync(600);
 			expect(mockedGetContent).toHaveBeenCalledTimes(1);
 
-			await vi.advanceTimersByTimeAsync(1_000);
-			await expect(
-				prefetcher.ensureContent("https://unrelated.example/article"),
-			).resolves.toBeNull();
-
 			// Well inside the 30s default, but past the 2s the server asked for.
-			await vi.advanceTimersByTimeAsync(1_500);
+			await vi.advanceTimersByTimeAsync(2_500);
+			await expect(
+				prefetcher.ensureContent("https://dev.to/article-a"),
+			).resolves.toBe("<p>Back</p>");
+		});
+	});
+
+	// A cooldown exists to stop the lookahead ladder from walking into a gate it
+	// has already been refused at. The card the reader is looking at is not the
+	// ladder — it is one request they explicitly asked for, and answering it
+	// without ever sending anything is what turned a few seconds of backoff into
+	// a card that read as permanently broken, retry button included.
+	describe("foreground probe across an active cooldown", () => {
+		const breakerError = () =>
+			new ConnectError(
+				"Service temporarily unavailable due to circuit breaker",
+				Code.Unavailable,
+				new Headers({ "X-Alt-Failure-Scope": "global" }),
+			);
+
+		async function armGlobalPause() {
+			mockedGetContent.mockRejectedValueOnce(breakerError());
+			prefetcher.triggerPrefetch(
+				[
+					makeFeed("0", "https://example.com/active"),
+					makeFeed("1", "https://dev.to/article-a"),
+				],
+				0,
+				1,
+			);
+			await vi.advanceTimersByTimeAsync(600);
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+		}
+
+		it("sends the visible card's request even while every host is paused", async () => {
+			await armGlobalPause();
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Probed</p>",
+				article_id: "art-probe",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
 			await expect(
 				prefetcher.ensureContent("https://unrelated.example/article"),
-			).resolves.toBe("<p>Back</p>");
+			).resolves.toBe("<p>Probed</p>");
+			expect(mockedGetContent).toHaveBeenCalledTimes(2);
+		});
+
+		it("sends it while only that article's host is cooling down", async () => {
+			mockedGetContent.mockRejectedValueOnce(
+				new ConnectError(
+					"the source site did not respond",
+					Code.Unavailable,
+					new Headers({ "X-Alt-Failure-Scope": "host" }),
+				),
+			);
+			prefetcher.triggerPrefetch(
+				[
+					makeFeed("0", "https://example.com/active"),
+					makeFeed("1", "https://dev.to/article-a"),
+				],
+				0,
+				1,
+			);
+			await vi.advanceTimersByTimeAsync(600);
+			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Probed</p>",
+				article_id: "art-probe",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			// Same host that just refused: the reader swiped onto it and tapped.
+			await expect(
+				prefetcher.ensureContent("https://dev.to/article-b"),
+			).resolves.toBe("<p>Probed</p>");
+		});
+
+		it("spaces repeated attempts so a held retry button cannot hammer", async () => {
+			await armGlobalPause();
+			mockedGetContent.mockRejectedValue(breakerError());
+
+			await expect(
+				prefetcher.ensureContent("https://a.example/article"),
+			).resolves.toBeNull();
+			expect(mockedGetContent).toHaveBeenCalledTimes(2);
+
+			// Straight after the probe: refused without a request, which is what
+			// the cooldown is for once the reader has had their attempt.
+			await expect(
+				prefetcher.ensureContent("https://b.example/article"),
+			).resolves.toBeNull();
+			expect(mockedGetContent).toHaveBeenCalledTimes(2);
+
+			await vi.advanceTimersByTimeAsync(5_500);
+			await expect(
+				prefetcher.ensureContent("https://c.example/article"),
+			).resolves.toBeNull();
+			expect(mockedGetContent).toHaveBeenCalledTimes(3);
+		});
+
+		it("leaves the background ladder suppressed while the foreground probes", async () => {
+			await armGlobalPause();
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Probed</p>",
+				article_id: "art-probe",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			// The probe is the reader's request, not a licence for the ladder:
+			// only the one call goes out, from ensureContent.
+			await prefetcher.ensureContent("https://unrelated.example/article");
+			expect(mockedGetContent).toHaveBeenCalledTimes(2);
+			expect(mockedGetContent).toHaveBeenLastCalledWith(
+				"https://unrelated.example/article",
+			);
+		});
+
+		it("lifts the pause when a probe gets through", async () => {
+			await armGlobalPause();
+			mockedGetContent.mockResolvedValue({
+				content: "<p>Probed</p>",
+				article_id: "art-probe",
+				og_image_url: null,
+			} as unknown as FeedContentOnTheFlyResponse);
+
+			await prefetcher.ensureContent("https://unrelated.example/article");
+
+			// A request just completed, so whatever the pause was guarding is
+			// over. Sitting out the rest of the window would keep the ladder
+			// suppressed and the next card blank for no reason.
+			await expect(
+				prefetcher.ensureContent("https://another.example/article"),
+			).resolves.toBe("<p>Probed</p>");
+			expect(mockedGetContent).toHaveBeenCalledTimes(3);
 		});
 	});
 
@@ -646,8 +873,8 @@ describe("ArticlePrefetcher", () => {
 			expect(mockedGetContent).not.toHaveBeenCalled();
 		});
 
-		it("resolves null during a host cooldown instead of issuing a doomed request", async () => {
-			mockedGetContent.mockRejectedValueOnce(
+		it("rations rather than refuses the visible card during a host cooldown", async () => {
+			mockedGetContent.mockRejectedValue(
 				new ConnectError("rate limited", Code.ResourceExhausted),
 			);
 
@@ -661,10 +888,18 @@ describe("ArticlePrefetcher", () => {
 				expect(mockedGetContent).toHaveBeenCalledTimes(1);
 			});
 
+			// The reader swiped onto this host and asked for the body: one
+			// attempt goes out, even though the ladder is held off.
 			await expect(
 				prefetcher.ensureContent("https://dev.to/article-2"),
 			).resolves.toBeNull();
-			expect(mockedGetContent).toHaveBeenCalledTimes(1);
+			expect(mockedGetContent).toHaveBeenCalledTimes(2);
+
+			// Asking again straight away is the case the cooldown is for.
+			await expect(
+				prefetcher.ensureContent("https://dev.to/article-3"),
+			).resolves.toBeNull();
+			expect(mockedGetContent).toHaveBeenCalledTimes(2);
 		});
 
 		it("fetches when nothing is cached or in flight", async () => {

--- a/alt-frontend-sv/src/lib/utils/articlePrefetcher.ts
+++ b/alt-frontend-sv/src/lib/utils/articlePrefetcher.ts
@@ -1,6 +1,7 @@
 import { Code, ConnectError } from "@connectrpc/connect";
 import { getFeedContentOnTheFlyClient } from "$lib/api/client";
 import type { RenderFeed } from "$lib/schema/feed";
+import { isGlobalFailureScope } from "./errorClassification";
 import { parseRetryAfter } from "./retryAfter";
 
 const MAX_CACHE_SIZE = 30;
@@ -10,12 +11,29 @@ const DISMISSED_CLEANUP_DELAY = 3000; // ms
 // ADR-000884: matches the typical reset window of the backend host rate limiter
 // (5 rps). When the server returns Retry-After, that value wins.
 const HOST_COOLDOWN_MS = 30_000;
-// Pause applied to every host after an Unavailable (HTTP 503). Unlike a 429,
-// which is one host's rate limiter, 503 means the BFF's circuit breaker is open
-// or the backend is down — a global condition that no other host can route
-// around. The breaker's own open timeout is 30s, so a comparable client pause
-// keeps the ladder from re-opening it the moment it half-opens.
+// Pause applied to every host after a failure that declares itself global —
+// the BFF's circuit breaker being open, which no other host can route around.
+// The breaker's own open timeout bounds this and travels in Retry-After; the
+// default only covers a gateway that declared the scope but not the timing.
+//
+// It is armed by the declared scope, never by CodeUnavailable alone. Both a
+// dead publisher and an open breaker arrive as that code, and treating the
+// former as the latter blacked the reader out for 30s per broken link.
 const GLOBAL_COOLDOWN_MS = 30_000;
+// How often a request the reader is waiting on may cross an active cooldown.
+//
+// Cooldowns exist to keep the lookahead ladder from walking into a gate that
+// already refused it. The visible card is not the ladder: it is one request the
+// reader explicitly asked for, and refusing it without sending anything is what
+// made a few seconds of backoff read as a permanently broken card — retry
+// button included, since that took the same short circuit. Rationing rather
+// than allowing keeps a held retry button from becoming the hammering the
+// cooldown was installed to prevent. The interval matches the BFF's
+// external-content open timeout, so a probe lands about as often as the
+// gateway re-probes itself.
+const FOREGROUND_PROBE_INTERVAL_MS = 5_000;
+// Probe-ledger key for the all-hosts pause. Not a possible host name.
+const GLOBAL_SCOPE_KEY = "*";
 
 export class ArticlePrefetcher {
 	private contentCache = new Map<string, string | "loading">();
@@ -33,10 +51,16 @@ export class ArticlePrefetcher {
 	// Per-URL in-flight fetches, so the visible card joins the prefetch already
 	// running for its own URL instead of racing it into the host rate limiter.
 	private inflight = new Map<string, Promise<string | null>>();
-	// Per-host cooldown (epoch ms when the cooldown ends). Set on 429.
+	// Per-host cooldown (epoch ms when the cooldown ends). Set on 429, and on
+	// any Unavailable that did not declare itself global.
 	private hostCooldown = new Map<string, number>();
-	// Epoch ms when the all-hosts pause ends, 0 when there is none. Set on 503.
+	// Epoch ms when the all-hosts pause ends, 0 when there is none. Set only by
+	// a failure carrying an explicit global scope.
 	private globalCooldownUntil = 0;
+	// When each cooldown scope last let a foreground request through, keyed by
+	// host or by GLOBAL_SCOPE_KEY. Rations the reader's attempts without
+	// silencing them.
+	private foregroundProbeAt = new Map<string, number>();
 	private onContentFetched:
 		| ((feedUrl: string, content: string) => void)
 		| null = null;
@@ -70,6 +94,53 @@ export class ArticlePrefetcher {
 		return 0;
 	}
 
+	/** Milliseconds left on this host's cooldown, 0 when it is not active. */
+	private hostPauseRemaining(host: string): number {
+		const until = this.hostCooldown.get(host);
+		if (until === undefined) return 0;
+		const remaining = until - Date.now();
+		if (remaining > 0) return remaining;
+		this.hostCooldown.delete(host);
+		return 0;
+	}
+
+	/**
+	 * The cooldown scope covering this host right now, or null when none does.
+	 * The all-hosts pause wins: backing off one host cannot route around it.
+	 */
+	private activeCooldownScope(host: string): string | null {
+		if (this.globalPauseRemaining() > 0) return GLOBAL_SCOPE_KEY;
+		if (this.hostPauseRemaining(host) > 0) return host;
+		return null;
+	}
+
+	/**
+	 * Whether a foreground request may cross this scope's cooldown now,
+	 * consuming the slot when it may. Callers that are told no must not fetch.
+	 */
+	private claimForegroundProbe(scope: string): boolean {
+		const now = Date.now();
+		const last = this.foregroundProbeAt.get(scope);
+		if (last !== undefined && now - last < FOREGROUND_PROBE_INTERVAL_MS) {
+			return false;
+		}
+		this.foregroundProbeAt.set(scope, now);
+		return true;
+	}
+
+	/**
+	 * Drop the backoff after a request completes. Something got through, so
+	 * whatever the cooldown was guarding is over; sitting out the rest of the
+	 * window would keep the ladder suppressed and the next cards blank long
+	 * after the host or the breaker recovered.
+	 */
+	private clearCooldowns(host: string): void {
+		this.hostCooldown.delete(host);
+		this.globalCooldownUntil = 0;
+		this.foregroundProbeAt.delete(host);
+		this.foregroundProbeAt.delete(GLOBAL_SCOPE_KEY);
+	}
+
 	/**
 	 * Prefetch content for a single article
 	 * Uses normalizedUrl as cache key for consistency with FeedDetailModal
@@ -88,12 +159,9 @@ export class ArticlePrefetcher {
 			return Promise.resolve();
 		}
 
-		// Honor cooldown: if this host returned 429 recently, skip until it lifts.
-		const cooldownUntil = this.hostCooldown.get(host);
-		if (cooldownUntil !== undefined) {
-			if (Date.now() < cooldownUntil) return Promise.resolve();
-			this.hostCooldown.delete(host);
-		}
+		// Honor the cooldown outright. The lookahead has nobody waiting on it,
+		// so unlike the visible card it gets no probe: skip until it lifts.
+		if (this.hostPauseRemaining(host) > 0) return Promise.resolve();
 
 		// Serialize per-host: chain after any in-flight prefetch on this host.
 		const previous = this.hostInflight.get(host) ?? Promise.resolve();
@@ -119,8 +187,9 @@ export class ArticlePrefetcher {
 	 * card through here makes that a no-op join.
 	 *
 	 * Resolves to null when the body is unavailable right now (empty response,
-	 * failed request, or an active host cooldown). Null is retryable: callers
-	 * should offer the reader a retry rather than latching an error.
+	 * failed request, or a cooldown that has already spent its probe). Null is
+	 * retryable: callers should offer the reader a retry rather than latching
+	 * an error.
 	 */
 	public ensureContent(feedUrl: string): Promise<string | null> {
 		if (!feedUrl) return Promise.resolve(null);
@@ -131,8 +200,6 @@ export class ArticlePrefetcher {
 		const pending = this.inflight.get(feedUrl);
 		if (pending) return pending;
 
-		if (this.globalPauseRemaining() > 0) return Promise.resolve(null);
-
 		let host: string;
 		try {
 			host = new URL(feedUrl).host;
@@ -140,16 +207,17 @@ export class ArticlePrefetcher {
 			return Promise.resolve(null);
 		}
 
-		const cooldownUntil = this.hostCooldown.get(host);
-		if (cooldownUntil !== undefined) {
-			if (Date.now() < cooldownUntil) return Promise.resolve(null);
-			this.hostCooldown.delete(host);
+		// A cooldown covering this card does not silence it. The reader asked
+		// for this one body, so they get an attempt — rationed, not refused.
+		const scope = this.activeCooldownScope(host);
+		if (scope !== null && !this.claimForegroundProbe(scope)) {
+			return Promise.resolve(null);
 		}
 
 		// The visible card does not queue behind the lookahead prefetches — it
 		// is what the reader is waiting on. It still registers on the host chain
 		// so those prefetches fall in behind it instead of racing it.
-		const run = this.fetchContent(feedUrl, host);
+		const run = this.fetchContent(feedUrl, host, scope !== null);
 		const gate = run.then(
 			() => undefined,
 			() => undefined,
@@ -167,11 +235,15 @@ export class ArticlePrefetcher {
 	}
 
 	/** Single in-flight request per URL, shared by prefetch and visible card. */
-	private fetchContent(cacheKey: string, host: string): Promise<string | null> {
+	private fetchContent(
+		cacheKey: string,
+		host: string,
+		crossCooldown = false,
+	): Promise<string | null> {
 		const pending = this.inflight.get(cacheKey);
 		if (pending) return pending;
 
-		const run = this.runFetch(cacheKey, host);
+		const run = this.runFetch(cacheKey, host, crossCooldown);
 		this.inflight.set(cacheKey, run);
 		void run.finally(() => {
 			if (this.inflight.get(cacheKey) === run) {
@@ -184,12 +256,17 @@ export class ArticlePrefetcher {
 	private async runFetch(
 		cacheKey: string,
 		host: string,
+		crossCooldown: boolean,
 	): Promise<string | null> {
 		// A cooldown may have been set by a peer chained behind us — re-check
 		// once the chain reaches our turn so we do not issue a doomed call.
-		if (this.globalPauseRemaining() > 0) return null;
-		const cooldownUntil = this.hostCooldown.get(host);
-		if (cooldownUntil !== undefined && Date.now() < cooldownUntil) return null;
+		// A caller holding a foreground probe has already been granted its one
+		// crossing; re-checking here would revoke it and put the reader back on
+		// a card that fails without asking anything.
+		if (!crossCooldown) {
+			if (this.globalPauseRemaining() > 0) return null;
+			if (this.hostPauseRemaining(host) > 0) return null;
+		}
 		// Another path may have populated the cache while we waited.
 		const cached = this.readBody(cacheKey);
 		if (cached) return cached;
@@ -198,6 +275,7 @@ export class ArticlePrefetcher {
 			this.contentCache.set(cacheKey, "loading");
 
 			const response = await getFeedContentOnTheFlyClient(cacheKey);
+			this.clearCooldowns(host);
 
 			if (response.content) {
 				this.contentCache.set(cacheKey, response.content);
@@ -227,9 +305,18 @@ export class ArticlePrefetcher {
 					host,
 					Date.now() + (retryAfterMs ?? HOST_COOLDOWN_MS),
 				);
-			} else if (connectErr.code === Code.Unavailable) {
+			} else if (isGlobalFailureScope(connectErr.metadata)) {
 				this.globalCooldownUntil =
 					Date.now() + (retryAfterMs ?? GLOBAL_COOLDOWN_MS);
+			} else if (connectErr.code === Code.Unavailable) {
+				// Unavailable that did not claim to be global. alt-backend
+				// returns it for a publisher that never answered, which is one
+				// host's problem — reading every one of them as an open breaker
+				// paused the whole reader on a single dead link.
+				this.hostCooldown.set(
+					host,
+					Date.now() + (retryAfterMs ?? HOST_COOLDOWN_MS),
+				);
 			}
 			console.warn(
 				`[ArticlePrefetcher] Failed to prefetch content: ${cacheKey}`,

--- a/alt-frontend-sv/src/lib/utils/errorClassification.ts
+++ b/alt-frontend-sv/src/lib/utils/errorClassification.ts
@@ -21,6 +21,30 @@ export function articleContentErrorMessage(err: unknown): string {
 }
 
 /**
+ * Header naming how far a failure reaches. alt-backend stamps it on errors it
+ * has attributed to a third-party publisher; the BFF stamps it on the one
+ * rejection that really is system-wide, its own open circuit breaker.
+ */
+export const FAILURE_SCOPE_HEADER = "X-Alt-Failure-Scope";
+
+/**
+ * Whether a failure reaches every host, so backing off one of them is futile.
+ *
+ * Only an explicit claim counts. `Code.Unavailable` is issued both by the BFF
+ * for an open breaker — genuinely global — and by alt-backend for a single
+ * publisher that never answered, which is most of them. Reading the code alone
+ * as global let one dead link pause every host for the whole cooldown, and the
+ * reader saw the summary fallback on every card without a request being sent.
+ *
+ * The ambiguous case resolves to false on purpose: pausing one host wrongly
+ * costs one card, pausing all of them wrongly costs the session, and the
+ * gateway's own breaker still bounds what a wrong guess can cost it.
+ */
+export function isGlobalFailureScope(metadata: Headers | undefined): boolean {
+	return metadata?.get(FAILURE_SCOPE_HEADER) === "global";
+}
+
+/**
  * Classifies errors as transient (retryable) or permanent.
  * Used by Article/Summary retry logic across Desktop and Mobile components.
  */

--- a/alt-frontend-sv/tests/e2e/mobile/pwa/installability.spec.ts
+++ b/alt-frontend-sv/tests/e2e/mobile/pwa/installability.spec.ts
@@ -128,6 +128,20 @@ test.describe("PWA installability", () => {
 			/manifest\.webmanifest$/,
 		);
 
+		// Chromium takes this fetch's credentials mode from the attribute alone,
+		// never from same-origin-ness, so a bare link sends no cookie and the
+		// Cloudflare Access edge in front of the deployed origin redirects it to
+		// its login domain — no manifest, no WebAPK, just a bookmark shortcut.
+		//
+		// This stack has no Access, so the assertion can pass here while
+		// production is broken; `src/app-html.source.spec.ts` is the gate that
+		// can actually catch the regression. It is stated here too because this
+		// file is where the installability contract is read.
+		await expect(page.locator('link[rel="manifest"]')).toHaveAttribute(
+			"crossorigin",
+			"use-credentials",
+		);
+
 		// iOS still takes its Home Screen icon from this tag rather than the
 		// manifest, so a manifest-only icon set installs with a screenshot.
 		await expect(page.locator('link[rel="apple-touch-icon"]')).toHaveCount(1);

--- a/docs/ADR/000963.md
+++ b/docs/ADR/000963.md
@@ -1,0 +1,234 @@
+---
+title: 失敗の到達範囲を X-Alt-Failure-Scope で宣言し Code.Unavailable の二重の意味を解消する
+date: 2026-08-09
+status: accepted
+tags:
+  - frontend
+  - backend
+  - connect-rpc
+  - architecture
+  - bugfix
+affected_services:
+  - 'alt-backend (Go) — `orchestrator/connect/v2/articles/handler.go`。出版社起因の失敗に `X-Alt-Failure-Scope: host` を stamp する'
+  - 'alt-butterfly-facade (Go) — `internal/handler/error_normalizer.go` / `bff_handler.go`。scope=host の 5xx を breaker 予算から外し、circuit-open に `X-Alt-Failure-Scope: global` を立てる'
+  - 'alt-frontend-sv (TypeScript / Svelte 5) — `src/lib/utils/errorClassification.ts` / `articlePrefetcher.ts`。全ホスト停止を宣言された scope でのみ発火させ、前景リクエストに probe を許す'
+  - 'alt-frontend-sv — `src/lib/components/mobile/feeds/swipe/VisualPreviewCard.svelte`。本文パネルを fetch 前に開く'
+aliases:
+  - ADR-963
+  - ADR-000963
+---
+# ADR-000963: 失敗の到達範囲を X-Alt-Failure-Scope で宣言し Code.Unavailable の二重の意味を解消する
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-09
+
+## Affected Services
+
+- alt-backend (Go)
+- alt-butterfly-facade (Go)
+- alt-frontend-sv (TypeScript / SvelteKit)
+
+## Context
+
+Visual Preview を数枚スワイプすると、以降どの記事を開いても即座に本文が出なくなる。
+
+```
+FULL ARTICLE
+Source content unavailable. Showing summary.
+[ TRY AGAIN ]
+```
+
+[[000959]] が入れた「`Code.Unavailable` を全ホスト一時停止として扱う」が、同じ ADR の
+別の決定と衝突していた。
+
+### 同一コードに 2 つの意味が載っていた
+
+| 発行者 | 条件 | Connect code | 到達範囲 |
+|---|---|---|---|
+| alt-butterfly-facade | 自身の circuit breaker が開いている | `unavailable` | **全ホスト** |
+| alt-backend | 出版社が無応答（[[000959]] §3 の `UpstreamFetchError`） | `unavailable` | その記事 1 本 |
+| alt-backend | 出版社が 404/403/429 以外を返した（500 / 503 / 406 …） | `unavailable` | その記事 1 本 |
+
+[[000959]] §6 は前者だけを想定して「フロントエンドは `Code.Unavailable` を全ホスト
+一時停止として扱う」と決めたが、同 ADR §3 が後者にも同じコードを割り当てていた。
+`unavailable` は HTTP 503 なので、status code でも区別できない。
+
+結果、**リンク切れ・無応答・bot ブロックの記事を 1 本踏むと 30 秒間どのカードも
+リクエストすら送られなくなる**。RSS では日常的に起きる事象で、数枚スワイプすれば
+ほぼ確実に踏む。
+
+```
+articlePrefetcher.ts (修正前)
+  } else if (connectErr.code === Code.Unavailable) {
+      this.globalCooldownUntil = Date.now() + (retryAfterMs ?? 30_000);
+  }
+  ...
+  ensureContent():
+      if (this.globalPauseRemaining() > 0) return Promise.resolve(null);
+```
+
+重み付けも逆転していた。本当にグローバルな breaker rejection は
+`Retry-After: 5`（`CBExternalContentOpenTimeout`）を伴うので 5 秒で復帰するが、
+per-host であるべき出版社無応答はヘッダを持たないため既定の **30 秒**が適用される。
+
+### 「すぐにこうなる」の体感を作っていたもの
+
+- `VisualPreviewCard.handleToggleContent` が `loadContent()` を **await してから**
+  `isContentExpanded = true` にしていた。パネルの `Loading article...` は初回タップでは
+  到達不能で、パネルは常に最終状態で現れる。それが fallback だと、開いた瞬間に
+  「壊れている」ように見える。
+- `ensureContent` の cooldown 短絡は "TRY AGAIN" にも効くので、押しても無反応に見えた。
+- この経路のコンポーネントテストは `describe.skip` されており、**どの層にも
+  カバレッジが無かった**。
+
+### [[000959]] §1 が塞ぎ損ねていた穴
+
+同 ADR は「4xx を breaker に計上しない」で出版社起因の失敗を予算から外したが、
+`UpstreamFetchError` は `CodeUnavailable` → 503 → `IsDependencyFailure(>=500)` に該当し、
+**依然として external_content breaker の予算を消費していた**。§3 が「alt-backend は
+健全なのだから内部障害として扱わない」と宣言した当のケースが、BFF 側では失敗として
+数えられ続けていた。
+
+## Decision
+
+**失敗の到達範囲をコードから推測させず、発行者に宣言させる。**
+
+### 1. `X-Alt-Failure-Scope` ヘッダを導入する
+
+Connect の unary エラー metadata は `mergeNonProtocolHeaders` で HTTP レスポンス
+ヘッダに merge される（connect-go v1.20.0 `protocol_connect.go:770`）。したがって
+BFF は透過 proxy として読め、connect-es は `ConnectError.metadata` として受け取る。
+この wire 仮定は `TestFailureScope_ReachesTheWireAsAResponseHeader` で実際の
+httptest サーバに対して検証する — [[000959]] の事故自体が未検証の wire 仮定
+（`codeFromString("SERVICE_UNAVAILABLE")` が `undefined`）だったため。
+
+| 値 | 意味 |
+|---|---|
+| `host` | 第三者ホスト 1 つに帰属する。他ホストは健在で alt-backend も健全 |
+| `global` | ゲートウェイの状態で、どのホストにも迂回できない |
+
+### 2. alt-backend は出版社起因の失敗にだけ `host` を stamp する
+
+`ExternalHTTPError` の全分岐と `UpstreamFetchError` に付ける。
+
+**`RateLimitedError`（自前の politeness gate）と未分類エラーには付けない。**
+ヘッダは失敗を予算から**免除する**方向にのみ効くので、出版社に帰属すると
+positively 判定できていないものに付けると、本物の alt-backend 障害が
+「サイトが遅い」の陰に隠れる。自前のスロット待ちを「ホストの健康状態」と
+名乗るのは、クライアントが字義どおりを期待する唯一の場所での虚偽でもある。
+
+### 3. BFF は scope=host の 5xx を breaker 予算から外す
+
+`IsDependencyFailure(statusCode) && !IsUpstreamAttributed(respHeader)` のときだけ
+`recordFailure`。4xx と同じ中立扱いで、[[000959]] §1 の論理をその ADR が
+閉じ損ねた半分に適用する。`IsUpstreamAttributed` は `host` の完全一致のみ true。
+不在・未知・不正はすべて「未帰属 = 我々の失敗」に倒す — stamp を止めた backend が
+健全に見えてはいけない。
+
+### 4. BFF の circuit-open は `global` を宣言する
+
+`handleCircuitOpen` が `X-Alt-Failure-Scope: global` を立てる。これが全ホストへ
+到達する唯一の条件である。
+
+### 5. フロントの既定を per-host に倒す
+
+全ホスト停止は **宣言された `global` でのみ**発火する。scope 不明の `Unavailable` は
+per-host cooldown に落とす。曖昧なケースで安い方の間違いを選ぶ — ホスト 1 つを
+誤って止めればカード 1 枚、全ホストを誤って止めればセッション 1 回分。しかも
+誤った推測のコストは BFF の breaker が上限を押さえている。
+
+### 6. 前景リクエストは cooldown を配給制で越える
+
+cooldown は「先読みラダーが拒否済みのゲートへ歩いていく」のを止めるためのもので、
+読者が見ているカードはラダーではない。`ensureContent` は cooldown scope
+（host または全ホスト）ごとに **5 秒に 1 回**だけ実リクエストを通す。
+`FOREGROUND_PROBE_INTERVAL_MS` は BFF の external_content open timeout に合わせてあり、
+ゲートウェイ自身の再プローブとほぼ同じ頻度になる。先読みは従来どおり完全に抑止する。
+
+リクエストが 1 本通った時点で cooldown は解除する。何かが通ったならゲートが
+守っていた条件は終わっており、窓を座って待つとホストや breaker の回復後も
+ラダーが抑止され次のカードが白いままになる。
+
+**[[000959]] が却下した「`isTransientError()` に `Code.Unavailable` を追加」とは
+別物である。**あちらは自動再送 2 箇所が 500ms 後に開いた breaker を叩き直す話で、
+こちらは読者の明示的な操作を scope ごとに 5 秒 1 回へ配給する。
+
+### 7. 本文パネルは fetch の前に開く
+
+`handleToggleContent` は `isContentExpanded = true` を先に立ててから `loadContent()`
+を await する。パネルの loading 状態が初回タップで到達可能になり、失敗しても
+「試した上で駄目だった」ことが画面に出る。
+
+`SwipeFeedCard`（visual-preview 以外）は変更しない。失敗をボタン側の
+`Try again` 状態で表す別の UX 契約を持っており、そちらのパネル内 loading は
+re-fetch 経路から到達可能である。
+
+### 却下した代替案
+
+| 案 | 却下理由 |
+|----|----------|
+| 出版社起因を `CodeUnavailable` 以外（例 `FailedPrecondition`）に写す | Connect code の意味論を Alt 固有の都合で歪める。HTTP status も変わり [[000959]] §1 の 4xx/5xx 境界が再び曖昧になる |
+| `Retry-After` の有無で global / host を判別する | 偶然の相関に依存する。backend の 429 も Retry-After を持つ |
+| フロントの global pause を廃止する | breaker が開いている間にラダーを走らせると、開いた breaker を叩き直す。[[000959]] の指摘は正しい |
+| 前景 probe を無制限に許す | retry ボタン長押しがそのまま hammering になる |
+| cooldown 成功時の解除をしない | 回復後もカードが白いまま残る。今回の症状の一部そのもの |
+
+## Consequences
+
+### Pros
+
+- リンク切れ 1 本が読書セッション全体を 30 秒暗転させる連鎖が断たれた。
+- 出版社無応答が alt-backend の failure budget を消費しなくなり、[[000959]] §1 の
+  意図が実際に達成された。
+- 読者がタップしたカードは、cooldown 中でも実際にリクエストを送る。
+  "TRY AGAIN" が「押しても何も起きない」ボタンではなくなった。
+- パネルが loading から開くようになり、失敗が「試した結果」として読める。
+- `VisualPreviewCard` の fallback markup にコンポーネントテストが付いた
+  （`describe.skip` の解除 + 展開順序の RED）。それまでどの層にもカバレッジが無かった。
+- wire 契約（metadata → レスポンスヘッダ）が httptest で assert され、
+  [[000959]] 型の「未検証の wire 仮定」が 1 つ減った。
+
+### Cons / Tradeoffs
+
+- ヘッダという Alt 固有の out-of-band 契約が 3 サービスに増えた。proto にも
+  Connect の標準にも現れないため、**新しい producer は stamp を忘れうる**。
+  忘れた場合は「未帰属 = 我々の失敗」に倒れるので breaker は保守側に振れるが、
+  フロントは per-host cooldown になり全ホスト停止が効かない。
+- `FOREGROUND_PROBE_INTERVAL_MS = 5_000` は BFF の open timeout に合わせた値で、
+  実測に基づくものではない。breaker が開いている間、開いているタブごとに
+  5 秒 1 回の拒否リクエストが増える。
+- scope=host の 5xx を中立にしたことで、**出版社側の広域障害は
+  external_content breaker で検知できなくなった**。検知はメトリクス / アラート側の
+  責務に移る（[[000959]] が 4xx について負ったトレードオフと同種）。
+- `SwipeFeedCard` の展開順序は揃っていない。2 つの swipe カードで
+  「失敗したときパネルが開くか」の挙動が異なる。
+- **コンテナ再ビルドによる実スタック検証は行っていない**（本セッションの環境に
+  docker daemon が無い）。検証はユニット / コンポーネントテストの範囲に留まる。
+  [[000946]] / [[000959]] が残した「breaker の open / half-open 遷移が実スタックで
+  未検証」という状態も解消していない。
+
+## Related ADRs
+
+- [[000959]] 外部サイトの応答と自前のレート制限ゲートを alt-backend の failure budget から切り離す — 本 ADR の直接の親。§3 と §6 の衝突を解消し、§1 が閉じ損ねた 5xx の穴を塞ぐ
+- [[000950]] BFF の依存クラス別 circuit breaker と MarkAsRead 後の未読投影キャッシュ invalidation を導入する
+- [[000884]] articlePrefetcher に per-host inflight gate と 429 cooldown を追加して visual-preview の自動 prefetch 経由 429 を抑止する — per-host cooldown の起点。本 ADR はそこへ scope 判定と前景 probe を足す
+- [[000883]] feeds 系 unary RPC に Connect-Timeout-Ms 5s を適用し VisualPreviewCard に summary フォールバック表示を追加する — `Source content unavailable.` markup の出所
+
+## Deploy-model 整合性セルフチェック
+
+- [x] 新設 compose service が `depends_on` で他 service を gate するか？ — **N/A**
+- [x] 新設 compose service に `restart: "no"` の one-shot init container を含むか？ — **N/A**
+- [x] 新設名前付き volume を populate する責務はどこにあるか？ — **N/A**
+- [x] いずれも該当しない: **rolling 互換**
+
+アプリケーションコードのみ。compose / CI / deploy pattern 不変。
+
+ヘッダは追加のみで、3 サービスの deploy 順序に依存しない。stamp する backend が
+先に出ても、読む BFF / フロントが先に出ても、未知ヘッダは無視されるか
+「未帰属」として従来の挙動になる。per-service rolling deploy
+([[000826]] / [[PM-2026-037]]) と整合する。

--- a/docs/ADR/000964.md
+++ b/docs/ADR/000964.md
@@ -1,0 +1,197 @@
+---
+title: manifest を crossorigin=use-credentials で取得し Cloudflare Access 下でのインストールを通す
+date: 2026-08-09
+status: accepted
+tags:
+  - frontend
+  - pwa
+  - networking
+  - bugfix
+affected_services:
+  - 'alt-frontend-sv (TypeScript / Svelte 5) — `src/app.html` の `<link rel="manifest">` に `crossorigin="use-credentials"` を付ける'
+  - 'alt-frontend-sv — `src/app-html.source.spec.ts` を新設。E2E スタックに Access が無く検出できない制約を text 上で pin する'
+  - 'alt-frontend-sv — `tests/e2e/mobile/pwa/installability.spec.ts` に同要件を明記'
+  - 'Cloudflare Access — 設定変更なし。manifest icon の minting 経路については未決（本 ADR の Cons を参照）'
+aliases:
+  - ADR-964
+  - ADR-000964
+---
+# ADR-000964: manifest を crossorigin=use-credentials で取得し Cloudflare Access 下でのインストールを通す
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-09
+
+## Affected Services
+
+- alt-frontend-sv (TypeScript / SvelteKit)
+
+## Context
+
+Android Chrome が本番の Alt を PWA としてインストールしない。ホーム画面には
+WebAPK ではなくブックマークショートカットが置かれる。
+
+デプロイ先のオリジンは Cloudflare Access の背後にあり、未認証リクエストを
+`*.cloudflareaccess.com` へ 302 する。`<link rel="manifest">` はその 302 を踏んでいた。
+
+### 同一オリジンでも cookie は付かない
+
+Chromium は manifest fetch の credentials mode を **`crossorigin` 属性の文字列だけ**で
+決めており、同一オリジンかどうかを見ていない。
+
+```cpp
+// third_party/blink/renderer/modules/manifest/manifest_manager.cc
+return EqualIgnoringAsciiCase(
+    link_element->FastGetAttribute(html_names::kCrossoriginAttr),
+    "use-credentials");
+
+// third_party/blink/renderer/modules/manifest/manifest_fetcher.cc
+request.SetCredentialsMode(use_credentials
+                              ? network::mojom::CredentialsMode::kInclude
+                              : network::mojom::CredentialsMode::kOmit);
+```
+
+属性が無ければ `kOmit`。Access は CF_Authorization を持たないリクエストとして扱い、
+ログインドメインへ 302 する。ブラウザは manifest を一度もパースしない。
+
+WHATWG HTML の `rel=manifest` の記述は generic な CORS settings attribute の表を
+経由しており、属性なし = `"same-origin"`（= cookie が付く）と読める。**Chromium は
+それを実装していない**。インストールを行うのは Chromium なので実装側を採る。
+
+### 同種の実例
+
+- mealie-recipes/mealie#3935 — Cloudflare Access 下で manifest が読めず、
+  `crossorigin="use-credentials"` で解決
+- danny-avila/LibreChat#5154 / #5156 — 同じ root cause。VitePWA の `useCredentials` で解決
+- Lissy93/dashy#2102 — 同じ一行で解決
+
+いずれも **CORS ヘッダやリバースプロキシの変更は不要**だった。Fetch 仕様上、
+same-origin のリクエストは response tainting が `"basic"` のまま
+`scheme-fetch` に入り、CORS チェックの経路に到達しないためである。
+
+Cloudflare 自身のトラブルシューティングも同じ処方を書いている —
+*「同一ドメインでは CORS チェックは起きない。このエラーが出るなら、リクエストが
+CF-Authorization cookie 無しで送られている可能性が高い」*。
+
+### service worker 側は手当て不要だった
+
+当初、Access のログイン画面を service worker が app shell としてキャッシュする
+汚染が懸念された。**このリポジトリでは前提が成立しない。** [[000962]] の worker は
+fetch ハンドラも Cache Storage も持たず、`src/service-worker.source.spec.ts` が
+4 つの assertion でそれを pin している。キャッシュが無いので汚染するものが無い。
+
+仕様を確認した結果、残りの懸念も解消した。
+
+- worker script の取得は仕様上 `credentials mode: "same-origin"` 固定で、
+  `crossorigin` 属性とは無関係に常に cookie が付く。
+- 定期更新チェックも `register()` と同じ Update アルゴリズムを通る。Access が
+  更新チェックを 302 しても、`newestWorker` が非 null のため job は黙って中断し、
+  **既存 worker は unregister されない**。push 配信も途切れない。
+- Workbox も CDN からの `importScripts` も使っていないため、`importScripts` の
+  credentials mode が仕様上あいまいだという問題にも触れない。
+
+## Decision
+
+**`<link rel="manifest">` に `crossorigin="use-credentials"` を付ける。それだけを行う。**
+
+属性は公開範囲を 1 バイトも広げない。URL は同一オリジンで、`static/` の静的アセット
+として route-guard を通らず既に匿名で配信されている。属性はブラウザが既に保持して
+いる cookie を添付させるだけで、認証の判定は従来どおり Access が行う。
+
+### service worker には fetch ハンドラを追加しない
+
+キャッシュ汚染対策として fetch ハンドラを足す案は**採らない**。
+
+1. 防ぐ対象のキャッシュを新規に作ることになる。現在は存在しない。
+2. [[000898]] / [[000902]] の stale chunk 防御は全層が「ネットワークが正本」で
+   あることを前提にしている。fetch に答える worker はその全層の前に立ち、
+   evict された module map を無期限に配り続けうる。**自己修復する障害を
+   恒久障害に変える。**
+3. [[000962]] の決定に反し、`service-worker.source.spec.ts` の 4 assertion が落ちる。
+
+### standalone 再認証時の UI は仕様として受け入れる
+
+セッション切れでホーム画面から起動すると、Access のログインドメインは manifest の
+`scope` 外なので Chrome が URL バー付きの UI を出す。認証後に scope 内へ戻れば
+standalone に復帰する見込みだが、**実機で未確認**である。セッション期間の延長で
+頻度は下げられるが、それは要件の緩和にあたるため採らない。
+
+### 検証手順
+
+1. `chrome://webapks` にエントリが生成されているか。出れば本物の WebAPK で、
+   ショートカットではない。
+2. DevTools → Application → Manifest から `cloudflareaccess.com` への
+   リダイレクトエラーが消えていること。
+3. インストールされたアイコンが実物か、汎用フォールバックか（下記 Cons を参照）。
+
+### 却下した代替案
+
+| 案 | 却下理由 |
+|----|----------|
+| Access に全面的な bypass を入れる | 属性 1 つで足りる。公開範囲を広げる理由が無い |
+| manifest を別ホストへ出す | cross-origin manifest は別の制約に当たり、Access の判定からも外れる |
+| service worker に fetch ハンドラ + キャッシュ除外を足す | 上記のとおり。防ぐ対象を作る変更である |
+
+## Consequences
+
+### Pros
+
+- Android で WebAPK として install できる経路が通る。
+- CORS ヘッダも nginx も compose も変更しない。
+- 同種 3 プロジェクト（mealie / LibreChat / dashy）で確認済みの処方と一致する。
+- E2E が構造的に検出できない制約に、実行可能な pin が付いた
+  （`src/app-html.source.spec.ts`）。
+
+### Cons / Tradeoffs
+
+- **WebAPK の icon minting は本 ADR では解決していない。** アイコンのハッシュを
+  計算する端末側のコードが credentials を無条件に落としている。
+
+  ```cpp
+  // components/webapps/browser/android/webapk/webapk_single_icon_hasher.cc
+  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
+  ```
+
+  `crossorigin` 属性を読む経路がこのクラスにも呼び出し側にも存在しない。
+  `/icons/*` が Access 配下にある限り、この fetch は 302 を踏み続ける。
+  minting server がオリジンへ取りに来ないこと（`webapk.proto` の
+  `Image.image_data` に端末が取得したバイト列を載せる）は確認済みで、
+  そこは問題ではない — **端末上の Chrome 自身の取得が未認証**なのが問題である。
+
+  影響はアイコンが実物にならない可能性であり、install 自体は
+  `ManifestIconDownloader` 経由の別経路で通る見込み（こちらは credentials を
+  omit していないと見られるが、実際に fetch を発行する renderer 側の行までは
+  追い切れていない）。**`/icons/*` の Access bypass が必要かどうかは未決**で、
+  Cloudflare 側の設定変更にあたるため本 ADR の範囲外とする。判断材料は
+  検証手順 3 で得られる。
+
+- standalone 再認証時の Android の実挙動は未確認。MDN の scope 記述と TWA の
+  Custom Tab 挙動からは「URL バーが出て認証後に戻る」が有力だが、
+  「別ウィンドウに出て戻らない」という報告も存在し、決着していない。実機確認が要る。
+
+- Cloudflare の Bot Fight Mode は例外指定ができず、Super Bot Fight Mode の
+  Static Resource Protection は拡張子リストに `.js` を含む（= worker script が
+  対象になりうる）。`.json` / `.webmanifest` は含まれない。症状が残る場合の
+  次の容疑者はここと Rocket Loader（`data-cfasync="false"` で除外可能）。
+
+- **実機・実スタックでの検証は行っていない**（本セッションの環境に docker daemon が
+  無く、Android 実機も無い）。検証はソースレベルの pin に留まる。
+
+## Related ADRs
+
+- [[000962]] Web Push のために push 専用 service worker を fetch ハンドラなし・Cache Storage 不使用で登録する — 本 ADR が fetch ハンドラ追加を却下する根拠
+- [[000902]] / [[000898]] stale `/_app/immutable/*` chunk 防御 — 同上
+- [[000755]] Cloudflare edge 層が Alt の前段に存在することの確認元
+
+## Deploy-model 整合性セルフチェック
+
+- [x] 新設 compose service が `depends_on` で他 service を gate するか？ — **N/A**
+- [x] 新設 compose service に `restart: "no"` の one-shot init container を含むか？ — **N/A**
+- [x] 新設名前付き volume を populate する責務はどこにあるか？ — **N/A**
+- [x] いずれも該当しない: **rolling 互換**
+
+`app.html` の属性 1 つとテスト 2 件のみ。compose / nginx / CI / deploy pattern 不変。


### PR DESCRIPTION
## Summary

Fixes a critical bug where a single unreachable publisher (dead link, no response, bot-blocked) would black out the entire reader for 30 seconds. The root cause was that `Code.Unavailable` is issued by two different parties with opposite meanings:
- **alt-backend**: one publisher did not answer (per-article failure)
- **BFF**: circuit breaker is open (global, affects all hosts)

The frontend had no way to distinguish them and defaulted to treating all `Unavailable` as global, causing a single dead link to pause prefetch on every host.

## Key Changes

### Backend (alt-backend)
- Added `X-Alt-Failure-Scope` header constant and `withFailureScope()` helper
- Stamps `X-Alt-Failure-Scope: host` on all publisher-attributed errors:
  - `ExternalHTTPError` (all status codes)
  - `UpstreamFetchError` (publisher timeout/no response)
- Does NOT stamp on alt-backend's own failures (unclassified errors, politeness gate)
- Added comprehensive test coverage (`TestFetchArticleContent_PublisherAttributableErrors_CarryHostFailureScope`, etc.)

### BFF (alt-butterfly-facade)
- Modified `recordOutcome()` to accept response headers and check for `X-Alt-Failure-Scope: host`
- Scope=host 5xx errors no longer charge the `external_content` circuit breaker (same treatment as 4xx)
- Scope=global (or absent) 5xx errors still charge the breaker
- BFF's own circuit-open rejection stamps `X-Alt-Failure-Scope: global`
- Added tests verifying upstream-attributed 5xx does not open breaker, and unattributed 5xx still does

### Frontend (alt-frontend-sv)
- Added `isGlobalFailureScope()` helper to read the header from `ConnectError.metadata`
- **Global pause** (all hosts) now armed ONLY by explicit `X-Alt-Failure-Scope: global`
- **Per-host cooldown** is the default for any `Code.Unavailable` without the header
- Added **foreground probe rationing**: visible card requests may cross an active cooldown once every 5 seconds (`FOREGROUND_PROBE_INTERVAL_MS`), preventing "TRY AGAIN" from being silent while still protecting the prefetch ladder
- Cooldown is cleared on successful request (something got through = gate condition ended)
- Updated test suite to cover both global and host-scoped failures, Retry-After handling, and probe behavior

### VisualPreviewCard UX fix
- Panel now opens on its loading state BEFORE the fetch settles (was: opened after fetch completed)
- Prevents the fallback markup from appearing instantly with no sign of an attempt
- Failure now reads as "tried and failed" rather than "permanently broken"
- Added component test coverage for the expand-then-fetch ordering

### Documentation
- **ADR-000963**: Full decision record on failure scope disambiguation, probe rationing, and the per-host default
- **ADR-000964**: Separate decision on PWA manifest `crossorigin="use-credentials"` (Cloudflare Access fix)
- Added `src/app-html.source.spec.ts` to pin the manifest fetch requirement at source level (E2E cannot test behind Access)

## Implementation Details

- Wire contract verified: Connect error metadata → HTTP response headers → client `ConnectError.metadata` (tested with httptest)
- Ambiguous case (no header) defaults to per-host, not global — cheaper mistake (one card vs. whole session)
- Foreground probe interval (5s) matches BFF's external-content open timeout, aligning client re-probe with gateway re-probe
- Service worker unchanged (no fetch handler added, no cache pollution risk per ADR-000962)
- Backward compatible: unstamped `Unavailable` treated as per-host, breaker still counts unattributed 5xx

## Testing

- 15+ new unit tests across all three services
- Component test for VisualPreviewCard expand ordering
- E2E test for manifest fetch

https://claude.ai/code/session_01TneftAKsXWeH8ue4KjDgy2