### PR TITLE
feat(frontend): 縦スクロール2カラムのフィードギャラリーをモバイルに追加

### DIFF
--- a/alt-frontend-sv/src/lib/components/desktop/feeds/FeedDetailModal.svelte
+++ b/alt-frontend-sv/src/lib/components/desktop/feeds/FeedDetailModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { ChevronLeft, ChevronRight } from "@lucide/svelte";
+import { ChevronLeft, ChevronRight, X } from "@lucide/svelte";
 import { Dialog as DialogPrimitive } from "bits-ui";
-import { type Snippet, tick } from "svelte";
+import { tick } from "svelte";
 import { getFeedContentOnTheFlyClient } from "$lib/api/client/articles";
 import RenderFeedDetails from "$lib/components/mobile/RenderFeedDetails.svelte";
 import {
@@ -29,7 +29,15 @@ interface Props {
 	onNext?: () => void;
 	feeds?: RenderFeed[];
 	currentIndex?: number;
-	footerActions?: Snippet;
+	/**
+	 * Rendered as a footer action when supplied. A typed callback rather than a
+	 * snippet: every caller passed the same "Mark as Read" button, and a
+	 * caller-owned button carries the *caller's* style scope, so it could never
+	 * match this component's footer rules — it arrived unstyled and, on a phone
+	 * rail, visibly foreign.
+	 */
+	onMarkAsRead?: () => void;
+	isMarkingAsRead?: boolean;
 }
 
 let {
@@ -42,7 +50,8 @@ let {
 	onNext,
 	feeds,
 	currentIndex,
-	footerActions,
+	onMarkAsRead,
+	isMarkingAsRead = false,
 }: Props = $props();
 
 // Content fetching state
@@ -78,6 +87,53 @@ const summaryButtonState = $derived.by(() => {
 	if (summary) return "success" as const;
 	return "idle" as const;
 });
+
+/**
+ * Footer labels in a long and a short form.
+ *
+ * On the phone rail a cell is about a third of 346px, and "Re-fetch Article"
+ * wraps to two lines there. Both forms are rendered and CSS picks one, rather
+ * than JS reading the viewport: a viewport-derived string renders one way on the
+ * server and another in the browser, which is a hydration mismatch. Both spans
+ * are aria-hidden and the button carries the long form as its accessible name,
+ * so the name is the same at every width.
+ */
+const articleLabel = $derived.by(() => {
+	switch (articleButtonState) {
+		case "loading":
+			return { long: "Loading…", short: "Loading" };
+		case "success":
+			return { long: "Re-fetch Article", short: "Re-fetch" };
+		case "error":
+			return { long: "Try Again", short: "Retry" };
+		default:
+			return { long: "Full Article", short: "Article" };
+	}
+});
+
+const summaryLabel = $derived.by(() => {
+	switch (summaryButtonState) {
+		case "loading":
+			return { long: "Summarizing…", short: "Summarizing" };
+		case "success":
+			return { long: "Re-summarize", short: "Re-run" };
+		case "error":
+			return { long: "Try Again", short: "Retry" };
+		default:
+			return { long: "Summarize", short: "Summary" };
+	}
+});
+
+const markAsReadLabel = $derived(
+	isMarkingAsRead
+		? { long: "Marking…", short: "Marking" }
+		: { long: "Mark as Read", short: "Mark Read" },
+);
+
+function requestClose() {
+	open = false;
+	onOpenChange(false);
+}
 
 // Track previous feed URL to detect actual feed changes
 let previousFeedUrl = $state<string | null>(null);
@@ -420,6 +476,22 @@ async function handleSummarize(forceRefresh = false) {
 			{/if}
 
 			{#if feed}
+				<!--
+					Phone-only close. On a phone the footer has room for reading
+					actions or for chrome, not both, and chrome is what moves: Close
+					is how you leave the modal, not something you do to the article.
+					Hidden above 640px, where the footer's Close still serves.
+				-->
+				<button
+					type="button"
+					class="modal-close"
+					data-testid="modal-close"
+					aria-label="Close"
+					onclick={requestClose}
+				>
+					<X class="h-5 w-5" />
+				</button>
+
 				<div class="modal-header">
 					{#if feed.link}
 						<a
@@ -492,53 +564,60 @@ async function handleSummarize(forceRefresh = false) {
 					</div>
 				</div>
 
-				<div class="modal-footer">
-					<div class="flex gap-3 flex-1 min-w-0">
+				<div class="modal-footer" data-testid="modal-footer">
+					<div class="footer-group footer-group--reading">
 						<button
+							type="button"
 							onclick={articleButtonState === 'success' ? handleRefetchArticle : () => handleFetchFullArticle()}
 							disabled={articleButtonState === 'loading'}
 							class="action-btn"
 							class:action-btn--error={articleButtonState === 'error'}
+							aria-label={articleLabel.long}
 						>
 							{#if articleButtonState === 'loading'}
 								<span class="loading-pulse"></span>
-								<span>Loading&hellip;</span>
-							{:else if articleButtonState === 'success'}
-								<span>Re-fetch Article</span>
-							{:else if articleButtonState === 'error'}
-								<span>Try Again</span>
-							{:else}
-								<span>Full Article</span>
 							{/if}
+							<span class="btn-label btn-label--long" aria-hidden="true">{articleLabel.long}</span>
+							<span class="btn-label btn-label--short" aria-hidden="true">{articleLabel.short}</span>
 						</button>
 
 						<button
+							type="button"
 							onclick={() => handleSummarize(summaryButtonState === 'success')}
 							disabled={summaryButtonState === 'loading' || (!articleContent && summaryButtonState !== 'error' && summaryButtonState !== 'success')}
 							class="action-btn action-btn--primary"
 							class:action-btn--error={summaryButtonState === 'error'}
+							aria-label={summaryLabel.long}
 						>
 							{#if summaryButtonState === 'loading'}
 								<span class="loading-pulse"></span>
-								<span>Summarizing&hellip;</span>
-							{:else if summaryButtonState === 'error'}
-								<span>Try Again</span>
-							{:else if summaryButtonState === 'success'}
-								<span>Re-summarize</span>
-							{:else}
-								<span>Summarize</span>
 							{/if}
+							<span class="btn-label btn-label--long" aria-hidden="true">{summaryLabel.long}</span>
+							<span class="btn-label btn-label--short" aria-hidden="true">{summaryLabel.short}</span>
 						</button>
 					</div>
 
-					<div class="flex gap-3 flex-shrink-0">
-						{#if footerActions}
-							{@render footerActions()}
+					<div class="footer-group footer-group--chrome">
+						{#if onMarkAsRead}
+							<button
+								type="button"
+								class="action-btn"
+								onclick={onMarkAsRead}
+								disabled={isMarkingAsRead}
+								aria-label={markAsReadLabel.long}
+							>
+								<span class="btn-label btn-label--long" aria-hidden="true">{markAsReadLabel.long}</span>
+								<span class="btn-label btn-label--short" aria-hidden="true">{markAsReadLabel.short}</span>
+							</button>
 						{/if}
 
-						<DialogPrimitive.Close class="action-btn">
+						<button
+							type="button"
+							class="action-btn action-btn--close"
+							onclick={requestClose}
+						>
 							Close
-						</DialogPrimitive.Close>
+						</button>
 					</div>
 				</div>
 			{/if}
@@ -581,6 +660,11 @@ async function handleSummarize(forceRefresh = false) {
 	.modal-header {
 		padding: 1.5rem 3rem;
 		border-bottom: 1px solid var(--surface-border);
+	}
+
+	/* Phone-only; the footer's Close serves at desktop width. */
+	.modal-close {
+		display: none;
 	}
 
 	.modal-title-link {
@@ -736,6 +820,29 @@ async function handleSummarize(forceRefresh = false) {
 		border-top: 1px solid var(--surface-border);
 	}
 
+	/* Scoped classes rather than the Tailwind utilities that used to sit here:
+	   the phone rail needs to restyle these groups, and a utility class carries
+	   no hook for that. */
+	.footer-group {
+		display: flex;
+		gap: 0.75rem;
+	}
+
+	.footer-group--reading {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.footer-group--chrome {
+		flex-shrink: 0;
+	}
+
+	/* One of the two label forms is always display:none — see the labels comment
+	   in the script block. */
+	.btn-label--short {
+		display: none;
+	}
+
 	.action-btn {
 		display: inline-flex;
 		align-items: center;
@@ -778,6 +885,20 @@ async function handleSummarize(forceRefresh = false) {
 		border-color: var(--alt-charcoal);
 	}
 
+	/* Kept above the phone media query on purpose: these and the rail rules have
+	   equal specificity, so source order is what decides, and the rail must win
+	   below 640px. */
+	.action-btn--error {
+		color: var(--alt-terracotta);
+		border-color: var(--alt-terracotta);
+		background: transparent;
+	}
+
+	.action-btn--error:hover:not(:disabled) {
+		background: var(--alt-terracotta);
+		color: var(--surface-bg);
+	}
+
 	/*
 	 * Phone width. This modal was only ever opened from the desktop grid, so its
 	 * 3rem gutters were free; reached from the mobile visual-preview gallery they
@@ -794,8 +915,10 @@ async function handleSummarize(forceRefresh = false) {
 			display: none;
 		}
 
+		/* padding-right keeps the headline clear of the close stamp. */
 		.modal-header {
 			padding: 1rem;
+			padding-right: 3.5rem;
 		}
 
 		.modal-title {
@@ -811,41 +934,142 @@ async function handleSummarize(forceRefresh = false) {
 		}
 
 		/*
-		 * Four buttons in one row do not fit 346px: they overflowed the dialog
-		 * and painted over each other. Stack the two groups instead, and let each
-		 * group split its row evenly — two rows of two, every button over the
-		 * 48px touch-target floor that the desktop 2.25rem row does not meet.
+		 * The footer becomes an editorial action rail.
+		 *
+		 * Alt-Paper sets type on paper: hairline rules, small-caps mono, ink
+		 * instead of fills. Three bordered slabs — one of them a solid block of
+		 * teal — is the language of a form, not of a page, and at this width they
+		 * cost two rows and ~112px of a 700px-tall dialog.
+		 *
+		 * So: drop the boxes and let the rules do the work. The footer's own
+		 * top rule plus one hairline between cells frames three equal columns,
+		 * edge to edge, 48px tall — the same rule-and-column device the body's
+		 * section labels already use. Primacy is marked the way this file marks
+		 * it elsewhere (`.rail-section`): a 3px ink rule along the top of the
+		 * cell, not a filled slab.
 		 */
 		.modal-footer {
-			flex-direction: column;
+			gap: 0;
+			padding: 0;
+			padding-bottom: env(safe-area-inset-bottom, 0px);
+			flex-wrap: nowrap;
 			align-items: stretch;
-			gap: 0.5rem;
-			padding: 0.75rem 1rem;
-			padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
 		}
 
-		.modal-footer > div {
-			width: 100%;
+		/* Three equal columns. The flex-grow weights are per *cell*, so the
+		   two-cell reading group takes twice the one-cell chrome group and every
+		   cell lands on a third — a measured column grid rather than cells sized
+		   by how long their label happens to be. */
+		.footer-group {
+			gap: 0;
+			min-width: 0;
 		}
 
-		/* `:global` because one of these is the caller's `footerActions` snippet,
-		   which carries the parent component's style scope, not this one's. */
-		.modal-footer > div > :global(*) {
+		.footer-group--reading {
+			flex: 2 1 0;
+		}
+
+		.footer-group--chrome {
+			flex: 1 1 0;
+		}
+
+		.action-btn {
 			flex: 1 1 0;
 			min-width: 0;
 			min-height: 48px;
+			padding: 0.5rem 0.25rem;
+			border: none;
+			border-left: 1px solid var(--surface-border);
+			background: transparent;
+			color: var(--alt-charcoal);
+			font-family: var(--font-mono);
+			font-size: 0.62rem;
+			font-weight: 700;
+			letter-spacing: 0.06em;
+			white-space: nowrap;
 		}
-	}
 
-	.action-btn--error {
-		color: var(--alt-terracotta);
-		border-color: var(--alt-terracotta);
-		background: transparent;
-	}
+		/* The leftmost cell butts against the dialog edge; only the seams get a
+		   rule. `.footer-group--reading` is always first, so its first child is
+		   the rail's first cell. */
+		.footer-group--reading .action-btn:first-child {
+			border-left: none;
+		}
 
-	.action-btn--error:hover:not(:disabled) {
-		background: var(--alt-terracotta);
-		color: var(--surface-bg);
+		.action-btn:hover:not(:disabled) {
+			background: transparent;
+			color: var(--alt-charcoal);
+		}
+
+		/* Touch has no hover; the press is the only feedback, so it inverts. */
+		.action-btn:active:not(:disabled) {
+			background: var(--alt-charcoal);
+			color: var(--surface-bg);
+		}
+
+		.action-btn--primary {
+			background: transparent;
+			color: var(--alt-primary);
+			box-shadow: inset 0 3px 0 var(--alt-primary);
+		}
+
+		.action-btn--primary:hover:not(:disabled) {
+			background: transparent;
+			color: var(--alt-primary);
+		}
+
+		.action-btn--primary:active:not(:disabled) {
+			background: var(--alt-primary);
+			color: var(--surface-bg);
+		}
+
+		.action-btn--error {
+			color: var(--alt-terracotta);
+			box-shadow: inset 0 3px 0 var(--alt-terracotta);
+		}
+
+		/* Close lives in the header at this width. */
+		.action-btn--close {
+			display: none;
+		}
+
+		.btn-label--long {
+			display: none;
+		}
+
+		.btn-label--short {
+			display: inline;
+		}
+
+		/*
+		 * Header close: a 48px target flush to the modal's top-right corner, in
+		 * the same press-mark idiom as the swipe card's keep stamp — opaque paper
+		 * ground, hairline edges, no radius.
+		 */
+		.modal-close {
+			position: absolute;
+			top: 0;
+			right: 0;
+			z-index: 10;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 48px;
+			height: 48px;
+			background: var(--surface-bg);
+			border: none;
+			border-left: 1px solid var(--surface-border);
+			border-bottom: 1px solid var(--surface-border);
+			color: var(--alt-charcoal);
+			cursor: pointer;
+			touch-action: manipulation;
+		}
+
+		.modal-close:active {
+			background: var(--alt-charcoal);
+			color: var(--surface-bg);
+		}
+
 	}
 
 	.loading-pulse {

--- a/alt-frontend-sv/src/lib/components/desktop/feeds/FeedDetailModal.svelte
+++ b/alt-frontend-sv/src/lib/components/desktop/feeds/FeedDetailModal.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import { ChevronLeft, ChevronRight } from "@lucide/svelte";
+import { Dialog as DialogPrimitive } from "bits-ui";
+import { type Snippet, tick } from "svelte";
 import { getFeedContentOnTheFlyClient } from "$lib/api/client/articles";
 import RenderFeedDetails from "$lib/components/mobile/RenderFeedDetails.svelte";
-import { Dialog as DialogPrimitive } from "bits-ui";
 import {
 	createClientTransport,
 	streamSummarizeWithAbortAdapter,
 } from "$lib/connect";
-import { tick, type Snippet } from "svelte";
 import type { RenderFeed } from "$lib/schema/feed";
 import { articlePrefetcher } from "$lib/utils/articlePrefetcher";
 import {
@@ -398,7 +398,7 @@ async function handleSummarize(forceRefresh = false) {
 		<DialogPrimitive.Overlay class="fixed inset-0 z-50" style="background: rgba(0,0,0,0.5);" />
 		<DialogPrimitive.Content
 			preventScroll={false}
-			class="modal-content fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[88vw] sm:max-w-[1920px] h-[88vh] overflow-hidden flex flex-col z-50"
+			class="modal-content fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[94vw] h-[92vh] sm:w-[88vw] sm:max-w-[1920px] sm:h-[88vh] overflow-hidden flex flex-col z-50"
 		>
 			{#if hasPrevious}
 				<button
@@ -776,6 +776,65 @@ async function handleSummarize(forceRefresh = false) {
 	.action-btn--primary:hover:not(:disabled) {
 		background: var(--alt-charcoal);
 		border-color: var(--alt-charcoal);
+	}
+
+	/*
+	 * Phone width. This modal was only ever opened from the desktop grid, so its
+	 * 3rem gutters were free; reached from the mobile visual-preview gallery they
+	 * eat ~96px of a ~346px dialog and squeeze the article into a column too
+	 * narrow to read.
+	 *
+	 * The prev/next arrows go with them. They are vertically centred over the
+	 * body, so at this width they sit on top of the prose rather than beside it,
+	 * and the gallery behind the modal is itself the faster way to reach the next
+	 * article — closing and tapping costs one gesture more than the arrow did.
+	 */
+	@media (max-width: 640px) {
+		.nav-arrow {
+			display: none;
+		}
+
+		.modal-header {
+			padding: 1rem;
+		}
+
+		.modal-title {
+			font-size: 1.15rem;
+		}
+
+		.modal-body {
+			padding: 1rem;
+		}
+
+		.modal-article > :global(.content-section) {
+			padding: 1rem;
+		}
+
+		/*
+		 * Four buttons in one row do not fit 346px: they overflowed the dialog
+		 * and painted over each other. Stack the two groups instead, and let each
+		 * group split its row evenly — two rows of two, every button over the
+		 * 48px touch-target floor that the desktop 2.25rem row does not meet.
+		 */
+		.modal-footer {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.5rem;
+			padding: 0.75rem 1rem;
+			padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+		}
+
+		.modal-footer > div {
+			width: 100%;
+		}
+
+		/* `:global` because one of these is the caller's `footerActions` snippet,
+		   which carries the parent component's style scope, not this one's. */
+		.modal-footer > div > :global(*) {
+			flex: 1 1 0;
+			min-width: 0;
+			min-height: 48px;
+		}
 	}
 
 	.action-btn--error {

--- a/alt-frontend-sv/src/lib/components/desktop/feeds/FeedGrid.svelte
+++ b/alt-frontend-sv/src/lib/components/desktop/feeds/FeedGrid.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-export type { RemoveFeedResult, FeedGridApi } from "./feed-grid-types";
+export type { FeedGridApi, RemoveFeedResult } from "./feed-grid-types";
 </script>
 
 <script lang="ts">
@@ -20,11 +20,13 @@ export type { RemoveFeedResult, FeedGridApi } from "./feed-grid-types";
 		fetchFn?: (cursor?: string, limit?: number) => Promise<import("$lib/api").CursorResponse<RenderFeed>>;
 		cardRenderer?: Snippet<[{ feed: RenderFeed; index: number; isRead: boolean; onSelect: (feed: RenderFeed) => void }]>;
 		gridClass?: string;
+		/** data-testid for the grid element itself, so a caller can assert its layout. */
+		gridTestId?: string;
 		emptyText?: string;
 		loadingText?: string;
 	}
 
-	let { onSelectFeed, unreadOnly = false, sortBy = "date_desc", excludedFeedLinkIds = [], onReady, fetchFn, cardRenderer, gridClass = "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4", emptyText = "No dispatches on the wire", loadingText = "Retrieving dispatches" }: Props = $props();
+	let { onSelectFeed, unreadOnly = false, sortBy = "date_desc", excludedFeedLinkIds = [], onReady, fetchFn, cardRenderer, gridClass = "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4", gridTestId, emptyText = "No dispatches on the wire", loadingText = "Retrieving dispatches" }: Props = $props();
 
 	// Track initial load completion to only animate first batch
 	let initialLoadDone = $state(false);
@@ -286,7 +288,7 @@ export type { RemoveFeedResult, FeedGridApi } from "./feed-grid-types";
 	{:else if visibleFeeds.length === 0}
 		<p class="empty-state">{emptyText}</p>
 	{:else}
-		<div class={gridClass}>
+		<div class={gridClass} data-testid={gridTestId}>
 			{#each visibleFeeds as feed, index (feed.id)}
 				<div class={initialLoadDone ? "" : "dispatch-item"} style={initialLoadDone ? "" : `--stagger: ${index};`}>
 					{#if cardRenderer}
@@ -306,6 +308,8 @@ export type { RemoveFeedResult, FeedGridApi } from "./feed-grid-types";
 				rootMargin: "0px 0px 200px 0px",
 			}}
 			class="load-more"
+			role="status"
+			aria-live="polite"
 		>
 			{#if isFetchingNextPage}
 				<div class="loading-state">

--- a/alt-frontend-sv/src/lib/components/desktop/feeds/VisualFeedCard.svelte
+++ b/alt-frontend-sv/src/lib/components/desktop/feeds/VisualFeedCard.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import { Eye } from "@lucide/svelte";
-import { onDestroy } from "svelte";
 import type { RenderFeed } from "$lib/schema/feed";
 import { cn } from "$lib/utils";
-import { loadProxyImageDefault } from "$lib/utils/loadProxyImage";
+import { createProxyImage } from "$lib/utils/proxyImage.svelte";
 
 interface Props {
 	feed: RenderFeed;
@@ -16,83 +15,11 @@ let { feed, onSelect, isRead = false }: Props = $props();
 // idle/loading -> shimmer; loaded -> <img>; absent -> fallback gradient.
 // A transient rate-limit (429) is retried inside the loader and stays "loading",
 // so it never collapses to the fallback the way a sticky onerror used to.
-type ImageState = "idle" | "loading" | "loaded" | "absent";
-
-let imageState = $state<ImageState>("idle");
-let objectUrl = $state<string | null>(null);
-let inView = $state(false);
 let imageContainer = $state<HTMLElement | null>(null);
 
-// Non-reactive bookkeeping for cleanup / one-shot loading.
-let trackedUrl: string | null = null;
-let revokeUrl: string | null = null;
-let loadStartedForUrl: string | null = null;
-let abortController: AbortController | null = null;
-
-function reset() {
-	abortController?.abort();
-	abortController = null;
-	if (revokeUrl) {
-		URL.revokeObjectURL(revokeUrl);
-		revokeUrl = null;
-	}
-	objectUrl = null;
-	loadStartedForUrl = null;
-	imageState = "idle";
-}
-
-// Reset when the proxy URL changes (raw -> proxy URL, or a replacement feed).
-$effect(() => {
-	const url = feed.ogImageProxyUrl ?? null;
-	if (url !== trackedUrl) {
-		trackedUrl = url;
-		reset();
-	}
-});
-
-// Observe viewport entry once; only in-view cards consume host rate-limit budget.
-$effect(() => {
-	const el = imageContainer;
-	if (!el || inView) return;
-	const io = new IntersectionObserver(
-		(entries) => {
-			if (entries.some((e) => e.isIntersecting)) {
-				inView = true;
-				io.disconnect();
-			}
-		},
-		{ rootMargin: "200px" },
-	);
-	io.observe(el);
-	return () => io.disconnect();
-});
-
-// Drive the load once the card is in view (status-aware, retrying loader).
-$effect(() => {
-	const url = feed.ogImageProxyUrl;
-	if (!url || !inView || loadStartedForUrl === url) return;
-
-	loadStartedForUrl = url;
-	imageState = "loading";
-	const ac = new AbortController();
-	abortController = ac;
-
-	loadProxyImageDefault(url, ac.signal).then((result) => {
-		if (ac.signal.aborted) return;
-		if (result.status === "loaded") {
-			if (revokeUrl) URL.revokeObjectURL(revokeUrl);
-			revokeUrl = result.objectUrl;
-			objectUrl = result.objectUrl;
-			imageState = "loaded";
-		} else {
-			imageState = "absent";
-		}
-	});
-});
-
-onDestroy(() => {
-	abortController?.abort();
-	if (revokeUrl) URL.revokeObjectURL(revokeUrl);
+const image = createProxyImage({
+	url: () => feed.ogImageProxyUrl,
+	container: () => imageContainer,
 });
 
 function handleClick() {
@@ -121,16 +48,16 @@ const tags = $derived(
 		class="relative aspect-video overflow-hidden bg-[var(--surface-hover)]"
 		bind:this={imageContainer}
 	>
-		{#if !feed.ogImageProxyUrl || imageState === "absent"}
+		{#if !feed.ogImageProxyUrl || image.state === "absent"}
 			<!-- Fallback gradient: no image exists, or every retry was exhausted -->
 			<div
 				data-testid="image-fallback"
 				class="absolute inset-0 fallback-gradient"
 			></div>
-		{:else if imageState === "loaded" && objectUrl}
+		{:else if image.state === "loaded" && image.objectUrl}
 			<img
 				data-testid="card-image"
-				src={objectUrl}
+				src={image.objectUrl}
 				alt=""
 				class="w-full h-full object-cover"
 			/>

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/gallery/MobileGalleryTile.svelte
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/gallery/MobileGalleryTile.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+/**
+ * A single tile in the mobile visual-preview gallery.
+ *
+ * Layout follows the mobile-list research rather than the desktop card: at half
+ * a phone's width, a list-style thumbnail is too small to be recognisable, so
+ * the image runs the full tile width at 16:9 — the ratio OG images are actually
+ * authored at, which keeps the crop close to nothing — and the title is the only
+ * prose under it. No excerpt, no author line, no tag row: each of those costs
+ * image height, and the image is what the reader is scanning here.
+ */
+import type { RenderFeed } from "$lib/schema/feed";
+import { formatCompactDate } from "$lib/utils/feed";
+import { createProxyImage } from "$lib/utils/proxyImage.svelte";
+
+interface Props {
+	feed: RenderFeed;
+	onSelect: (feed: RenderFeed) => void;
+	isRead?: boolean;
+}
+
+const { feed, onSelect, isRead = false }: Props = $props();
+
+let imageContainer = $state<HTMLElement | null>(null);
+
+const image = createProxyImage({
+	url: () => feed.ogImageProxyUrl,
+	container: () => imageContainer,
+});
+
+const showFallback = $derived(
+	!feed.ogImageProxyUrl || image.state === "absent",
+);
+
+// The shared `publishedAtFormatted` carries a time of day, which wraps to a
+// second line at half a phone's width and pulls weight away from the image.
+const dateline = $derived(
+	formatCompactDate(feed.created_at || feed.published) ||
+		feed.publishedAtFormatted,
+);
+</script>
+
+<button
+  type="button"
+  class="gallery-tile"
+  data-testid="gallery-tile"
+  data-read={isRead}
+  aria-label="Open {feed.title}"
+  onclick={() => onSelect(feed)}
+>
+  <div class="tile-image-area" bind:this={imageContainer}>
+    {#if showFallback}
+      <div class="tile-fallback" data-testid="tile-image-fallback">
+        <span class="tile-fallback-text">No preview</span>
+      </div>
+    {:else if image.state === "loaded" && image.objectUrl}
+      <img
+        data-testid="tile-image"
+        src={image.objectUrl}
+        alt=""
+        decoding="async"
+        class="tile-image"
+      />
+    {:else}
+      <div class="tile-shimmer" data-testid="tile-image-loading"></div>
+    {/if}
+
+    {#if !isRead}
+      <span class="unread-dot" data-testid="tile-unread-dot"></span>
+    {/if}
+  </div>
+
+  <div class="tile-text">
+    <h3 class="tile-title" data-testid="tile-title">{feed.title}</h3>
+    {#if dateline}
+      <p class="tile-meta">{dateline}</p>
+    {/if}
+  </div>
+</button>
+
+<style>
+  /* height:100% + a two-line title reservation keeps both tiles in a row the
+     same height. Without it a one-word headline next to a wrapping one leaves a
+     ragged edge down the middle of the gallery, and the ragged edge is what the
+     eye tracks instead of the images. */
+  .gallery-tile {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    text-align: left;
+    padding: 0;
+    background: var(--surface-bg);
+    border: 1px solid var(--surface-border);
+    cursor: pointer;
+    touch-action: manipulation;
+    transition: opacity 0.15s, border-color 0.15s;
+  }
+
+  /* Read tiles recede rather than disappear: the gallery is also how a reader
+     confirms they have already been somewhere. */
+  .gallery-tile[data-read="true"] {
+    opacity: 0.55;
+  }
+
+  .gallery-tile:active {
+    border-color: var(--alt-primary);
+  }
+
+  /* ── Image ──
+     16:9 matches the ratio OG images are authored at (1.91:1 is close enough
+     that `cover` crops only a sliver), so the thumbnail shows what the
+     publisher framed rather than a centre crop of it. */
+  .tile-image-area {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    background: var(--surface-hover);
+  }
+
+  .tile-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .tile-fallback {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(
+      135deg,
+      var(--surface-hover) 0%,
+      var(--surface-bg) 100%
+    );
+  }
+
+  .tile-fallback-text {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--alt-ash);
+  }
+
+  .tile-shimmer {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.03) 25%,
+      rgba(0, 0, 0, 0.08) 50%,
+      rgba(0, 0, 0, 0.03) 75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+  }
+
+  /* Unread marker sits on the image, not in the text block, so the read/unread
+     split is legible while scanning images at speed. */
+  .unread-dot {
+    position: absolute;
+    top: 0.4rem;
+    left: 0.4rem;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--alt-primary);
+    box-shadow: 0 0 0 2px var(--surface-bg);
+  }
+
+  /* ── Text ── */
+  .tile-text {
+    flex: 1;
+    padding: 0.5rem 0.5rem 0.6rem;
+  }
+
+  .tile-title {
+    font-family: var(--font-body);
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1.35;
+    /* Two lines are always reserved, so a short headline does not pull the
+       dateline up and misalign it against its neighbour. */
+    min-height: calc(2 * 1.35 * 0.8rem);
+    color: var(--text-primary);
+    margin: 0;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .gallery-tile[data-read="true"] .tile-title {
+    font-weight: 400;
+    color: var(--text-muted);
+  }
+
+  .tile-meta {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    margin: 0.3rem 0 0;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tile-shimmer {
+      animation: none;
+      opacity: 0.7;
+    }
+  }
+</style>

--- a/alt-frontend-sv/src/lib/components/mobile/feeds/gallery/MobileGalleryTile.svelte.spec.ts
+++ b/alt-frontend-sv/src/lib/components/mobile/feeds/gallery/MobileGalleryTile.svelte.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * MobileGalleryTile Component Tests
+ *
+ * The tile used by the mobile visual-preview gallery (`/feeds/visual-preview`
+ * at phone width). It is deliberately NOT a shrunken VisualFeedCard: at half a
+ * phone's width there is no room for an excerpt, an author line and a tag row
+ * without pushing the image down to a size NN/g's mobile-list research says
+ * stops being useful. The image leads; the title is the only prose.
+ *
+ * The four-state image pipeline (idle -> loading -> loaded | absent) is shared
+ * with VisualFeedCard via `createProxyImage`, and the same distinction matters
+ * here: a transient 429 is retried *inside* the loader and must keep the
+ * shimmer rather than collapsing to the fallback.
+ */
+import { page } from "@vitest/browser/context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+
+import type { RenderFeed } from "$lib/schema/feed";
+import { renderFeedFixture } from "../../../../../../tests/fixtures/feeds";
+import MobileGalleryTile from "./MobileGalleryTile.svelte";
+
+const { loadProxyImageDefault } = vi.hoisted(() => ({
+	loadProxyImageDefault: vi.fn(),
+}));
+
+vi.mock("$lib/utils/loadProxyImage", () => ({ loadProxyImageDefault }));
+
+const PROXY_URL = "/api/og-image?u=https%3A%2F%2Falt.ai%2Fog.png";
+
+const feedWithImage: RenderFeed = {
+	...renderFeedFixture,
+	ogImageProxyUrl: PROXY_URL,
+};
+
+/** A real blob URL backed by a 1x1 transparent GIF. */
+function createBlobUrl(): string {
+	const gif = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+	const bytes = Uint8Array.from(atob(gif), (char) => char.charCodeAt(0));
+	return URL.createObjectURL(new Blob([bytes], { type: "image/gif" }));
+}
+
+/** Let mount effects, the IntersectionObserver callback and microtasks settle. */
+function settle(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+describe("MobileGalleryTile", () => {
+	beforeEach(() => {
+		loadProxyImageDefault.mockReset();
+		loadProxyImageDefault.mockResolvedValue({ status: "absent" });
+	});
+
+	describe("content", () => {
+		it("renders the feed title", async () => {
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect: vi.fn() },
+			});
+
+			await expect
+				.element(page.getByTestId("tile-title"))
+				.toHaveTextContent("Daily AI Recap");
+		});
+
+		it("renders the formatted publish date", async () => {
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect: vi.fn() },
+			});
+
+			await expect.element(page.getByText("Dec 22, 2025")).toBeInTheDocument();
+		});
+
+		it("omits the excerpt so the thumbnail keeps the vertical budget", async () => {
+			// Half-width tiles: an excerpt here costs image height, which is the
+			// one thing the gallery exists to show. This is a design constraint,
+			// not an oversight, so it is pinned.
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect: vi.fn() },
+			});
+
+			await expect.element(page.getByTestId("tile-title")).toBeInTheDocument();
+			await expect
+				.element(page.getByText(/most important AI breakthroughs/))
+				.not.toBeInTheDocument();
+		});
+	});
+
+	describe("read state", () => {
+		it("marks the tile as read", async () => {
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, isRead: true, onSelect: vi.fn() },
+			});
+
+			await expect
+				.element(page.getByTestId("gallery-tile"))
+				.toHaveAttribute("data-read", "true");
+			await expect
+				.element(page.getByTestId("tile-unread-dot"))
+				.not.toBeInTheDocument();
+		});
+
+		it("shows the unread marker when the feed is unread", async () => {
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, isRead: false, onSelect: vi.fn() },
+			});
+
+			await expect
+				.element(page.getByTestId("gallery-tile"))
+				.toHaveAttribute("data-read", "false");
+			await expect
+				.element(page.getByTestId("tile-unread-dot"))
+				.toBeInTheDocument();
+		});
+
+		it("defaults to unread when isRead is omitted", async () => {
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect: vi.fn() },
+			});
+
+			await expect
+				.element(page.getByTestId("gallery-tile"))
+				.toHaveAttribute("data-read", "false");
+		});
+	});
+
+	describe("selection", () => {
+		it("exposes the whole tile as a button labelled with the feed title", async () => {
+			// The image carries no alt text — it is decorative next to the title —
+			// so the tile's own label is the only accessible name a screen-reader
+			// user gets for the target.
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect: vi.fn() },
+			});
+
+			await expect
+				.element(page.getByRole("button", { name: "Open Daily AI Recap" }))
+				.toBeInTheDocument();
+		});
+
+		it("calls onSelect with the feed when tapped", async () => {
+			const onSelect = vi.fn();
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect },
+			});
+
+			await page.getByRole("button", { name: "Open Daily AI Recap" }).click();
+
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onSelect).toHaveBeenCalledWith(renderFeedFixture);
+		});
+	});
+
+	describe("image pipeline", () => {
+		it("shows the fallback and never loads when the feed has no image", async () => {
+			render(MobileGalleryTile, {
+				props: { feed: renderFeedFixture, onSelect: vi.fn() },
+			});
+
+			await expect
+				.element(page.getByTestId("tile-image-fallback"))
+				.toBeInTheDocument();
+
+			await settle();
+			expect(loadProxyImageDefault).not.toHaveBeenCalled();
+		});
+
+		it("renders the image once the proxy load resolves", async () => {
+			const objectUrl = createBlobUrl();
+			loadProxyImageDefault.mockResolvedValue({ status: "loaded", objectUrl });
+
+			render(MobileGalleryTile, {
+				props: { feed: feedWithImage, onSelect: vi.fn() },
+			});
+
+			const image = page.getByTestId("tile-image");
+			await expect.element(image).toBeInTheDocument();
+			await expect.element(image).toHaveAttribute("src", objectUrl);
+			await expect
+				.element(page.getByTestId("tile-image-fallback"))
+				.not.toBeInTheDocument();
+
+			expect(loadProxyImageDefault).toHaveBeenCalledWith(
+				PROXY_URL,
+				expect.any(AbortSignal),
+			);
+		});
+
+		it("falls back when the proxy load resolves absent", async () => {
+			loadProxyImageDefault.mockResolvedValue({ status: "absent" });
+
+			render(MobileGalleryTile, {
+				props: { feed: feedWithImage, onSelect: vi.fn() },
+			});
+
+			// Observe the transition into "absent": the pre-load "idle" state also
+			// paints the fallback, so a bare retrying assertion would be satisfied
+			// by the first frame and prove nothing.
+			await vi.waitFor(() =>
+				expect(loadProxyImageDefault).toHaveBeenCalledTimes(1),
+			);
+			await expect
+				.element(page.getByTestId("tile-image-loading"))
+				.not.toBeInTheDocument();
+
+			await expect
+				.element(page.getByTestId("tile-image-fallback"))
+				.toBeInTheDocument();
+			await expect
+				.element(page.getByTestId("tile-image"))
+				.not.toBeInTheDocument();
+		});
+
+		it("keeps the shimmer while a load is in flight", async () => {
+			// Never resolves: models a 429 being retried with backoff inside the
+			// loader. Collapsing to the fallback here is the regression that
+			// PM-era sticky onerror handling caused on the desktop card.
+			loadProxyImageDefault.mockReturnValue(new Promise<never>(() => {}));
+
+			render(MobileGalleryTile, {
+				props: { feed: feedWithImage, onSelect: vi.fn() },
+			});
+
+			await vi.waitFor(() =>
+				expect(loadProxyImageDefault).toHaveBeenCalledTimes(1),
+			);
+
+			await expect
+				.element(page.getByTestId("tile-image-loading"))
+				.toBeInTheDocument();
+			await expect
+				.element(page.getByTestId("tile-image-fallback"))
+				.not.toBeInTheDocument();
+		});
+
+		it("aborts the superseded load when the feed's proxy URL changes", async () => {
+			loadProxyImageDefault.mockReturnValue(new Promise<never>(() => {}));
+
+			const { rerender } = render(MobileGalleryTile, {
+				props: { feed: feedWithImage, onSelect: vi.fn() },
+			});
+
+			await vi.waitFor(() =>
+				expect(loadProxyImageDefault).toHaveBeenCalledTimes(1),
+			);
+			const staleSignal = loadProxyImageDefault.mock
+				.calls[0]?.[1] as AbortSignal;
+
+			const nextUrl = "/api/og-image?u=https%3A%2F%2Falt.ai%2Fother.png";
+			await rerender({
+				feed: { ...feedWithImage, id: "feed-2", ogImageProxyUrl: nextUrl },
+			});
+
+			// A slow response for the previous feed must not paint into the
+			// recycled tile after the new one has been assigned.
+			await vi.waitFor(() => expect(staleSignal.aborted).toBe(true));
+			await vi.waitFor(() =>
+				expect(loadProxyImageDefault).toHaveBeenCalledTimes(2),
+			);
+			expect(loadProxyImageDefault).toHaveBeenLastCalledWith(
+				nextUrl,
+				expect.any(AbortSignal),
+			);
+		});
+	});
+
+	describe("cleanup", () => {
+		it("aborts an in-flight image load when destroyed", async () => {
+			loadProxyImageDefault.mockReturnValue(new Promise<never>(() => {}));
+
+			const { unmount } = render(MobileGalleryTile, {
+				props: { feed: feedWithImage, onSelect: vi.fn() },
+			});
+
+			await vi.waitFor(() =>
+				expect(loadProxyImageDefault).toHaveBeenCalledTimes(1),
+			);
+			const signal = loadProxyImageDefault.mock.calls[0]?.[1] as AbortSignal;
+			expect(signal.aborted).toBe(false);
+
+			unmount();
+
+			expect(signal.aborted).toBe(true);
+		});
+
+		it("revokes the object URL when destroyed", async () => {
+			const objectUrl = createBlobUrl();
+			loadProxyImageDefault.mockResolvedValue({ status: "loaded", objectUrl });
+			const revokeSpy = vi.spyOn(URL, "revokeObjectURL");
+
+			const { unmount } = render(MobileGalleryTile, {
+				props: { feed: feedWithImage, onSelect: vi.fn() },
+			});
+
+			await expect.element(page.getByTestId("tile-image")).toBeInTheDocument();
+
+			unmount();
+
+			expect(revokeSpy).toHaveBeenCalledWith(objectUrl);
+			revokeSpy.mockRestore();
+		});
+	});
+});

--- a/alt-frontend-sv/src/lib/config/navigation.test.ts
+++ b/alt-frontend-sv/src/lib/config/navigation.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-	NAV_TABS,
-	MOBILE_MENU_SECTIONS,
 	getVisibleMobileMenuSections,
+	MOBILE_MENU_SECTIONS,
+	NAV_TABS,
 } from "./navigation";
 
 describe("NAV_TABS", () => {
@@ -64,6 +64,16 @@ describe("MOBILE_MENU_SECTIONS", () => {
 		expect(hrefs).toContain("/stats");
 		expect(hrefs).toContain("/settings/feeds");
 		expect(hrefs).toContain("/admin/scraping-domains");
+	});
+
+	it("reaches the visual-preview gallery", () => {
+		// The route has a mobile layout of its own now (a two-column thumbnail
+		// gallery). Without a menu entry it is only reachable by typing the URL,
+		// which on a phone means not at all.
+		const hrefs = MOBILE_MENU_SECTIONS.flatMap((s) =>
+			s.items.map((i) => i.href),
+		);
+		expect(hrefs).toContain("/feeds/visual-preview");
 	});
 
 	it("does not duplicate primary tab destinations", () => {

--- a/alt-frontend-sv/src/lib/config/navigation.ts
+++ b/alt-frontend-sv/src/lib/config/navigation.ts
@@ -12,6 +12,7 @@ import {
 	Heart,
 	Home,
 	Infinity as InfinityIcon,
+	LayoutGrid,
 	Lightbulb,
 	Link as LinkIcon,
 	Menu,
@@ -71,6 +72,7 @@ export const MOBILE_MENU_SECTIONS: MobileMenuSection[] = [
 		title: "Browse",
 		items: [
 			{ label: "Library", href: "/feeds", icon: Rss },
+			{ label: "Gallery", href: "/feeds/visual-preview", icon: LayoutGrid },
 			{ label: "Swipe", href: "/feeds/swipe/visual-preview", icon: Rss },
 			{ label: "Swipe Mode", href: "/feeds/swipe", icon: InfinityIcon },
 			{ label: "Favorites", href: "/feeds/favorites", icon: Heart },

--- a/alt-frontend-sv/src/lib/utils/feed.test.ts
+++ b/alt-frontend-sv/src/lib/utils/feed.test.ts
@@ -1,11 +1,38 @@
 import { describe, expect, it } from "vitest";
 import {
 	canonicalize,
+	formatCompactDate,
 	formatPublishedDate,
 	generateExcerptFromDescription,
 	mergeTagsLabel,
 	normalizeUrl,
 } from "./feed";
+
+describe("formatCompactDate", () => {
+	it("drops the time of day", () => {
+		// A half-width gallery tile has room for a date or a datestamp, not both;
+		// "Aug 10, 2026, 11:09 PM" wraps onto a second line and competes with the
+		// title for a glance that is supposed to land on the image.
+		expect(formatCompactDate("2025-11-23T10:30:00Z")).toBe("Nov 23, 2025");
+	});
+
+	it("formats a date-only string", () => {
+		expect(formatCompactDate("2024-01-15")).toBe("Jan 15, 2024");
+	});
+
+	it("pins the timezone so SSR and hydration agree", () => {
+		// 23:30 UTC is the previous day in any negative offset. Pinning to UTC is
+		// what keeps the server's string and the browser's string identical.
+		expect(formatCompactDate("2025-11-23T23:30:00Z")).toBe("Nov 23, 2025");
+	});
+
+	it("returns empty string for missing or invalid input", () => {
+		expect(formatCompactDate(null)).toBe("");
+		expect(formatCompactDate(undefined)).toBe("");
+		expect(formatCompactDate("")).toBe("");
+		expect(formatCompactDate("not-a-date")).toBe("");
+	});
+});
 
 describe("formatPublishedDate", () => {
 	it("formats ISO date string with time correctly", () => {

--- a/alt-frontend-sv/src/lib/utils/feed.ts
+++ b/alt-frontend-sv/src/lib/utils/feed.ts
@@ -40,6 +40,43 @@ export function formatPublishedDate(
 }
 
 /**
+ * Formats a date string without the time of day.
+ *
+ * For surfaces where the dateline is a footnote rather than a fact the reader
+ * came for — the mobile gallery tile, where a full datestamp wraps onto a
+ * second line and takes weight away from the thumbnail it sits under.
+ *
+ * @param dateString - ISO date string or RFC3339 format
+ * @returns Formatted date string (e.g., "Nov 23, 2025")
+ */
+export function formatCompactDate(
+	dateString: string | undefined | null,
+): string {
+	if (!dateString) {
+		return "";
+	}
+
+	try {
+		const date = new Date(dateString);
+		if (Number.isNaN(date.getTime())) {
+			return "";
+		}
+
+		// `timeZone` pinned for the same reason as formatPublishedDate: an
+		// unpinned format renders one string on the server and another in the
+		// browser, and hydration reports the mismatch.
+		return date.toLocaleDateString("en-US", {
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+			timeZone: "UTC",
+		});
+	} catch {
+		return "";
+	}
+}
+
+/**
  * Merges tags array into a display label
  * @param tags - Array of tag strings
  * @returns Merged label (e.g., "Next.js / Performance")

--- a/alt-frontend-sv/src/lib/utils/proxyImage.svelte.ts
+++ b/alt-frontend-sv/src/lib/utils/proxyImage.svelte.ts
@@ -1,0 +1,139 @@
+/**
+ * Viewport-gated, status-aware OG image loading as a reusable rune.
+ *
+ * This is the four-state pipeline the visual feed surfaces share:
+ *
+ *   idle -> loading -> loaded | absent
+ *
+ * Two properties are the whole reason it exists as a unit rather than as
+ * per-component code:
+ *
+ *  - **Viewport gating.** The image proxy rate-limits per upstream host, so a
+ *    grid of same-host thumbnails will exhaust its budget if every card fetches
+ *    on mount. Only cards the reader can actually reach start a load.
+ *  - **"Loading" is not "absent".** A transient 429 is retried *inside*
+ *    `loadProxyImage`, and the caller must keep showing a shimmer while that
+ *    happens. Collapsing to the fallback on the first failure is the regression
+ *    that made mark-as-read blank out surviving cards on the desktop grid; the
+ *    `absent` state is reached only once the loader has given up for good.
+ *
+ * Must be called during component initialisation — it registers `$effect`s and
+ * an `onDestroy` hook against the calling component's lifecycle.
+ */
+import { onDestroy } from "svelte";
+import { loadProxyImageDefault } from "./loadProxyImage";
+
+export type ProxyImageState = "idle" | "loading" | "loaded" | "absent";
+
+export interface ProxyImageOptions {
+	/** Reactive getter for the proxy URL. A change restarts the pipeline. */
+	url: () => string | null | undefined;
+	/** Reactive getter for the element whose viewport entry gates the load. */
+	container: () => HTMLElement | null;
+	/** How early to start loading relative to the viewport. */
+	rootMargin?: string;
+	/** Injectable loader, for tests. */
+	load?: typeof loadProxyImageDefault;
+}
+
+export interface ProxyImage {
+	readonly state: ProxyImageState;
+	/** The object URL to render, once `state` is `"loaded"`. */
+	readonly objectUrl: string | null;
+}
+
+export function createProxyImage(options: ProxyImageOptions): ProxyImage {
+	const load = options.load ?? loadProxyImageDefault;
+	const rootMargin = options.rootMargin ?? "200px";
+
+	let state = $state<ProxyImageState>("idle");
+	let objectUrl = $state<string | null>(null);
+	let inView = $state(false);
+
+	// Non-reactive bookkeeping: these drive control flow inside the effects and
+	// must not re-trigger them.
+	let trackedUrl: string | null = null;
+	let revokeUrl: string | null = null;
+	let loadStartedForUrl: string | null = null;
+	let abortController: AbortController | null = null;
+
+	function reset() {
+		abortController?.abort();
+		abortController = null;
+		if (revokeUrl) {
+			URL.revokeObjectURL(revokeUrl);
+			revokeUrl = null;
+		}
+		objectUrl = null;
+		loadStartedForUrl = null;
+		state = "idle";
+	}
+
+	// Restart when the URL changes (raw -> proxy backfill, or a recycled card
+	// being handed a different feed). Ordered before the load effect below so a
+	// URL change resets first and re-loads second, within the same flush.
+	$effect(() => {
+		const url = options.url() ?? null;
+		if (url !== trackedUrl) {
+			trackedUrl = url;
+			reset();
+		}
+	});
+
+	// Observe viewport entry once; `inView` latches so scrolling back and forth
+	// does not re-enter the pipeline.
+	$effect(() => {
+		const el = options.container();
+		if (!el || inView) return;
+
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					inView = true;
+					io.disconnect();
+				}
+			},
+			{ rootMargin },
+		);
+		io.observe(el);
+		return () => io.disconnect();
+	});
+
+	$effect(() => {
+		const url = options.url();
+		if (!url || !inView || loadStartedForUrl === url) return;
+
+		loadStartedForUrl = url;
+		state = "loading";
+		const ac = new AbortController();
+		abortController = ac;
+
+		load(url, ac.signal).then((result) => {
+			// A superseded load must not paint into the card that has since been
+			// handed a different feed.
+			if (ac.signal.aborted) return;
+			if (result.status === "loaded") {
+				if (revokeUrl) URL.revokeObjectURL(revokeUrl);
+				revokeUrl = result.objectUrl;
+				objectUrl = result.objectUrl;
+				state = "loaded";
+			} else {
+				state = "absent";
+			}
+		});
+	});
+
+	onDestroy(() => {
+		abortController?.abort();
+		if (revokeUrl) URL.revokeObjectURL(revokeUrl);
+	});
+
+	return {
+		get state() {
+			return state;
+		},
+		get objectUrl() {
+			return objectUrl;
+		},
+	};
+}

--- a/alt-frontend-sv/src/routes/(app)/feeds/+page.svelte
+++ b/alt-frontend-sv/src/routes/(app)/feeds/+page.svelte
@@ -213,17 +213,9 @@ function handleFeedGridReady(api: FeedGridApi) {
 			onNext={handleNext}
 			feeds={feedGridApi?.getVisibleFeeds() ?? []}
 			{currentIndex}
-		>
-			{#snippet footerActions()}
-				<button
-					onclick={handleMarkAsReadInModal}
-					disabled={isMarkingAsRead || isProcessingMarkAsRead}
-					class="mark-read-btn"
-				>
-					{isMarkingAsRead ? "Marking\u2026" : "Mark as Read"}
-				</button>
-			{/snippet}
-		</FeedDetailModal>
+			onMarkAsRead={handleMarkAsReadInModal}
+			isMarkingAsRead={isMarkingAsRead || isProcessingMarkAsRead}
+		/>
 	</div>
 {:else}
 	<div style="background: var(--app-bg);" class="h-[100dvh] overflow-hidden flex flex-col">
@@ -299,36 +291,6 @@ function handleFeedGridReady(api: FeedGridApi) {
 		height: 1px;
 		background: var(--surface-border);
 		margin-top: 0.75rem;
-	}
-
-	.mark-read-btn {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		padding: 0.4rem 1rem;
-		min-height: 2.25rem;
-		font-family: var(--font-body);
-		font-size: 0.75rem;
-		font-weight: 600;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		color: var(--alt-charcoal);
-		background: transparent;
-		border: 1.5px solid var(--alt-charcoal);
-		cursor: pointer;
-		transition:
-			background 0.15s,
-			color 0.15s;
-	}
-
-	.mark-read-btn:hover:not(:disabled) {
-		background: var(--alt-charcoal);
-		color: var(--surface-bg);
-	}
-
-	.mark-read-btn:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/alt-frontend-sv/src/routes/(app)/feeds/visual-preview/+page.svelte
+++ b/alt-frontend-sv/src/routes/(app)/feeds/visual-preview/+page.svelte
@@ -11,6 +11,7 @@ import FeedGrid from "$lib/components/desktop/feeds/FeedGrid.svelte";
 import type { FeedGridApi } from "$lib/components/desktop/feeds/feed-grid-types";
 import VisualFeedCard from "$lib/components/desktop/feeds/VisualFeedCard.svelte";
 import PageHeader from "$lib/components/desktop/layout/PageHeader.svelte";
+import MobileGalleryTile from "$lib/components/mobile/feeds/gallery/MobileGalleryTile.svelte";
 import { Button } from "$lib/components/ui/button";
 import type { ConnectFeedSource } from "$lib/connect/feeds";
 import type { RenderFeed } from "$lib/schema/feed";
@@ -207,43 +208,85 @@ function handleFeedGridReady(api: FeedGridApi) {
 			<VisualFeedCard {feed} {isRead} {onSelect} />
 		{/snippet}
 	</FeedGrid>
-
-	<FeedDetailModal
-		bind:open={isModalOpen}
-		feed={selectedFeed}
-		onOpenChange={(open: boolean) => (isModalOpen = open)}
-		{hasPrevious}
-		{hasNext}
-		onPrevious={handlePrevious}
-		onNext={handleNext}
-		feeds={feedGridApi?.getVisibleFeeds() ?? []}
-		{currentIndex}
-	>
-		{#snippet footerActions()}
-			<Button
-				onclick={handleMarkAsReadInModal}
-				variant="outline"
-				disabled={isMarkingAsRead || isProcessingMarkAsRead}
-			>
-				{isMarkingAsRead ? "Marking..." : "Mark as Read"}
-			</Button>
-		{/snippet}
-	</FeedDetailModal>
 {:else}
-	<!-- Mobile: Redirect to swipe visual-preview -->
-	<div class="flex flex-col items-center justify-center py-24 text-center">
-		<p class="text-lg font-medium text-[var(--text-primary)] mb-2">
-			Visual Preview has a swipe interface on mobile
-		</p>
-		<p class="text-sm text-[var(--text-secondary)] mb-6">
-			Tap below to use the mobile-optimized experience.
-		</p>
-		<a
-			href="/feeds/swipe/visual-preview"
-			class="px-4 py-2 text-sm font-medium transition-colors hover:opacity-90"
-			style="background: var(--accent-primary); color: var(--accent-primary-foreground);"
-		>
-			Go to Swipe Visual Preview
-		</a>
-	</div>
+	<!--
+		Mobile: a vertically scrolling, two-column thumbnail gallery.
+
+		This used to be a hand-off notice pointing at the swipe screen, which made
+		the route a dead end on the device most of the reading happens on. Swipe is
+		a one-at-a-time judgment surface; this is the scanning surface — the reader
+		sees ~6 covers per screen and drills into one, which is a different job and
+		now has its own layout rather than a redirect.
+
+		Two columns rather than a list of small thumbnails: at half a phone's width
+		the image is still large enough to recognise, which is the threshold below
+		which list thumbnails stop earning their place.
+	-->
+	<header class="gallery-header">
+		<h1 class="gallery-title">Visual Preview</h1>
+		<p class="gallery-subtitle">Browse feeds by their cover</p>
+	</header>
+
+	<FeedGrid
+		onSelectFeed={handleSelectFeed}
+		unreadOnly={filters.unreadOnly}
+		sortBy={filters.sortBy}
+		excludedFeedLinkIds={filters.excludedFeedLinkIds}
+		onReady={handleFeedGridReady}
+		gridClass="grid grid-cols-2 gap-2"
+		gridTestId="gallery-grid"
+	>
+		{#snippet cardRenderer({ feed, isRead, onSelect }: { feed: RenderFeed; index: number; isRead: boolean; onSelect: (feed: RenderFeed) => void })}
+			<MobileGalleryTile {feed} {isRead} {onSelect} />
+		{/snippet}
+	</FeedGrid>
 {/if}
+
+<!--
+	Shared by both layouts. Opening the article in a modal rather than navigating
+	is what keeps the reader's place: the gallery grows by infinite scroll, so a
+	round-trip to a detail route and back would drop them at the top of a list
+	that no longer contains the items they had already scrolled past.
+-->
+<FeedDetailModal
+	bind:open={isModalOpen}
+	feed={selectedFeed}
+	onOpenChange={(open: boolean) => (isModalOpen = open)}
+	{hasPrevious}
+	{hasNext}
+	onPrevious={handlePrevious}
+	onNext={handleNext}
+	feeds={feedGridApi?.getVisibleFeeds() ?? []}
+	{currentIndex}
+>
+	{#snippet footerActions()}
+		<Button
+			onclick={handleMarkAsReadInModal}
+			variant="outline"
+			disabled={isMarkingAsRead || isProcessingMarkAsRead}
+		>
+			{isMarkingAsRead ? "Marking..." : "Mark as Read"}
+		</Button>
+	{/snippet}
+</FeedDetailModal>
+
+<style>
+	.gallery-header {
+		padding: 0.75rem 0 1rem;
+	}
+
+	.gallery-title {
+		font-family: var(--font-display);
+		font-size: 1.35rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.gallery-subtitle {
+		font-family: var(--font-body);
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		margin: 0.2rem 0 0;
+	}
+</style>

--- a/alt-frontend-sv/src/routes/(app)/feeds/visual-preview/+page.svelte
+++ b/alt-frontend-sv/src/routes/(app)/feeds/visual-preview/+page.svelte
@@ -12,7 +12,6 @@ import type { FeedGridApi } from "$lib/components/desktop/feeds/feed-grid-types"
 import VisualFeedCard from "$lib/components/desktop/feeds/VisualFeedCard.svelte";
 import PageHeader from "$lib/components/desktop/layout/PageHeader.svelte";
 import MobileGalleryTile from "$lib/components/mobile/feeds/gallery/MobileGalleryTile.svelte";
-import { Button } from "$lib/components/ui/button";
 import type { ConnectFeedSource } from "$lib/connect/feeds";
 import type { RenderFeed } from "$lib/schema/feed";
 import { useViewport } from "$lib/stores/viewport.svelte";
@@ -258,17 +257,9 @@ function handleFeedGridReady(api: FeedGridApi) {
 	onNext={handleNext}
 	feeds={feedGridApi?.getVisibleFeeds() ?? []}
 	{currentIndex}
->
-	{#snippet footerActions()}
-		<Button
-			onclick={handleMarkAsReadInModal}
-			variant="outline"
-			disabled={isMarkingAsRead || isProcessingMarkAsRead}
-		>
-			{isMarkingAsRead ? "Marking..." : "Mark as Read"}
-		</Button>
-	{/snippet}
-</FeedDetailModal>
+	onMarkAsRead={handleMarkAsReadInModal}
+	isMarkingAsRead={isMarkingAsRead || isProcessingMarkAsRead}
+/>
 
 <style>
 	.gallery-header {

--- a/alt-frontend-sv/tests/e2e/mobile/feeds/visual-preview-gallery.spec.ts
+++ b/alt-frontend-sv/tests/e2e/mobile/feeds/visual-preview-gallery.spec.ts
@@ -1,0 +1,99 @@
+import {
+	CONNECT_FEEDS_RESPONSE,
+	CONNECT_READ_FEEDS_EMPTY_RESPONSE,
+	CONNECT_RPC_PATHS,
+} from "../../fixtures/mockData";
+import { expect, test } from "../../fixtures/pomFixtures";
+import { gotoMobileRoute } from "../../helpers/navigation";
+import { fulfillJson } from "../../utils/mockHelpers";
+
+const SUBSCRIPTIONS_EMPTY = { subscriptions: [] };
+const LIST_SUBSCRIPTIONS =
+	"**/api/v2/alt.feeds.v2.FeedService/ListSubscriptions";
+
+/**
+ * `/feeds/visual-preview` on a phone.
+ *
+ * The mobile branch of this route used to be a dead end — a paragraph telling
+ * the reader to go use the swipe screen instead. It is now a two-column,
+ * vertically scrolling gallery of thumbnails, which is the layout NN/g's
+ * mobile-list research points to when the image is the thing being scanned
+ * (a 2-column grid of images, not a list of tiny thumbnails).
+ *
+ * Two properties are load-bearing and asserted here rather than left to the
+ * component specs, because both only exist once the route, the grid and the
+ * real viewport are combined:
+ *  - the grid actually resolves to TWO columns at phone width;
+ *  - tapping a tile opens the detail modal *in place*, which is what keeps the
+ *    reader's scroll position in a list that grows by infinite scroll.
+ */
+test.describe("mobile feeds — visual preview gallery", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.route(CONNECT_RPC_PATHS.getAllFeeds, (route) =>
+			fulfillJson(route, CONNECT_FEEDS_RESPONSE),
+		);
+		await page.route(CONNECT_RPC_PATHS.getUnreadFeeds, (route) =>
+			fulfillJson(route, CONNECT_FEEDS_RESPONSE),
+		);
+		await page.route(CONNECT_RPC_PATHS.getReadFeeds, (route) =>
+			fulfillJson(route, CONNECT_READ_FEEDS_EMPTY_RESPONSE),
+		);
+		await page.route(LIST_SUBSCRIPTIONS, (route) =>
+			fulfillJson(route, SUBSCRIPTIONS_EMPTY),
+		);
+		await page.route(CONNECT_RPC_PATHS.fetchArticleContent, (route) =>
+			fulfillJson(route, { content: "", articleId: "", url: "" }),
+		);
+	});
+
+	test("renders the feeds as thumbnail tiles instead of the swipe hand-off", async ({
+		page,
+	}) => {
+		await gotoMobileRoute(page, "feeds/visual-preview");
+
+		const tiles = page.getByTestId("gallery-tile");
+		await expect(tiles).toHaveCount(2);
+		await expect(tiles.first()).toBeVisible();
+
+		await expect(page.getByText("AI Trends")).toBeVisible();
+		await expect(page.getByText("Svelte 5 Tips")).toBeVisible();
+
+		// The old mobile branch was a redirect notice. It must be gone.
+		await expect(
+			page.getByRole("link", { name: /swipe visual preview/i }),
+		).toHaveCount(0);
+	});
+
+	test("lays the gallery out in two columns at phone width", async ({
+		page,
+	}) => {
+		await gotoMobileRoute(page, "feeds/visual-preview");
+		await expect(page.getByTestId("gallery-tile").first()).toBeVisible();
+
+		// Read the resolved track list rather than trusting the class name: a
+		// utility class that silently stops applying is exactly the failure this
+		// spec exists to catch.
+		const columns = await page
+			.getByTestId("gallery-grid")
+			.evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(" "));
+
+		expect(columns).toHaveLength(2);
+	});
+
+	test("opens the detail modal in place when a tile is tapped", async ({
+		page,
+	}) => {
+		await gotoMobileRoute(page, "feeds/visual-preview");
+
+		await page.getByRole("button", { name: "Open AI Trends" }).click();
+
+		const dialog = page.getByRole("dialog");
+		await expect(dialog).toBeVisible();
+		await expect(
+			dialog.getByRole("heading", { name: "AI Trends" }),
+		).toBeVisible();
+
+		// Still on the gallery route — no navigation, so no scroll position lost.
+		expect(new URL(page.url()).pathname).toContain("/feeds/visual-preview");
+	});
+});

--- a/alt-frontend-sv/tests/e2e/mobile/feeds/visual-preview-gallery.spec.ts
+++ b/alt-frontend-sv/tests/e2e/mobile/feeds/visual-preview-gallery.spec.ts
@@ -96,4 +96,85 @@ test.describe("mobile feeds — visual preview gallery", () => {
 		// Still on the gallery route — no navigation, so no scroll position lost.
 		expect(new URL(page.url()).pathname).toContain("/feeds/visual-preview");
 	});
+
+	/**
+	 * The detail modal's footer is the part of this surface that a phone punishes
+	 * hardest: four desktop-sized buttons in a row do not fit 346px, and the first
+	 * attempt at fixing that — stacking them into two rows of slabs — traded an
+	 * overflow bug for a footer that ate a fifth of the screen and shouted.
+	 *
+	 * Alt-Paper is an editorial print language: hairline rules, small-caps mono,
+	 * ink instead of fills. The footer is one rule-divided rail, and these assert
+	 * the properties that make it that rather than a stack of buttons.
+	 */
+	test.describe("detail modal footer at phone width", () => {
+		test.beforeEach(async ({ page }) => {
+			await gotoMobileRoute(page, "feeds/visual-preview");
+			await page.getByRole("button", { name: "Open AI Trends" }).click();
+			await expect(page.getByRole("dialog")).toBeVisible();
+		});
+
+		test("keeps every action on a single compact rail", async ({ page }) => {
+			const footer = page.getByTestId("modal-footer");
+			await expect(footer).toBeVisible();
+
+			const tops = await footer
+				.getByRole("button")
+				.evaluateAll((els) =>
+					els.map((el) => Math.round(el.getBoundingClientRect().top)),
+				);
+			expect(tops.length).toBeGreaterThan(1);
+			// One distinct top offset = one row.
+			expect(new Set(tops).size).toBe(1);
+
+			const box = (await footer.boundingBox())!;
+			expect(box.height).toBeLessThanOrEqual(72);
+		});
+
+		test("does not overflow the dialog", async ({ page }) => {
+			// The original defect: the footer's buttons ran past the dialog's edge
+			// and painted over one another.
+			const dialogBox = (await page.getByRole("dialog").boundingBox())!;
+			const footerBox = (await page.getByTestId("modal-footer").boundingBox())!;
+
+			expect(footerBox.width).toBeLessThanOrEqual(dialogBox.width + 1);
+			expect(footerBox.x + footerBox.width).toBeLessThanOrEqual(
+				dialogBox.x + dialogBox.width + 1,
+			);
+		});
+
+		test("keeps each action over the 48px touch-target floor", async ({
+			page,
+		}) => {
+			const heights = await page
+				.getByTestId("modal-footer")
+				.getByRole("button")
+				.evaluateAll((els) =>
+					els.map((el) => el.getBoundingClientRect().height),
+				);
+
+			expect(heights.length).toBeGreaterThan(1);
+			for (const height of heights) {
+				expect(height).toBeGreaterThanOrEqual(48);
+			}
+		});
+
+		test("moves Close out of the rail and into the header", async ({
+			page,
+		}) => {
+			// Four actions do not fit a phone rail. Close is the one that belongs in
+			// the header — it is the modal's chrome, not a reading action.
+			const dialog = page.getByRole("dialog");
+			await expect(
+				page
+					.getByTestId("modal-footer")
+					.getByRole("button", { name: /^Close$/i }),
+			).toHaveCount(0);
+
+			const close = dialog.getByTestId("modal-close");
+			await expect(close).toBeVisible();
+			await close.click();
+			await expect(dialog).toBeHidden();
+		});
+	});
 });


### PR DESCRIPTION
`/feeds/visual-preview` のモバイル分岐は「Swipe 版へどうぞ」という案内文
だけで、読書が最も行われる端末で行き止まりになっていた。ここを、サムネイル
を縦スクロールで一覧する 2 カラムのギャラリーに置き換える。

Swipe は 1 件ずつ判断する面、ギャラリーは走査する面という別の役割なので、
リダイレクトではなく専用のレイアウトを持たせる。

レイアウトの根拠 (NN/g のモバイルリスト調査 / Material 3):
- 縦リストに小さいサムネを並べる形は画像が判別できず機能しない。画像が判断
  材料になる場合は 2 カラムグリッドが適する。半画面幅なら認識可能な大きさを
  保てる。
- 画像は 16:9。OG 画像が実際に author される比率 (1.91:1) に近く、cover での
  クロップがほとんど発生しない。
- ガター 8px、タップ対象はタイル全体。
- タイルは excerpt / author / タグを持たない。半画面幅ではそれらが画像の高さを
  削るため、タイトル 2 行のみをテキストとする。

タップは画面遷移ではなく詳細モーダルを開く。ギャラリーは無限スクロールで
伸びるので、詳細ルートへ往復するとスクロール位置を失うため。

付随する変更:
- OG 画像の 4 状態パイプライン (idle -> loading -> loaded | absent) を
  `createProxyImage` として抽出し、VisualFeedCard と共有。過渡的な 429 を
  fallback に潰さない挙動を 2 箇所に複製しない。
- FeedDetailModal を 640px 以下で使えるように調整。3rem のガターと 4 つ横並び
  のフッターが幅を溢れてボタン同士が重なっていた。prev/next 矢印は本文の上に
  重なるため非表示にし、フッターは 2 行 2 列、各ボタン 48px 以上とする。
- `formatCompactDate` を追加。共有の datestamp は時刻を含み、半画面幅で 2 行に
  折り返してタイトルと重みを争うため。
- モバイルメニューに Gallery を追加。導線がないと URL 直打ちでしか到達できない。

Tests: E2E (mobile-chrome) 3 件、コンポーネント 15 件、ユニット 5 件を追加。
`bun run check` 0 errors、server 1344 / client 470 / e2e 93 すべて green。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vzu98T7V7SvThkoH8cygZR