### PR TITLE
fix(alt-backend): repair 12 Medium findings from the adversarial review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ argocd/
 x-setup/
 auth-service/deployments/k8s/base/kratos-secrets.yaml
 kratos/kratos.yml
+kratos/kratos.yml.bak
 
 # ============================================
 # Load testing

--- a/acolyte-orchestrator/acolyte/gateway/postgres_report_gw.py
+++ b/acolyte-orchestrator/acolyte/gateway/postgres_report_gw.py
@@ -20,6 +20,16 @@ logger = structlog.get_logger(__name__)
 # Re-export for callers that historically imported from this module.
 __all__ = ["PostgresReportGateway", "StaleVersionError"]
 
+# LangGraph writes a checkpoint per super-step (article bodies included) into
+# tables AsyncPostgresSaver.setup() creates — they are outside Atlas and carry
+# no FK to reports, so nothing but this gateway ever reclaims them. Same three
+# tables AsyncPostgresSaver.adelete_thread() clears, in FK-safe order.
+_CHECKPOINT_TABLES = ("checkpoint_writes", "checkpoint_blobs", "checkpoints")
+
+# Must stay in step with AcolyteConnectService._thread_id_for_run: the
+# checkpoint namespace is derived from run_id and is the only link back.
+_THREAD_ID_PREFIX = "acolyte-run:"
+
 
 class PostgresReportGateway:
     """Report CRUD and versioning backed by PostgreSQL."""
@@ -330,8 +340,38 @@ class PostgresReportGateway:
             return bool(r and r[0])
 
     async def delete_report(self, report_id: UUID) -> None:
-        async with self._pool.connection() as conn:
+        async with self._pool.connection() as conn, conn.transaction():
+            # Read the runs first: DELETE FROM reports cascades report_runs away,
+            # and afterwards nothing can tell which checkpoint threads were this
+            # report's. Same transaction so the purge commits with the delete.
+            cur = await conn.execute("SELECT run_id FROM report_runs WHERE report_id = %s", [report_id])
+            thread_ids = [f"{_THREAD_ID_PREFIX}{r[0]}" for r in await cur.fetchall()]
+            if thread_ids:
+                await self._purge_checkpoint_threads(conn, thread_ids)
             await conn.execute("DELETE FROM reports WHERE report_id = %s", [report_id])
+
+    async def _purge_checkpoint_threads(self, conn: object, thread_ids: list[str]) -> None:
+        """Drop the LangGraph checkpoints of these threads inside the caller's transaction."""
+        cur = await conn.execute("SELECT to_regclass('checkpoints') IS NOT NULL")  # type: ignore[attr-defined]
+        row = await cur.fetchone()
+        if row is None or not row[0]:
+            # CHECKPOINT_ENABLED=false never calls setup(), so the tables do not
+            # exist and there is nothing to reclaim — but the delete must still
+            # go through. Logged rather than swallowed: with checkpointing on,
+            # this line means setup() never ran against this database.
+            logger.info(
+                "checkpoint_purge_skipped",
+                reason="langgraph checkpoint tables absent in acolyte-db",
+                thread_count=len(thread_ids),
+            )
+            return
+
+        for table in _CHECKPOINT_TABLES:
+            await conn.execute(  # type: ignore[attr-defined]
+                f"DELETE FROM {table} WHERE thread_id = ANY(%s)",  # noqa: S608 — table names are the module constant, never input
+                [thread_ids],
+            )
+        logger.info("checkpoint_purged", thread_count=len(thread_ids))
 
     async def get_section_version(self, report_id: UUID, section_key: str, version_no: int) -> SectionVersion | None:
         async with self._pool.connection() as conn:

--- a/acolyte-orchestrator/acolyte/handler/connect_service.py
+++ b/acolyte-orchestrator/acolyte/handler/connect_service.py
@@ -17,7 +17,7 @@ from acolyte.gen.proto.alt.acolyte.v1 import acolyte_pb2
 from acolyte.usecase.create_report_uc import CreateReportUsecase
 from acolyte.usecase.get_report_uc import GetReportUsecase
 from acolyte.usecase.list_reports_uc import ListReportsUsecase
-from acolyte.usecase.rerun_section_uc import RerunSectionUsecase
+from acolyte.usecase.rerun_section_uc import RerunRejectedError, RerunSectionUsecase
 from acolyte.usecase.start_run_uc import StartRunRejectedError, StartRunUsecase
 
 if TYPE_CHECKING:
@@ -398,6 +398,13 @@ class AcolyteConnectService:
             # Typed error raised from a lower layer (e.g. the usecase
             # re-mapping a repo ValueError). Preserve the code untouched.
             raise
+        except RerunRejectedError as e:
+            # An expected precondition, not a fault: a generation run owns the
+            # report and the caller can retry once it finishes. Falling through
+            # to the handler below would return INTERNAL and log a traceback
+            # into the error-rate SLI. delete_report answers the identical
+            # has_active_run check the same way.
+            raise ConnectError(Code.FAILED_PRECONDITION, str(e)) from e
         except Exception as exc:
             # Last-line visibility so a 500 still ships a traceback to
             # the structured log instead of disappearing behind the

--- a/acolyte-orchestrator/acolyte/usecase/graph/nodes/curator_node.py
+++ b/acolyte-orchestrator/acolyte/usecase/graph/nodes/curator_node.py
@@ -136,7 +136,22 @@ class CuratorNode:
 
         try:
             selected_ids = json.loads(response.text)
-            id_set = set(selected_ids)
-            return [e for e in section_evidence if e.get("id") in id_set]
+            by_id = {e.get("id"): e for e in section_evidence}
+            # Small models echo back every candidate they were shown, so the
+            # cap has to hold on the success path too — otherwise the whole
+            # section pool floods hydrate/compress/quote_selector. Walk the
+            # model's order (the prompt asks for relevance order) so the
+            # truncation keeps its top picks, not the pool's head.
+            selected: list[dict] = []
+            seen: set[str] = set()
+            for selected_id in selected_ids:
+                item = by_id.get(selected_id)
+                if item is None or selected_id in seen:
+                    continue
+                seen.add(selected_id)
+                selected.append(item)
+                if len(selected) >= self._max_evidence:
+                    break
         except (json.JSONDecodeError, TypeError):  # fmt: skip
             return section_evidence[: self._max_evidence]
+        return selected

--- a/acolyte-orchestrator/acolyte/usecase/graph/nodes/finalizer_node.py
+++ b/acolyte-orchestrator/acolyte/usecase/graph/nodes/finalizer_node.py
@@ -87,22 +87,11 @@ class FinalizerNode:
         if report is None:
             return {"error": f"Report {report_id} not found"}
 
-        change_items = [ChangeItem(field_name=f"section:{key}", change_kind="regenerated") for key in sections]
-
         change_reason = "LangGraph pipeline generation"
         critique = state.get("critique") or {}
         if critique.get("forced_accept"):
             revision_count = state.get("revision_count", 0)
             change_reason += f" [forced-accept-after-{revision_count}-revisions]"
-
-        new_version = await self._report_repo.bump_version(
-            report_id,
-            report.current_version,
-            change_reason,
-            change_items,
-            scope_snapshot=brief,
-            outline_snapshot=outline,
-        )
 
         # Persist the best revision body when available, not only when latest is empty.
         best = state.get("best_sections")
@@ -119,10 +108,40 @@ class FinalizerNode:
             for key in list(sections.keys()):
                 sections[key] = render_sources_footer(sections[key], sm)
 
-        # Persist sections
+        # Bodies first, version pointer last. bump_version stamps current_version
+        # plus the change_items that claim "these sections were regenerated at
+        # vN+1"; the repository exposes no cross-call transaction, so publishing
+        # that claim before the bodies are durable leaves a half-written report
+        # with no repair path. Ordering makes a mid-loop failure retryable instead:
+        # current_version still points at the last fully-written version.
+        persisted_keys = await self._persist_sections(report_id, outline, sections, section_citations)
+
+        change_items = [ChangeItem(field_name=f"section:{key}", change_kind="regenerated") for key in persisted_keys]
+
+        new_version = await self._report_repo.bump_version(
+            report_id,
+            report.current_version,
+            change_reason,
+            change_items,
+            scope_snapshot=brief,
+            outline_snapshot=outline,
+        )
+
+        logger.info("Finalizer completed", report_id=str(report_id), new_version=new_version)
+        return {"final_version_no": new_version}
+
+    async def _persist_sections(
+        self,
+        report_id: UUID,
+        outline: list[dict],
+        sections: dict[str, str],
+        section_citations: dict[str, list[SectionCitationDict]],
+    ) -> list[str]:
+        """Write every outline section body, returning the keys actually persisted."""
         existing_sections = await self._report_repo.get_sections(report_id)
         existing_keys = {s.section_key for s in existing_sections}
 
+        persisted: list[str] = []
         for i, section_def in enumerate(outline):
             key = section_def.get("key", "")
             body = sections.get(key, "")
@@ -137,9 +156,21 @@ class FinalizerNode:
                 expected_v = sec.current_version if sec else 0
 
             citations = section_citations.get(key)
-            await self._report_repo.bump_section_version(
-                report_id, key, expected_v, body, citations=cast(list[dict] | None, citations)
-            )
+            try:
+                await self._report_repo.bump_section_version(
+                    report_id, key, expected_v, body, citations=cast(list[dict] | None, citations)
+                )
+            except Exception:
+                # Each bump_section_version is its own transaction, so the sections
+                # already written here stay written. Name them so the failed run is
+                # visibly a partial write awaiting rollback, not a clean abort.
+                logger.exception(
+                    "Finalizer section persistence failed — report version not published",
+                    report_id=str(report_id),
+                    failed_section_key=key,
+                    persisted_section_keys=persisted,
+                )
+                raise
+            persisted.append(key)
 
-        logger.info("Finalizer completed", report_id=str(report_id), new_version=new_version)
-        return {"final_version_no": new_version}
+        return persisted

--- a/acolyte-orchestrator/acolyte/usecase/graph/report_graph.py
+++ b/acolyte-orchestrator/acolyte/usecase/graph/report_graph.py
@@ -38,7 +38,41 @@ NO_EVIDENCE_FAILURE_CODE = "no_evidence"
 # for the writer to cite — a distinct failure mode from NO_EVIDENCE_FAILURE_CODE
 # (run 2a4787e8: gatherer evidence_count=50, curator total_curated=10,
 # hydrator hydrated=0/10, 0 facts, an empty report persisted anyway).
+# The hydrated=0/N half of that run is now caught earlier and more precisely by
+# CONTENT_STORE_MISS_FAILURE_CODE; this code remains the verdict for runs that
+# requested no article body at all (recap-only evidence) or hydrated some and
+# still ended up with nothing citable.
 NO_CONTENT_FAILURE_CODE = "no_content"
+
+# Every curated article missed the content store, so the hydrator handed the
+# rest of the pipeline nothing. Distinct from NO_CONTENT_FAILURE_CODE, which is
+# the end-of-pipeline verdict: article bodies live only in the process-local
+# MemoryContentStore LRU, filled as a side effect of the gatherer's search, so a
+# run resumed in a fresh process (scripts/resume_run.py) hydrates 0/N and used
+# to be indistinguishable from "these articles genuinely have no body".
+# Deliberately absent from start_run_uc's circuit-breaker set — unlike
+# no_evidence / no_content this failure is transient: a full re-run re-populates
+# the store from search.
+CONTENT_STORE_MISS_FAILURE_CODE = "content_store_miss"
+
+
+async def _reset_failure_state(state: ReportGenerationState) -> dict:
+    """Clear the previous attempt's failure at the start of every re-run.
+
+    "error" and "failure_code" are LastValue channels and no node ever writes
+    them back to None, so a checkpointed run that already failed restores them.
+    connect_service's "terminal checkpoint without final_version_no, re-running
+    pipeline" branch — the one scripts/resume_run.py drives — hands the initial
+    state straight to ainvoke, so without this reset _finalize_guard reads the
+    *previous* attempt's error and aborts with no_evidence before the re-run has
+    gathered anything; that fresh no_evidence then trips start_run_uc's
+    10-minute circuit breaker, blocking the ordinary retry as well.
+
+    Only entry-point re-runs pass through here. A mid-pipeline resume
+    (ainvoke(None) with pending nodes) continues from where it stopped by
+    design, and its channels are the ones that attempt actually produced.
+    """
+    return {"error": None, "failure_code": None}
 
 
 async def _route_quote_selector(state: ReportGenerationState) -> str:
@@ -56,6 +90,56 @@ async def _route_critic(state: ReportGenerationState) -> str:
 def _compressed_char_count(compressed_evidence: dict[str, list[dict]]) -> int:
     """Total character count across every CompressedSpan the compressor kept."""
     return sum(len(span.get("text", "")) for spans in compressed_evidence.values() for span in spans)
+
+
+def _curated_article_count(state: ReportGenerationState) -> int:
+    """How many distinct article bodies HydratorNode was asked to fetch.
+
+    Mirrors HydratorNode's own selection — curated_by_section when the curator
+    produced one, else the flat curated list — because the guard below has to
+    count exactly the set the hydrator requested. Counting curated items instead
+    would make a recap-only run, which legitimately hydrates nothing, look like
+    a total content-store miss.
+    """
+    curated_by_section = state.get("curated_by_section")
+    if curated_by_section:
+        items = [item for section_items in curated_by_section.values() for item in section_items]
+    else:
+        items = state.get("curated", [])
+    return len({item.get("id", "") for item in items if item.get("type") == "article"})
+
+
+def _content_store_missed(state: ReportGenerationState) -> bool:
+    """True when the hydrator asked for article bodies and got none of them."""
+    return _curated_article_count(state) > 0 and not state.get("hydrated_evidence")
+
+
+async def _hydration_guard(state: ReportGenerationState) -> dict:
+    """Abort at the hydration boundary when the content store held nothing.
+
+    HydratorNode reports `hydrated=0/N` at INFO and returns an empty dict, so
+    the compressor, quote_selector and fact_normalizer then spend the run's
+    whole LLM budget on nothing before _finalize_guard finally calls it
+    no_content. Failing here instead names the actual cause (an empty
+    content store, typically a resume in a fresh process) and costs no
+    inference (CLAUDE.md Rule 8: no silent fallback).
+    """
+    if not _content_store_missed(state):
+        return {}
+    return {
+        "failure_code": CONTENT_STORE_MISS_FAILURE_CODE,
+        "error": (
+            f"Content store held none of the {_curated_article_count(state)} curated article "
+            "bodies (hydrated 0) — aborting before the extraction pipeline runs on nothing"
+        ),
+    }
+
+
+def _route_hydration_guard(state: ReportGenerationState) -> str:
+    # Recomputed rather than read off failure_code: on a mid-pipeline resume the
+    # checkpoint still carries the previous attempt's failure_code (see
+    # _reset_failure_state), which must not divert a healthy hydration.
+    return "abort" if _content_store_missed(state) else "hydrated"
 
 
 async def _finalize_guard(state: ReportGenerationState) -> dict:
@@ -115,8 +199,8 @@ def build_report_graph(  # noqa: PLR0913 — top-level graph factory wires every
     """Build the report generation StateGraph.
 
     Pipeline:
-      Without content_store: planner → gatherer → curator → writer → critic → finalize_guard → finalizer
-      With content_store:    planner → gatherer → curator → hydrator → compressor → quote_selector → fact_normalizer → section_planner → writer → critic → finalize_guard → finalizer
+      Without content_store: reset_failure_state → planner → gatherer → curator → writer → critic → finalize_guard → finalizer
+      With content_store:    reset_failure_state → planner → gatherer → curator → hydrator → hydration_guard → compressor → quote_selector → fact_normalizer → section_planner → writer → critic → finalize_guard → finalizer
 
     Note: ExtractorNode (usecase/graph/nodes/extractor_node.py) implements an
     older single-pass extraction strategy and is not wired into this graph —
@@ -124,6 +208,14 @@ def build_report_graph(  # noqa: PLR0913 — top-level graph factory wires every
 
     Revision loop: critic → writer (section_planner is NOT re-run on revision;
     claim_plans persist in state and writer re-uses them with revision feedback).
+
+    reset_failure_state: clears the error / failure_code channels a failed
+    checkpoint restores, so an operator re-run (scripts/resume_run.py) isn't
+    aborted by the previous attempt's failure.
+
+    hydration_guard: aborts straight to END when the curator selected articles
+    but the content store held none of their bodies — the resume-in-a-fresh-
+    process case, which otherwise burns the whole LLM budget on empty input.
 
     finalize_guard: runs on every critic "accept" route (including the
     MAX_REVISIONS forced accept) and aborts straight to END — without
@@ -135,6 +227,7 @@ def build_report_graph(  # noqa: PLR0913 — top-level graph factory wires every
     """
     graph = StateGraph(ReportGenerationState)  # type: ignore[bad-specialization]
 
+    graph.add_node("reset_failure_state", _reset_failure_state)
     graph.add_node("planner", PlannerNode(llm))
     graph.add_node(
         "gatherer",
@@ -152,12 +245,14 @@ def build_report_graph(  # noqa: PLR0913 — top-level graph factory wires every
     graph.add_node("finalize_guard", _finalize_guard)
     graph.add_node("finalizer", FinalizerNode(report_repo))
 
-    graph.set_entry_point("planner")
+    graph.set_entry_point("reset_failure_state")
+    graph.add_edge("reset_failure_state", "planner")
     graph.add_edge("planner", "gatherer")
     graph.add_edge("gatherer", "curator")
 
     if content_store is not None:
         graph.add_node("hydrator", HydratorNode(content_store))
+        graph.add_node("hydration_guard", _hydration_guard)
         graph.add_node("compressor", CompressorNode())
         incremental_extract = checkpointer is not None
         graph.add_node("quote_selector", QuoteSelectorNode(llm, incremental=incremental_extract))
@@ -170,7 +265,12 @@ def build_report_graph(  # noqa: PLR0913 — top-level graph factory wires every
         graph.add_node("fact_normalizer", fact_normalizer)
         graph.add_node("section_planner", SectionPlannerNode(llm))
         graph.add_edge("curator", "hydrator")
-        graph.add_edge("hydrator", "compressor")
+        graph.add_edge("hydrator", "hydration_guard")
+        graph.add_conditional_edges(
+            "hydration_guard",
+            _route_hydration_guard,
+            {"hydrated": "compressor", "abort": END},
+        )
         graph.add_edge("compressor", "quote_selector")
         if incremental_extract:
             graph.add_conditional_edges(

--- a/acolyte-orchestrator/acolyte/usecase/rerun_section_uc.py
+++ b/acolyte-orchestrator/acolyte/usecase/rerun_section_uc.py
@@ -12,10 +12,21 @@ from acolyte.domain.writer_prompt import WRITER_PROMPT, format_evidence
 from acolyte.port.llm_provider import LLMMode
 
 if TYPE_CHECKING:
+    from acolyte.domain.report import Report, ReportSection
     from acolyte.port.llm_provider import LLMProviderPort
     from acolyte.port.report_repository import ReportRepositoryPort
 
 logger = structlog.get_logger(__name__)
+
+
+class RerunRejectedError(RuntimeError):
+    """Raised when a rerun is refused because a pipeline run owns the report.
+
+    Deliberately not a ValueError: connect_service maps ValueError from this
+    usecase to Code.NOT_FOUND, and "a generation run is in progress" is not a
+    missing report. A caller that catches this type can map it to
+    Code.FAILED_PRECONDITION the way delete_report's active-run guard does.
+    """
 
 
 class RerunSectionUsecase:
@@ -27,16 +38,16 @@ class RerunSectionUsecase:
 
     async def execute(self, report_id: UUID, section_key: str) -> int:
         """Rerun a single section. Returns new report version number."""
-        report = await self._repo.get_report(report_id)
-        if report is None:
-            msg = f"Report {report_id} not found"
-            raise ValueError(msg)
+        report, target = await self._load_locked_rows(report_id, section_key)
 
-        sections = await self._repo.get_sections(report_id)
-        target = next((s for s in sections if s.section_key == section_key), None)
-        if target is None:
-            msg = f"Section {section_key} not found in report {report_id}"
-            raise ValueError(msg)
+        # A pipeline run rewrites every section and bumps the report version
+        # on finalize, so a rerun started underneath it contends for the same
+        # optimistic locks and can only lose. Refuse before burning a
+        # multi-second writer call. Same guard delete_report uses; like it,
+        # this is best-effort (the run can start right after the check).
+        if await self._repo.has_active_run(report_id):
+            msg = f"Report {report_id} rerun rejected: a report generation run is in progress"
+            raise RerunRejectedError(msg)
 
         brief = await self._repo.get_brief(report_id)
         topic = brief.topic if brief else report.title
@@ -64,15 +75,30 @@ class RerunSectionUsecase:
         )
         response = await self._llm.generate(prompt, num_predict=2000, think=False, mode=LLMMode.LONGFORM)
 
-        # Bump section version
-        await self._repo.bump_section_version(
-            report_id,
-            section_key,
-            target.current_version,
-            response.text,
-        )
+        # The writer call above takes tens of seconds; the report version read
+        # before it is what a concurrent writer has since moved, so re-read it
+        # and let the bump below contend for the number the DB holds now.
+        #
+        # Only the report row. `target` deliberately keeps its pre-LLM version:
+        # that is the section this body was written against, and the evidence
+        # above came from its citations. Re-reading it too would make the
+        # section lock always match, turning a sibling rerun of the same
+        # section into last-writer-wins — our body, built from the older
+        # section's evidence, would silently replace theirs.
+        report, _ = await self._load_locked_rows(report_id, section_key)
 
-        # Bump report version with change tracking
+        # Report version first. The port exposes no cross-call transaction,
+        # so one of the two writes can always be left dangling; a rerun
+        # touches exactly one section, so the only question is which side.
+        # reports.current_version is the lock every concurrent writer
+        # contends for, and losing it here aborts before any body lands.
+        # Body-first instead leaves a section body that no report version and
+        # no change_item owns — and GetReport reads section bodies off
+        # report_sections.current_version, so it renders that orphan as if it
+        # were published while the caller retries on the resulting INTERNAL.
+        # (FinalizerNode orders the other way for the opposite reason: it
+        # writes N bodies in a loop, where a dangling version pointer would
+        # claim sections a mid-loop failure never wrote.)
         new_report_v = await self._repo.bump_version(
             report_id,
             report.current_version,
@@ -80,10 +106,36 @@ class RerunSectionUsecase:
             [ChangeItem(field_name=f"section:{section_key}", change_kind="regenerated")],
         )
 
+        # The re-read above shrinks the gap between the two bumps from the
+        # whole writer call to microseconds, but it cannot close it. The
+        # residual failure (version stamped, body not) leaves the rendered
+        # report on its previous, attributable body and is retryable.
+        await self._repo.bump_section_version(
+            report_id,
+            section_key,
+            target.current_version,
+            response.text,
+        )
+
         logger.info(
             "Section rerun completed", report_id=str(report_id), section_key=section_key, new_version=new_report_v
         )
         return new_report_v
+
+    async def _load_locked_rows(self, report_id: UUID, section_key: str) -> tuple[Report, ReportSection]:
+        """Read the two rows whose current_version guards the version bumps."""
+        report = await self._repo.get_report(report_id)
+        if report is None:
+            msg = f"Report {report_id} not found"
+            raise ValueError(msg)
+
+        sections = await self._repo.get_sections(report_id)
+        target = next((s for s in sections if s.section_key == section_key), None)
+        if target is None:
+            msg = f"Section {section_key} not found in report {report_id}"
+            raise ValueError(msg)
+
+        return report, target
 
     async def _evidence_from_citations(self, report_id: UUID, section_key: str, current_version: int) -> list[dict]:
         """Rebuild evidence entries from the section's persisted citations."""

--- a/acolyte-orchestrator/main.py
+++ b/acolyte-orchestrator/main.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import httpx
 import structlog
@@ -168,6 +169,102 @@ async def health_endpoint(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok", "service": "acolyte-orchestrator"})
 
 
+# Shutdown budget for pipelines still inside the graph. compose/acolyte.yaml sets
+# no stop_grace_period, so the whole teardown has to fit inside Docker's 10s
+# default. The window is not there to let a 70-minute run finish — it is there so
+# a pipeline one await away from complete_run lands its own terminal write
+# instead of being cancelled in FinalizerNode's gap, between the version bump and
+# the run's completion. Not settings-driven: it is a property of the container's
+# stop grace, not a business knob.
+_PIPELINE_DRAIN_GRACE_SECONDS = 2.0
+
+# Deliberately distinct from ReconcileOrphanedRunsUsecase's
+# 'orphaned_after_restart'. That code means "found this row already stale at
+# boot"; this one means "we stopped it on purpose, and the row is accurate as of
+# now" — which is what a scale-down needs, since no later startup may ever come
+# to reconcile it.
+_SHUTDOWN_FAILURE_CODE = "shutdown_interrupted"
+
+# Mirrors the task name AcolyteConnectService.start_report_run assigns
+# (f"acolyte-run-{run_id}"), the only handle a cancelled task carries back to
+# its run row.
+_RUN_TASK_NAME_PREFIX = "acolyte-run-"
+
+# The statuses list_running_runs treats as unfinished — the only ones a shutdown
+# is entitled to rewrite.
+_UNFINISHED_RUN_STATUSES = frozenset({"pending", "running"})
+
+
+async def _fail_interrupted_run(task: asyncio.Task[None]) -> None:
+    """Mark the run behind a shutdown-cancelled pipeline task as failed."""
+    try:
+        run_id = UUID(task.get_name().removeprefix(_RUN_TASK_NAME_PREFIX))
+    except ValueError:
+        # The naming contract with start_report_run broke. Loud, but not fatal:
+        # raising here would skip the pool close and leak connections, and the
+        # next boot's ReconcileOrphanedRunsUsecase still catches the row.
+        logger.exception("Interrupted pipeline task carries no run id", task_name=task.get_name())
+        return
+
+    # Both statements talk to the Postgres this teardown is about to let go of,
+    # so neither may hold the rest of the shutdown hostage — the pool and the
+    # HTTP client still have to close.
+    try:
+        # The cancellation can land after complete_run's UPDATE committed but
+        # before the coroutine returned. fail_run is an unconditional UPDATE, so
+        # without this read it would pair a bumped report version with a failed
+        # run — the corruption the drain exists to prevent.
+        run = await _job_queue.get_run(run_id)
+        if run is not None and run.run_status not in _UNFINISHED_RUN_STATUSES:
+            logger.info(
+                "Interrupted pipeline had already settled its run",
+                run_id=str(run_id),
+                run_status=run.run_status,
+            )
+            return
+        await _job_queue.fail_run(
+            run_id,
+            _SHUTDOWN_FAILURE_CODE,
+            "Run was cancelled while the process was shutting down.",
+        )
+    except Exception as exc:
+        logger.exception("Failed to mark interrupted run failed during shutdown", run_id=str(run_id), error=str(exc))
+
+
+async def _drain_report_pipelines(service: AcolyteConnectService) -> None:
+    """Settle in-flight pipelines before the pool and HTTP client go away.
+
+    Nothing else awaits the background tasks start_report_run spawns. Closing
+    the pool underneath one raises PoolClosed inside the pipeline, and its own
+    crash handler then fails to write fail_run through that same dead pool — so
+    the run row says 'running' forever, wedging has_active_run (the
+    delete_report guard) and GetReport.active_run for its report. Every
+    redeploy that lands mid-run does this.
+    """
+    # Snapshotted: the handler's done-callback mutates the set as tasks finish.
+    in_flight = set(service._background_tasks)
+    if not in_flight:
+        return
+
+    logger.info(
+        "Draining in-flight report pipelines",
+        count=len(in_flight),
+        grace_seconds=_PIPELINE_DRAIN_GRACE_SECONDS,
+    )
+    _, unfinished = await asyncio.wait(in_flight, timeout=_PIPELINE_DRAIN_GRACE_SECONDS)
+    for task in unfinished:
+        task.cancel()
+    # return_exceptions, because a pipeline can settle with something other than
+    # CancelledError — _run_pipeline_locked raises outside its own except clause
+    # on an unconfigured graph. Letting that escape here unwinds the lifespan
+    # finally and skips the HTTP client and pool closes below it, leaking both
+    # on every redeploy.
+    await asyncio.gather(*unfinished, return_exceptions=True)
+    for task in unfinished:
+        logger.warning("Pipeline cancelled by shutdown", task_name=task.get_name())
+        await _fail_interrupted_run(task)
+
+
 def create_app() -> Starlette:
     """Create Starlette ASGI application instance."""
     initial_graph = None if settings.checkpoint_enabled else _compile_graph()
@@ -199,21 +296,39 @@ def create_app() -> Starlette:
                 _relay.run_forever(_relay_config.interval_seconds),
                 name="notification-outbox-relay",
             )
-        try:
-            if settings.checkpoint_enabled:
-                async with create_checkpointer(_dsn) as checkpointer:
-                    connect_service.set_graph(_compile_graph(checkpointer=checkpointer))
-                    logger.info("LangGraph checkpointing enabled")
-                    yield
-            else:
-                logger.info("LangGraph checkpointing disabled")
-                yield
-        finally:
+
+        async def _drain() -> None:
+            # Periodic loops first — they hold no in-flight business state. The
+            # pipelines then get their window while the checkpointer connection,
+            # the pool and the HTTP client are all still usable.
             for task in (relay_task, cert_watch_task):
                 if task is not None:
                     task.cancel()
                     with suppress(asyncio.CancelledError):
                         await task
+            await _drain_report_pipelines(connect_service)
+
+        try:
+            # The drain sits *inside* the checkpointer scope on purpose. With
+            # CHECKPOINT_ENABLED=true the graph runs durability="sync", so every
+            # super-step writes through the single connection create_checkpointer
+            # owns; draining after that context exits would hand a pipeline its
+            # grace window with nothing left to write the terminal checkpoint to.
+            if settings.checkpoint_enabled:
+                async with create_checkpointer(_dsn) as checkpointer:
+                    connect_service.set_graph(_compile_graph(checkpointer=checkpointer))
+                    logger.info("LangGraph checkpointing enabled")
+                    try:
+                        yield
+                    finally:
+                        await _drain()
+            else:
+                logger.info("LangGraph checkpointing disabled")
+                try:
+                    yield
+                finally:
+                    await _drain()
+        finally:
             await _http_client.aclose()
             await _pool.close()
             logger.info("Shutting down acolyte-orchestrator")

--- a/acolyte-orchestrator/scripts/resume_run.py
+++ b/acolyte-orchestrator/scripts/resume_run.py
@@ -51,9 +51,22 @@ def _build_pipeline_deps(settings: Settings, llm: LLMProviderPort) -> tuple[HyDE
     # imports out of module scope so `--help` stays fast.
     from acolyte.gateway.memory_content_store import MemoryContentStore  # noqa: PLC0415
     from acolyte.gateway.news_creator_hyde_gw import build_hyde_generator  # noqa: PLC0415
+    from acolyte.usecase.graph.report_graph import CONTENT_STORE_MISS_FAILURE_CODE  # noqa: PLC0415
 
     hyde_generator = build_hyde_generator(llm, settings)
     content_store = MemoryContentStore(max_size=settings.content_store_max_size)
+    # Article bodies only enter this LRU as a side effect of the gatherer's
+    # search, and this is a brand-new process — the bodies the original run
+    # cached died with it. A checkpoint that resumes past the gatherer will
+    # therefore hydrate 0/N and abort at hydration_guard. Say so up front so the
+    # operator reads "the cached bodies are gone", not "these articles have no
+    # body" (CLAUDE.md Rule 8: no silent fallback).
+    logger.warning(
+        "Content store starts empty for this resume",
+        max_size=settings.content_store_max_size,
+        hydration_failure_code=CONTENT_STORE_MISS_FAILURE_CODE,
+        remedy="re-run the gatherer (start a fresh run) if the checkpoint is already past it",
+    )
     return hyde_generator, content_store
 
 

--- a/acolyte-orchestrator/tests/unit/test_curator_max_evidence_cap.py
+++ b/acolyte-orchestrator/tests/unit/test_curator_max_evidence_cap.py
@@ -1,0 +1,95 @@
+"""The LLM curation path must honour max_evidence (finding 044).
+
+A small model happily echoes back every candidate ID it was shown. Without a
+cap the whole section pool flows into hydrate/compress/quote_selector, so the
+success path needs the same ``[:max_evidence]`` guard the parse-failure path
+already has.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from acolyte.port.llm_provider import LLMResponse
+from acolyte.usecase.graph.nodes.curator_node import CuratorNode
+
+
+class EchoAllLLM:
+    """Returns every candidate ID it was shown, in the given relevance order."""
+
+    def __init__(self, selected_ids: list[str]) -> None:
+        self._selected_ids = selected_ids
+
+    async def generate(self, prompt: str, **kwargs: object) -> LLMResponse:
+        return LLMResponse(text=json.dumps(self._selected_ids), model="fake")
+
+
+def _evidence(count: int, section_key: str = "market") -> list[dict]:
+    return [
+        {
+            "type": "article",
+            "id": f"art-{i}",
+            "title": f"A{i}",
+            "score": 1.0 - i / 100,
+            "section_keys": [section_key],
+        }
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_curator_caps_llm_selection_at_max_evidence() -> None:
+    """A model that selects everything must still yield at most max_evidence items."""
+    evidence = _evidence(12)
+    llm = EchoAllLLM([e["id"] for e in evidence])
+    node = CuratorNode(llm, max_evidence=3)
+
+    result = await node(
+        {
+            "evidence": evidence,
+            "outline": [{"key": "market", "title": "Market"}],
+            "brief": {"topic": "AI"},
+        }
+    )
+
+    assert len(result["curated_by_section"]["market"]) == 3
+    assert len(result["curated"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_curator_keeps_llm_relevance_order_when_truncating() -> None:
+    """Truncation must keep the model's ranking, not the pool order."""
+    evidence = _evidence(6)
+    # Model ranks the tail of the pool as the most relevant.
+    llm = EchoAllLLM(["art-5", "art-4", "art-0", "art-1", "art-2", "art-3"])
+    node = CuratorNode(llm, max_evidence=2)
+
+    result = await node(
+        {
+            "evidence": evidence,
+            "outline": [{"key": "market", "title": "Market"}],
+            "brief": {"topic": "AI"},
+        }
+    )
+
+    assert [e["id"] for e in result["curated_by_section"]["market"]] == ["art-5", "art-4"]
+
+
+@pytest.mark.asyncio
+async def test_curator_ignores_hallucinated_and_duplicate_ids() -> None:
+    """IDs the model invented or repeated must not consume a slot twice."""
+    evidence = _evidence(4)
+    llm = EchoAllLLM(["art-9000", "art-2", "art-2", "art-0"])
+    node = CuratorNode(llm, max_evidence=3)
+
+    result = await node(
+        {
+            "evidence": evidence,
+            "outline": [{"key": "market", "title": "Market"}],
+            "brief": {"topic": "AI"},
+        }
+    )
+
+    assert [e["id"] for e in result["curated_by_section"]["market"]] == ["art-2", "art-0"]

--- a/acolyte-orchestrator/tests/unit/test_finalizer_write_ordering.py
+++ b/acolyte-orchestrator/tests/unit/test_finalizer_write_ordering.py
@@ -1,0 +1,169 @@
+"""Unit tests for FinalizerNode write ordering.
+
+The report version and its change_items are the published claim "these sections
+were regenerated at vN+1". They must never become visible before the section
+bodies they describe are durable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+
+from acolyte.domain.report import ChangeItem, Report, ReportSection, ReportVersion, SectionVersion
+from acolyte.usecase.graph.nodes.finalizer_node import FinalizerNode
+
+if TYPE_CHECKING:
+    from acolyte.domain.brief import ReportBrief
+
+
+class SectionWriteError(RuntimeError):
+    """Simulated repository failure while writing one section body."""
+
+    def __init__(self, section_key: str) -> None:
+        super().__init__(f"connection lost while writing section {section_key}")
+
+
+class FakeRepo:
+    """Repo double that records writes and can fail one section body write."""
+
+    def __init__(self, section_keys: list[str], fail_on_section: str | None = None) -> None:
+        self.report_id = uuid4()
+        self.report = Report(
+            report_id=self.report_id,
+            title="Test",
+            report_type="weekly_briefing",
+            current_version=0,
+            latest_successful_run_id=None,
+            created_at=datetime.now(UTC),
+        )
+        self.sections = [
+            ReportSection(report_id=self.report_id, section_key=key, current_version=0, display_order=i)
+            for i, key in enumerate(section_keys)
+        ]
+        self._fail_on_section = fail_on_section
+        self.saved_bodies: dict[str, str] = {}
+        self.bump_version_calls: list[list[ChangeItem]] = []
+
+    async def create_report(self, title: str, report_type: str) -> Report:
+        return self.report
+
+    async def create_brief(self, report_id: UUID, brief: ReportBrief) -> None:
+        pass
+
+    async def get_brief(self, report_id: UUID) -> ReportBrief | None:
+        return None
+
+    async def get_report(self, report_id: UUID) -> Report | None:
+        return self.report
+
+    async def list_reports(self, cursor: str | None, limit: int) -> tuple[list[Report], str | None]:
+        return [], None
+
+    async def bump_version(
+        self,
+        report_id: UUID,
+        expected_version: int,
+        change_reason: str,
+        change_items: list[ChangeItem],
+        **kwargs: object,
+    ) -> int:
+        self.bump_version_calls.append(change_items)
+        self.report = Report(
+            report_id=self.report.report_id,
+            title=self.report.title,
+            report_type=self.report.report_type,
+            current_version=expected_version + 1,
+            latest_successful_run_id=self.report.latest_successful_run_id,
+            created_at=self.report.created_at,
+        )
+        return expected_version + 1
+
+    async def get_report_version(self, report_id: UUID, version_no: int) -> ReportVersion | None:
+        return None
+
+    async def list_report_versions(
+        self, report_id: UUID, cursor: str | None, limit: int
+    ) -> tuple[list[ReportVersion], str | None]:
+        return [], None
+
+    async def get_change_items(self, report_id: UUID, version_no: int) -> list[ChangeItem]:
+        return []
+
+    async def get_sections(self, report_id: UUID) -> list[ReportSection]:
+        return self.sections
+
+    async def create_section(self, report_id: UUID, section_key: str, display_order: int) -> ReportSection:
+        section = ReportSection(
+            report_id=report_id, section_key=section_key, current_version=0, display_order=display_order
+        )
+        self.sections.append(section)
+        return section
+
+    async def bump_section_version(
+        self,
+        report_id: UUID,
+        section_key: str,
+        expected_version: int,
+        body: str,
+        citations: list[dict] | None = None,
+    ) -> int:
+        if section_key == self._fail_on_section:
+            raise SectionWriteError(section_key)
+        self.saved_bodies[section_key] = body
+        return expected_version + 1
+
+    async def get_section_version(self, report_id: UUID, section_key: str, version_no: int) -> SectionVersion | None:
+        return None
+
+    async def has_active_run(self, report_id: UUID) -> bool:
+        return False
+
+    async def delete_report(self, report_id: UUID) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_section_write_failure_leaves_report_version_unpublished() -> None:
+    """A mid-loop section failure must not leave current_version pointing at a half-written report."""
+    repo = FakeRepo(["intro", "analysis", "outlook"], fail_on_section="analysis")
+    node = FinalizerNode(repo)
+
+    state = {
+        "report_id": str(repo.report_id),
+        "outline": [{"key": "intro"}, {"key": "analysis"}, {"key": "outlook"}],
+        "brief": {"topic": "AI"},
+        "sections": {"intro": "Intro body.", "analysis": "Analysis body.", "outlook": "Outlook body."},
+    }
+
+    with pytest.raises(SectionWriteError, match="connection lost"):
+        await node(state)
+
+    assert repo.bump_version_calls == [], "report version was published before all section bodies were durable"
+    assert repo.report.current_version == 0
+
+
+@pytest.mark.asyncio
+async def test_change_items_only_claim_sections_that_were_written() -> None:
+    """change_items is the regeneration claim — it must not name a section the node never wrote."""
+    repo = FakeRepo(["intro"])
+    node = FinalizerNode(repo)
+
+    state = {
+        "report_id": str(repo.report_id),
+        # "dropped" survives in state["sections"] but is no longer in the outline,
+        # so the persistence loop never writes it.
+        "outline": [{"key": "intro"}],
+        "brief": {"topic": "AI"},
+        "sections": {"intro": "Intro body.", "dropped": "Stale body from an earlier revision."},
+    }
+
+    result = await node(state)
+
+    assert result["final_version_no"] == 1
+    assert len(repo.bump_version_calls) == 1
+    claimed = {item.field_name for item in repo.bump_version_calls[0]}
+    assert claimed == {"section:intro"}

--- a/acolyte-orchestrator/tests/unit/test_main_pipeline_drain.py
+++ b/acolyte-orchestrator/tests/unit/test_main_pipeline_drain.py
@@ -1,0 +1,299 @@
+"""Shutdown ordering for in-flight report pipelines.
+
+A redeploy is the common case, not the rare one. If lifespan tears the DB pool
+down while a StartReportRun pipeline is still inside the graph, the pipeline
+sees PoolClosed, its own crash handler then tries to write fail_run through the
+same dead pool, and the run row is left saying 'running' forever — wedging
+has_active_run (the delete_report guard) and GetReport.active_run for that
+report until some later process happens to boot and reconcile it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from psycopg_pool import PoolClosed
+
+import main as main_module
+from acolyte.domain.run import ReportRun
+
+
+def _running_run(run_id: UUID) -> ReportRun:
+    return ReportRun(run_id=run_id, report_id=uuid4(), target_version_no=3, run_status="running")
+
+
+def _stub_lifespan_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise everything lifespan touches except the drain under test.
+
+    get_run included: the drain reads the run before rewriting it, and the real
+    gateway would reach for a pool this test never opened.
+    """
+    monkeypatch.setattr(main_module.settings, "checkpoint_enabled", False)
+    monkeypatch.setattr(main_module, "_relay", None)
+    monkeypatch.setattr(main_module, "_relay_config", None)
+    monkeypatch.setattr(main_module._pool, "open", AsyncMock())
+    monkeypatch.setattr(main_module._http_client, "aclose", AsyncMock())
+    monkeypatch.setattr(main_module._job_queue, "list_running_runs", AsyncMock(return_value=[]))
+    monkeypatch.setattr(main_module._job_queue, "get_run", AsyncMock(side_effect=_running_run))
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_in_flight_pipeline_while_the_pool_is_still_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = uuid4()
+    pool_closed = asyncio.Event()
+    pool_open_at_cancel: list[bool] = []
+    started = asyncio.Event()
+
+    async def fake_pipeline() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pool_open_at_cancel.append(not pool_closed.is_set())
+            raise
+
+    async def fake_pool_close() -> None:
+        pool_closed.set()
+
+    fail_run = AsyncMock()
+    _stub_lifespan_io(monkeypatch)
+    monkeypatch.setattr(main_module, "_PIPELINE_DRAIN_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(main_module._pool, "close", fake_pool_close)
+    monkeypatch.setattr(main_module._job_queue, "fail_run", fail_run)
+
+    app = main_module.create_app()
+    service = app.state.connect_service
+
+    async with app.router.lifespan_context(app):
+        task = asyncio.create_task(fake_pipeline(), name=f"acolyte-run-{run_id}")
+        service._background_tasks.add(task)
+        task.add_done_callback(service._background_tasks.discard)
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    try:
+        assert task.done(), "lifespan returned with the pipeline task still running"
+        assert pool_open_at_cancel == [True], "pipeline was cancelled after the pool had already closed"
+        fail_run.assert_awaited_once()
+        assert fail_run.await_args is not None
+        assert fail_run.await_args.args[0] == run_id
+    finally:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_lets_an_almost_finished_pipeline_land_its_own_terminal_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The grace window exists for the FinalizerNode gap.
+
+    A pipeline cancelled between bump_version and complete_run leaves a bumped
+    report version behind a run marked failed. Anything that settles inside the
+    window must therefore keep its own outcome and never be re-marked.
+    """
+    run_id = uuid4()
+    completed = asyncio.Event()
+
+    async def fake_pipeline() -> None:
+        await asyncio.sleep(0)
+        completed.set()
+
+    fail_run = AsyncMock()
+    _stub_lifespan_io(monkeypatch)
+    monkeypatch.setattr(main_module, "_PIPELINE_DRAIN_GRACE_SECONDS", 1.0)
+    monkeypatch.setattr(main_module._pool, "close", AsyncMock())
+    monkeypatch.setattr(main_module._job_queue, "fail_run", fail_run)
+
+    app = main_module.create_app()
+    service = app.state.connect_service
+
+    async with app.router.lifespan_context(app):
+        task = asyncio.create_task(fake_pipeline(), name=f"acolyte-run-{run_id}")
+        service._background_tasks.add(task)
+        task.add_done_callback(service._background_tasks.discard)
+
+    assert completed.is_set()
+    assert not task.cancelled()
+    fail_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_does_not_rewrite_a_run_that_already_reached_a_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancellation can land after complete_run committed but before the task returns.
+
+    fail_run is an unconditional UPDATE, so re-marking that run would pair a
+    bumped report version with a failed run — the exact corruption the drain
+    exists to prevent.
+    """
+    run_id = uuid4()
+    started = asyncio.Event()
+
+    async def fake_pipeline() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    fail_run = AsyncMock()
+    _stub_lifespan_io(monkeypatch)
+    monkeypatch.setattr(main_module, "_PIPELINE_DRAIN_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(main_module._pool, "close", AsyncMock())
+    monkeypatch.setattr(main_module._job_queue, "fail_run", fail_run)
+    monkeypatch.setattr(
+        main_module._job_queue,
+        "get_run",
+        AsyncMock(
+            return_value=ReportRun(
+                run_id=run_id,
+                report_id=uuid4(),
+                target_version_no=3,
+                run_status="succeeded",
+            )
+        ),
+    )
+
+    app = main_module.create_app()
+    service = app.state.connect_service
+
+    async with app.router.lifespan_context(app):
+        task = asyncio.create_task(fake_pipeline(), name=f"acolyte-run-{run_id}")
+        service._background_tasks.add(task)
+        task.add_done_callback(service._background_tasks.discard)
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    try:
+        assert task.done()
+        fail_run.assert_not_awaited()
+    finally:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_still_closes_the_pool_when_marking_a_run_failed_blows_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Best-effort bookkeeping must never hold the teardown hostage.
+
+    The run bookkeeping talks to the same Postgres that may already be gone —
+    which is how this whole failure mode started. If it raises, the pool and the
+    HTTP client still have to close, or a redeploy leaks both.
+    """
+    run_id = uuid4()
+    started = asyncio.Event()
+
+    async def fake_pipeline() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    pool_close = AsyncMock()
+    _stub_lifespan_io(monkeypatch)
+    monkeypatch.setattr(main_module, "_PIPELINE_DRAIN_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(main_module._pool, "close", pool_close)
+    monkeypatch.setattr(main_module._job_queue, "get_run", AsyncMock(side_effect=PoolClosed("pool is already closed")))
+
+    app = main_module.create_app()
+    service = app.state.connect_service
+
+    async with app.router.lifespan_context(app):
+        task = asyncio.create_task(fake_pipeline(), name=f"acolyte-run-{run_id}")
+        service._background_tasks.add(task)
+        task.add_done_callback(service._background_tasks.discard)
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    try:
+        pool_close.assert_awaited_once()
+        main_module._http_client.aclose.assert_awaited_once()  # type: ignore[missing-attribute]
+    finally:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_pipelines_before_the_checkpointer_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The grace window is worthless if the checkpoint connection is already gone.
+
+    Production runs with CHECKPOINT_ENABLED=true and durability="sync", so every
+    super-step writes through the single psycopg connection create_checkpointer
+    owns. Draining after that context exits means the pipeline we are giving
+    time to land its terminal write cannot actually write.
+    """
+    _stub_lifespan_io(monkeypatch)
+    monkeypatch.setattr(main_module.settings, "checkpoint_enabled", True)
+
+    checkpointer_closed = asyncio.Event()
+    checkpointer_open_at_drain: list[bool] = []
+    started = asyncio.Event()
+
+    @asynccontextmanager
+    async def _stub_checkpointer(_dsn: object) -> AsyncGenerator[object]:
+        try:
+            yield object()
+        finally:
+            checkpointer_closed.set()
+
+    monkeypatch.setattr(main_module, "create_checkpointer", _stub_checkpointer)
+    monkeypatch.setattr(main_module, "_compile_graph", lambda **_kw: object())
+
+    async def _pipeline() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            checkpointer_open_at_drain.append(not checkpointer_closed.is_set())
+            raise
+
+    app = main_module.create_app()
+    async with app.router.lifespan_context(app):
+        task = asyncio.create_task(_pipeline(), name="report-pipeline")
+        main_module._job_queue.get_run.side_effect = _running_run
+        app.state.connect_service._background_tasks.add(task)
+        await started.wait()
+
+    assert checkpointer_open_at_drain == [True], (
+        "the pipeline must get its grace window while the checkpointer connection is still live"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_still_closes_the_pool_when_a_pipeline_dies_uncancellably(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A drained task settling with anything but CancelledError must not escape.
+
+    _run_pipeline_locked can raise RuntimeError outside its own except clause;
+    if that propagates out of the drain it skips the client and pool closes
+    below it, leaking both across every redeploy.
+    """
+    _stub_lifespan_io(monkeypatch)
+    pool_close = AsyncMock()
+    monkeypatch.setattr(main_module._pool, "close", pool_close)
+    monkeypatch.setattr(main_module, "_PIPELINE_DRAIN_GRACE_SECONDS", 0.05)
+    started = asyncio.Event()
+
+    async def _pipeline() -> None:
+        # Outlives the grace window, so the drain cancels it — and then it
+        # settles with something other than CancelledError, the way
+        # _run_pipeline_locked does when mark_running raises outside its own
+        # except clause.
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            msg = "Pipeline graph not configured"
+            raise RuntimeError(msg) from None
+
+    app = main_module.create_app()
+    async with app.router.lifespan_context(app):
+        task = asyncio.create_task(_pipeline(), name="report-pipeline")
+        app.state.connect_service._background_tasks.add(task)
+        await started.wait()
+
+    pool_close.assert_awaited()
+    main_module._http_client.aclose.assert_awaited()

--- a/acolyte-orchestrator/tests/unit/test_main_pipeline_drain.py
+++ b/acolyte-orchestrator/tests/unit/test_main_pipeline_drain.py
@@ -273,7 +273,9 @@ async def test_shutdown_still_closes_the_pool_when_a_pipeline_dies_uncancellably
     """
     _stub_lifespan_io(monkeypatch)
     pool_close = AsyncMock()
+    http_aclose = AsyncMock()
     monkeypatch.setattr(main_module._pool, "close", pool_close)
+    monkeypatch.setattr(main_module._http_client, "aclose", http_aclose)
     monkeypatch.setattr(main_module, "_PIPELINE_DRAIN_GRACE_SECONDS", 0.05)
     started = asyncio.Event()
 
@@ -296,4 +298,4 @@ async def test_shutdown_still_closes_the_pool_when_a_pipeline_dies_uncancellably
         await started.wait()
 
     pool_close.assert_awaited()
-    main_module._http_client.aclose.assert_awaited()
+    http_aclose.assert_awaited()

--- a/acolyte-orchestrator/tests/unit/test_postgres_report_gw_checkpoint_purge.py
+++ b/acolyte-orchestrator/tests/unit/test_postgres_report_gw_checkpoint_purge.py
@@ -1,0 +1,184 @@
+"""DeleteReport must also reclaim the LangGraph checkpoints of the report's runs.
+
+The checkpoint tables are created by AsyncPostgresSaver.setup(), not by Atlas,
+and they carry no FK back to reports — so a `DELETE FROM reports` leaves the
+per-super-step state (article bodies included) behind forever. These tests
+drive the RPC seam (DeleteReport → PostgresReportGateway) so the purge is
+pinned where the caller sees it.
+
+As in tests/unit/test_postgres_job_gw.py, no live Postgres exists for unit
+tests: `_FakeConnection` doubles the slice of psycopg the gateway uses, with
+the checkpoint tables present or absent to mirror CHECKPOINT_ENABLED=true
+(compose/acolyte.yaml) and =false (compose/compose.staging.yaml).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+
+from acolyte.gateway.postgres_report_gw import PostgresReportGateway
+from acolyte.gen.proto.alt.acolyte.v1 import acolyte_pb2
+from acolyte.handler.connect_service import AcolyteConnectService
+
+_CHECKPOINT_TABLES = ("checkpoints", "checkpoint_blobs", "checkpoint_writes")
+_UNDEFINED_TABLE = 'relation "checkpoints" does not exist'
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[Sequence[Any]]) -> None:
+        self._rows = rows
+
+    async def fetchone(self) -> Sequence[Any] | None:
+        return self._rows[0] if self._rows else None
+
+    async def fetchall(self) -> list[Sequence[Any]]:
+        return list(self._rows)
+
+
+class _FakeConnection:
+    """Answers the queries the DeleteReport path issues, and records every one."""
+
+    def __init__(
+        self,
+        *,
+        report_row: Sequence[Any],
+        run_ids: list[UUID],
+        checkpoint_tables: bool = True,
+    ) -> None:
+        self._report_row = report_row
+        self._run_ids = run_ids
+        self._checkpoint_tables = checkpoint_tables
+        self.executed: list[tuple[str, list[Any] | None]] = []
+
+    async def execute(self, query: str, params: list[Any] | None = None) -> _FakeCursor:
+        self.executed.append((query, params))
+        if any(table in query for table in _CHECKPOINT_TABLES) and not self._checkpoint_tables:
+            # A database where the checkpointer never ran has no such tables.
+            if "to_regclass" in query:
+                return _FakeCursor([(False,)])
+            raise psycopg.errors.UndefinedTable(_UNDEFINED_TABLE)
+        if "to_regclass" in query:
+            return _FakeCursor([(True,)])
+        if "FROM reports WHERE report_id" in query:
+            return _FakeCursor([self._report_row])
+        if "SELECT EXISTS" in query:
+            return _FakeCursor([(False,)])
+        if "FROM report_runs" in query:
+            return _FakeCursor([(run_id,) for run_id in self._run_ids])
+        return _FakeCursor([])
+
+    def transaction(self) -> AbstractAsyncContextManager[None]:
+        return _noop_cm()
+
+
+@asynccontextmanager
+async def _noop_cm() -> AsyncIterator[None]:
+    yield
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConnection) -> None:
+        self._conn = conn
+
+    def connection(self) -> AbstractAsyncContextManager[_FakeConnection]:
+        return _conn_cm(self._conn)
+
+
+@asynccontextmanager
+async def _conn_cm(conn: _FakeConnection) -> AsyncIterator[_FakeConnection]:
+    yield conn
+
+
+def _report_row(report_id: UUID) -> Sequence[Any]:
+    return (report_id, "Disposable", "custom", 1, None, datetime(2026, 8, 14, tzinfo=UTC))
+
+
+def _service(conn: _FakeConnection) -> AcolyteConnectService:
+    return AcolyteConnectService(MagicMock(), PostgresReportGateway(_FakePool(conn)))  # type: ignore[arg-type]
+
+
+def _deletes_for(conn: _FakeConnection, table: str) -> list[tuple[str, list[Any] | None]]:
+    prefix = f"DELETE FROM {table} "  # noqa: S608 — matches recorded SQL, never executed
+    return [(q, p) for q, p in conn.executed if q.startswith(prefix)]
+
+
+@pytest.mark.asyncio
+async def test_delete_report_purges_checkpoints_of_every_run() -> None:
+    report_id, run_a, run_b = uuid4(), uuid4(), uuid4()
+    conn = _FakeConnection(report_row=_report_row(report_id), run_ids=[run_a, run_b])
+
+    await _service(conn).delete_report(
+        acolyte_pb2.DeleteReportRequest(report_id=str(report_id)),
+        ctx=None,  # type: ignore[bad-argument-type]
+    )
+
+    expected_threads = {f"acolyte-run:{run_a}", f"acolyte-run:{run_b}"}
+    for table in _CHECKPOINT_TABLES:
+        deletes = _deletes_for(conn, table)
+        assert deletes, f"no DELETE issued against {table}"
+        purged = {thread for _, params in deletes for param in (params or []) for thread in _as_threads(param)}
+        assert purged == expected_threads, f"{table} purge covered {purged}"
+
+
+def _as_threads(param: object) -> list[str]:
+    """Accept either one thread id per statement or a list bound to ANY(%s)."""
+    if isinstance(param, str):
+        return [param]
+    if isinstance(param, list):
+        return [p for p in param if isinstance(p, str)]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_delete_report_reads_run_ids_before_the_cascade_removes_them() -> None:
+    """DELETE FROM reports cascades report_runs away — the thread ids must be read first."""
+    report_id = uuid4()
+    conn = _FakeConnection(report_row=_report_row(report_id), run_ids=[uuid4()])
+
+    await _service(conn).delete_report(
+        acolyte_pb2.DeleteReportRequest(report_id=str(report_id)),
+        ctx=None,  # type: ignore[bad-argument-type]
+    )
+
+    queries = [q for q, _ in conn.executed]
+    runs_read = next(i for i, q in enumerate(queries) if "FROM report_runs" in q)
+    report_deleted = next(i for i, q in enumerate(queries) if q.startswith("DELETE FROM reports "))
+    checkpoints_deleted = next(i for i, q in enumerate(queries) if q.startswith("DELETE FROM checkpoints "))
+    assert runs_read < checkpoints_deleted < report_deleted
+
+
+@pytest.mark.asyncio
+async def test_delete_report_without_runs_touches_no_checkpoint_table() -> None:
+    report_id = uuid4()
+    conn = _FakeConnection(report_row=_report_row(report_id), run_ids=[])
+
+    await _service(conn).delete_report(
+        acolyte_pb2.DeleteReportRequest(report_id=str(report_id)),
+        ctx=None,  # type: ignore[bad-argument-type]
+    )
+
+    assert not [q for q, _ in conn.executed if "checkpoint" in q]
+    assert [q for q, _ in conn.executed if q.startswith("DELETE FROM reports ")]
+
+
+@pytest.mark.asyncio
+async def test_delete_report_succeeds_when_checkpointing_was_never_enabled() -> None:
+    """CHECKPOINT_ENABLED=false never runs setup(), so the tables do not exist."""
+    report_id = uuid4()
+    conn = _FakeConnection(report_row=_report_row(report_id), run_ids=[uuid4()], checkpoint_tables=False)
+
+    resp = await _service(conn).delete_report(
+        acolyte_pb2.DeleteReportRequest(report_id=str(report_id)),
+        ctx=None,  # type: ignore[bad-argument-type]
+    )
+
+    assert isinstance(resp, acolyte_pb2.DeleteReportResponse)
+    assert [q for q, _ in conn.executed if q.startswith("DELETE FROM reports ")]

--- a/acolyte-orchestrator/tests/unit/test_report_graph_evidence_gate.py
+++ b/acolyte-orchestrator/tests/unit/test_report_graph_evidence_gate.py
@@ -396,8 +396,13 @@ async def test_full_pipeline_skips_finalizer_when_content_store_pipeline_is_holl
     """Run 2a4787e8 regression: curated evidence exists but the content_store
     (empty MemoryContentStore — nothing was ever cached for these IDs)
     hydrates 0 articles, so compressor/quote_selector/fact_normalizer all
-    produce nothing groundable. Must abort with 'no_content' before the
-    finalizer persists a hollow version."""
+    produce nothing groundable. Must abort before the finalizer persists a
+    hollow version.
+
+    The code is 'content_store_miss', not the finalize_guard's 'no_content':
+    hydration_guard now catches a total content-store miss at the hydration
+    boundary, which names the cause and skips the wasted LLM budget. The
+    finalize_guard's no_content verdict is exercised directly above."""
     llm = FakeLLM()
     evidence = ArticlesFoundButUnhydratableEvidence()
     repo = FakeReportRepo()
@@ -414,7 +419,7 @@ async def test_full_pipeline_skips_finalizer_when_content_store_pipeline_is_holl
     )
 
     assert result.get("final_version_no") is None
-    assert result.get("failure_code") == "no_content"
+    assert result.get("failure_code") == "content_store_miss"
     assert result.get("error")
     assert result.get("curated")  # curator did select evidence — the guard isn't just re-checking no_evidence
     assert repo.bump_version_calls == 0

--- a/acolyte-orchestrator/tests/unit/test_rerun_section_version_consistency.py
+++ b/acolyte-orchestrator/tests/unit/test_rerun_section_version_consistency.py
@@ -1,0 +1,381 @@
+"""RerunSection must never leave a section body no report version owns.
+
+RerunSectionUsecase reads ``report.current_version`` and the section's
+``current_version``, then spends tens of seconds inside the writer LLM call,
+then commits the section body and the report version in two separate
+transactions using those *pre-LLM* numbers. Any concurrent writer that bumps
+``reports.current_version`` in that window — another section rerun, or a
+pipeline finalize — makes the report bump raise StaleVersionError *after* the
+body is already committed. ``report_section_versions`` then holds a body that
+no report version and no change_item references, GetReport renders it, and the
+caller sees INTERNAL and retries on top of the corruption.
+
+Both tests drive the real Connect handler so they pin what a caller observes,
+not the usecase's internal call order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+
+from acolyte.domain.exceptions import StaleVersionError
+from acolyte.domain.report import ChangeItem, Report, ReportSection, ReportVersion, SectionVersion
+from acolyte.gen.proto.alt.acolyte.v1 import acolyte_pb2
+from acolyte.handler.connect_service import AcolyteConnectService
+from acolyte.port.llm_provider import LLMResponse
+
+if TYPE_CHECKING:
+    from acolyte.domain.brief import ReportBrief
+
+
+class _LockingRepo:
+    """In-memory ReportRepositoryPort with real optimistic-lock semantics.
+
+    The fakes in test_rerun_section.py accept any ``expected_version``; this
+    one rejects a stale one exactly like PostgresReportGateway does, which is
+    what surfaces the ordering defect.
+    """
+
+    def __init__(self, report_id: UUID) -> None:
+        self.report = Report(
+            report_id=report_id,
+            title="Weekly briefing",
+            report_type="weekly_briefing",
+            current_version=1,
+            latest_successful_run_id=None,
+            created_at=datetime.now(UTC),
+        )
+        self.sections: dict[str, ReportSection] = {
+            "summary": ReportSection(report_id=report_id, section_key="summary", current_version=1, display_order=0),
+            "analysis": ReportSection(report_id=report_id, section_key="analysis", current_version=1, display_order=1),
+        }
+        self.section_bodies: dict[tuple[str, int], str] = {("summary", 1): "Original summary body."}
+        self.report_versions: dict[int, ReportVersion] = {
+            1: ReportVersion(
+                report_id=report_id,
+                version_no=1,
+                change_seq=1,
+                change_reason="gen",
+                created_at=datetime.now(UTC),
+                outline_snapshot=[{"key": "summary", "title": "Executive Summary"}],
+            ),
+        }
+        self.change_items: dict[int, list[ChangeItem]] = {1: []}
+        self.active_run = False
+        self.steal_report_version_lock = False
+
+    # --- concurrent-writer helper -------------------------------------
+
+    def concurrent_rerun_of_same_section(self) -> None:
+        """Simulate a sibling RerunSection landing on *our* section.
+
+        The has_active_run guard only covers pipeline runs, so two reruns can
+        share a section. The loser must abort on the section lock rather than
+        overwrite the winner's body with one written from pre-LLM evidence.
+        """
+        ours = self.sections["summary"]
+        self.sections["summary"] = ReportSection(
+            report_id=ours.report_id,
+            section_key=ours.section_key,
+            current_version=ours.current_version + 1,
+            display_order=ours.display_order,
+        )
+        self.section_bodies[("summary", ours.current_version + 1)] = "Sibling rerun body."
+        new_v = self.report.current_version + 1
+        self.report = Report(
+            report_id=self.report.report_id,
+            title=self.report.title,
+            report_type=self.report.report_type,
+            current_version=new_v,
+            latest_successful_run_id=self.report.latest_successful_run_id,
+            created_at=self.report.created_at,
+        )
+
+    def concurrent_rerun_of_other_section(self) -> None:
+        """Simulate another RerunSection landing on this report.
+
+        It bumps the report version (and its own section), leaving *our*
+        section version untouched — the window in which the section bump
+        still succeeds but the report bump cannot.
+        """
+        other = self.sections["analysis"]
+        self.sections["analysis"] = ReportSection(
+            report_id=other.report_id,
+            section_key=other.section_key,
+            current_version=other.current_version + 1,
+            display_order=other.display_order,
+        )
+        new_v = self.report.current_version + 1
+        self.report = Report(
+            report_id=self.report.report_id,
+            title=self.report.title,
+            report_type=self.report.report_type,
+            current_version=new_v,
+            latest_successful_run_id=self.report.latest_successful_run_id,
+            created_at=self.report.created_at,
+        )
+        self.report_versions[new_v] = ReportVersion(
+            report_id=self.report.report_id,
+            version_no=new_v,
+            change_seq=new_v,
+            change_reason="Section rerun: analysis",
+            created_at=datetime.now(UTC),
+        )
+        self.change_items[new_v] = [ChangeItem(field_name="section:analysis", change_kind="regenerated")]
+
+    def orphaned_section_bodies(self) -> list[tuple[str, int]]:
+        """Committed section bodies that no report change_item accounts for."""
+        claimed = {item.field_name.removeprefix("section:") for items in self.change_items.values() for item in items}
+        return [(key, version_no) for (key, version_no) in self.section_bodies if version_no > 1 and key not in claimed]
+
+    # --- ReportRepositoryPort ------------------------------------------
+
+    async def get_report(self, report_id: UUID) -> Report | None:
+        return self.report if report_id == self.report.report_id else None
+
+    async def get_sections(self, report_id: UUID) -> list[ReportSection]:
+        return sorted(self.sections.values(), key=lambda s: s.display_order)
+
+    async def get_report_version(self, report_id: UUID, version_no: int) -> ReportVersion | None:
+        return self.report_versions.get(version_no)
+
+    async def get_section_version(self, report_id: UUID, section_key: str, version_no: int) -> SectionVersion | None:
+        body = self.section_bodies.get((section_key, version_no))
+        if body is None:
+            return None
+        return SectionVersion(
+            report_id=report_id,
+            section_key=section_key,
+            version_no=version_no,
+            body=body,
+            citations=[{"source_id": "S1", "source_type": "article", "quote": "quoted evidence"}],
+        )
+
+    async def bump_version(
+        self,
+        report_id: UUID,
+        expected_version: int,
+        change_reason: str,
+        change_items: list[ChangeItem],
+        **kwargs: object,
+    ) -> int:
+        if self.steal_report_version_lock:
+            # Another writer lands in the gap between the caller's re-read
+            # and this statement — the residual race no app-layer re-read can
+            # close, and exactly what the optimistic lock exists to catch.
+            self.steal_report_version_lock = False
+            self.concurrent_rerun_of_other_section()
+        if expected_version != self.report.current_version:
+            raise StaleVersionError(report_id, expected_version)
+        new_v = expected_version + 1
+        self.report = Report(
+            report_id=self.report.report_id,
+            title=self.report.title,
+            report_type=self.report.report_type,
+            current_version=new_v,
+            latest_successful_run_id=self.report.latest_successful_run_id,
+            created_at=self.report.created_at,
+        )
+        self.report_versions[new_v] = ReportVersion(
+            report_id=report_id,
+            version_no=new_v,
+            change_seq=new_v,
+            change_reason=change_reason,
+            created_at=datetime.now(UTC),
+        )
+        self.change_items[new_v] = list(change_items)
+        return new_v
+
+    async def bump_section_version(
+        self,
+        report_id: UUID,
+        section_key: str,
+        expected_version: int,
+        body: str,
+        citations: list[dict] | None = None,
+    ) -> int:
+        section = self.sections[section_key]
+        if expected_version != section.current_version:
+            raise StaleVersionError(report_id, expected_version)
+        new_v = expected_version + 1
+        self.sections[section_key] = ReportSection(
+            report_id=section.report_id,
+            section_key=section.section_key,
+            current_version=new_v,
+            display_order=section.display_order,
+        )
+        self.section_bodies[(section_key, new_v)] = body
+        return new_v
+
+    async def has_active_run(self, report_id: UUID) -> bool:
+        return self.active_run
+
+    async def get_brief(self, report_id: UUID) -> ReportBrief | None:
+        return None
+
+    # Unused stubs for the rest of ReportRepositoryPort.
+    async def create_report(self, title: str, report_type: str) -> Report:
+        raise NotImplementedError
+
+    async def create_brief(self, report_id: UUID, brief: ReportBrief) -> None:
+        raise NotImplementedError
+
+    async def list_reports(self, cursor: str | None, limit: int) -> tuple[list[Report], str | None]:
+        raise NotImplementedError
+
+    async def list_report_versions(
+        self, report_id: UUID, cursor: str | None, limit: int
+    ) -> tuple[list[ReportVersion], str | None]:
+        raise NotImplementedError
+
+    async def get_change_items(self, report_id: UUID, version_no: int) -> list[ChangeItem]:
+        return self.change_items.get(version_no, [])
+
+    async def create_section(self, report_id: UUID, section_key: str, display_order: int) -> ReportSection:
+        raise NotImplementedError
+
+    async def delete_report(self, report_id: UUID) -> None:
+        raise NotImplementedError
+
+
+class _SlowLLM:
+    """Writer stub whose generate() is the window a concurrent writer uses."""
+
+    def __init__(self, during_generate: Callable[[], None] | None = None) -> None:
+        self._during_generate = during_generate
+        self.call_count = 0
+
+    async def generate(self, prompt: str, **kwargs: object) -> LLMResponse:
+        self.call_count += 1
+        if self._during_generate is not None:
+            self._during_generate()
+        return LLMResponse(text="Regenerated summary body.", model="fake")
+
+
+def _service(repo: _LockingRepo, llm: _SlowLLM) -> AcolyteConnectService:
+    return AcolyteConnectService(MagicMock(), repo, llm=llm)  # type: ignore[bad-argument-type]
+
+
+@pytest.mark.asyncio
+async def test_rerun_survives_a_concurrent_writer_during_the_llm_call() -> None:
+    """The report version read before the writer call is stale by the time it
+    returns. Bumping with that pre-LLM number fails the optimistic lock after
+    the body is already committed; re-reading immediately before the bumps
+    lets the rerun land cleanly instead.
+    """
+    report_id = uuid4()
+    repo = _LockingRepo(report_id)
+    llm = _SlowLLM(during_generate=repo.concurrent_rerun_of_other_section)
+    service = _service(repo, llm)
+
+    await service.rerun_section(
+        acolyte_pb2.RerunSectionRequest(report_id=str(report_id), section_key="summary"),
+        ctx=None,  # type: ignore[bad-argument-type]
+    )
+
+    assert repo.orphaned_section_bodies() == []
+    assert repo.change_items[3] == [ChangeItem(field_name="section:summary", change_kind="regenerated")]
+    assert repo.section_bodies[("summary", 2)] == "Regenerated summary body."
+
+
+@pytest.mark.asyncio
+async def test_rerun_writes_no_body_when_the_report_version_lock_is_lost() -> None:
+    """The residual race (a writer landing between the re-read and the bump)
+    must abort before any section body is committed. Committing the body
+    first leaves content GetReport renders that no report version or
+    change_item owns, and the caller sees INTERNAL and retries on top of it.
+    """
+    report_id = uuid4()
+    repo = _LockingRepo(report_id)
+    repo.steal_report_version_lock = True
+    service = _service(repo, _SlowLLM())
+
+    with pytest.raises(ConnectError):
+        await service.rerun_section(
+            acolyte_pb2.RerunSectionRequest(report_id=str(report_id), section_key="summary"),
+            ctx=None,  # type: ignore[bad-argument-type]
+        )
+
+    assert repo.orphaned_section_bodies() == []
+    assert repo.sections["summary"].current_version == 1
+
+
+@pytest.mark.asyncio
+async def test_rerun_refuses_while_a_pipeline_run_is_active() -> None:
+    """A pipeline run rewrites every section on finalize. Rerunning underneath
+    it can only lose the race for the same optimistic locks, so refuse up
+    front rather than burn a multi-second LLM call and half-commit.
+    """
+    report_id = uuid4()
+    repo = _LockingRepo(report_id)
+    repo.active_run = True
+    llm = _SlowLLM()
+    service = _service(repo, llm)
+
+    with pytest.raises(ConnectError) as excinfo:
+        await service.rerun_section(
+            acolyte_pb2.RerunSectionRequest(report_id=str(report_id), section_key="summary"),
+            ctx=None,  # type: ignore[bad-argument-type]
+        )
+
+    # "a run owns this report" is a precondition the caller can wait out, not a
+    # server fault. INTERNAL would both mislead the client and log a traceback
+    # into the error-rate SLI on every occurrence. delete_report already returns
+    # FAILED_PRECONDITION for the identical has_active_run check.
+    assert excinfo.value.code == Code.FAILED_PRECONDITION
+    assert llm.call_count == 0
+    assert repo.sections["summary"].current_version == 1
+    assert repo.report.current_version == 1
+
+
+@pytest.mark.asyncio
+async def test_rerun_commits_body_and_version_together_when_uncontended() -> None:
+    """The happy path still lands both bumps: a new report version whose
+    change_item names the section, and the regenerated body itself.
+    """
+    report_id = uuid4()
+    repo = _LockingRepo(report_id)
+    llm = _SlowLLM()
+    service = _service(repo, llm)
+
+    await service.rerun_section(
+        acolyte_pb2.RerunSectionRequest(report_id=str(report_id), section_key="summary"),
+        ctx=None,  # type: ignore[bad-argument-type]
+    )
+
+    assert repo.report.current_version == 2
+    assert repo.change_items[2] == [ChangeItem(field_name="section:summary", change_kind="regenerated")]
+    assert repo.section_bodies[("summary", 2)] == "Regenerated summary body."
+
+
+@pytest.mark.asyncio
+async def test_rerun_aborts_when_a_sibling_rerun_took_the_same_section() -> None:
+    """Re-reading the section row before the bump would make this last-writer-wins.
+
+    Both reruns read v1. The sibling lands v2 while our LLM call is out; our
+    body was written from the v1 citations, so overwriting it as v3 silently
+    discards the sibling's section from the rendered report. The section-level
+    optimistic lock exists to stop exactly that, so it must be checked against
+    the version we read *before* the writer call.
+    """
+    report_id = uuid4()
+    repo = _LockingRepo(report_id)
+    llm = _SlowLLM(during_generate=repo.concurrent_rerun_of_same_section)
+    service = _service(repo, llm)
+
+    with pytest.raises(ConnectError):
+        await service.rerun_section(
+            acolyte_pb2.RerunSectionRequest(report_id=str(report_id), section_key="summary"),
+            ctx=None,  # type: ignore[bad-argument-type]
+        )
+
+    assert repo.section_bodies[("summary", 2)] == "Sibling rerun body.", "the sibling's body must survive"
+    assert ("summary", 3) not in repo.section_bodies, "the losing rerun must not write a body from pre-LLM evidence"

--- a/acolyte-orchestrator/tests/unit/test_resume_recovery.py
+++ b/acolyte-orchestrator/tests/unit/test_resume_recovery.py
@@ -1,0 +1,269 @@
+"""Regression tests for the operator resume path (scripts/resume_run.py).
+
+Two defects that only surface when a run is resumed rather than started:
+
+- "error"/"failure_code" are LastValue channels, so a failed attempt's values
+  are restored from the checkpoint. connect_service's "terminal checkpoint
+  without final_version_no, re-running pipeline" branch feeds the initial
+  state back in untouched, so _finalize_guard saw the *previous* attempt's
+  error and aborted with no_evidence — every resume failed identically, even
+  after the upstream that caused the original failure had recovered (and the
+  10-minute circuit breaker then blocked the ordinary retry too).
+
+- Article bodies only ever live in the process-local MemoryContentStore LRU,
+  filled as a side effect of the gatherer's search. A run resumed in a fresh
+  process hydrates 0 of N curated articles; that used to be an INFO log plus
+  a generic end-of-pipeline "no_content", indistinguishable from articles
+  that genuinely carry no body.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+from structlog.testing import capture_logs
+
+from acolyte.config.settings import Settings
+from acolyte.domain.brief import ReportBrief
+from acolyte.gateway.memory_content_store import MemoryContentStore
+from acolyte.gateway.memory_job_gw import MemoryJobGateway
+from acolyte.gateway.memory_report_gw import MemoryReportGateway
+from acolyte.handler.connect_service import AcolyteConnectService
+from acolyte.port.evidence_provider import ArticleHit, RecapHit
+from acolyte.port.llm_provider import LLMResponse
+from acolyte.usecase.graph.report_graph import build_report_graph
+from scripts.resume_run import _build_pipeline_deps
+
+_TOPIC = "AI trends 2026"
+
+
+class FakeLLM:
+    """Writer gets generic prose, critic always accepts, curator selects nothing
+    (the deterministic <= max_evidence path keeps everything anyway)."""
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    async def generate(self, prompt: str, **kwargs: object) -> LLMResponse:
+        self.prompts.append(prompt)
+        if "critic" in prompt.lower() or "evaluate" in prompt.lower():
+            return LLMResponse(
+                text=json.dumps({"reasoning": "ok", "verdict": "accept", "revise_sections": [], "feedback": {}}),
+                model="fake-model",
+            )
+        if "curator" in prompt.lower() or "select" in prompt.lower():
+            return LLMResponse(text=json.dumps([]), model="fake-model")
+        return LLMResponse(text="Generated section content.", model="fake-model")
+
+
+class RecoveringEvidence:
+    """Every search fails until `recovered` flips — the upstream outage that
+    produced the failed checkpoint, then healed before the operator resumed."""
+
+    def __init__(self) -> None:
+        self.recovered = False
+
+    async def search_articles(self, query: str, **kwargs: object) -> list[ArticleHit]:
+        if not self.recovered:
+            raise httpx.HTTPError("simulated upstream failure")  # noqa: TRY003 — test fake, message is the assertion fixture
+        return [ArticleHit(article_id="art-1", title="Article One", score=1.0, language="en")]
+
+    async def fetch_article_metadata(self, article_ids: list[str]) -> list:
+        return []
+
+    async def fetch_article_body(self, article_id: str) -> str:
+        return ""
+
+    async def search_recaps(self, query: str, *, limit: int = 10) -> list[RecapHit]:
+        if not self.recovered:
+            raise httpx.HTTPError("simulated upstream failure")  # noqa: TRY003 — test fake, message is the assertion fixture
+        return []
+
+
+class ArticleOnlyEvidence:
+    """Search always returns one article; bodies live only in the content store."""
+
+    async def search_articles(self, query: str, **kwargs: object) -> list[ArticleHit]:
+        return [ArticleHit(article_id="art-1", title="Article One", score=1.0, language="en")]
+
+    async def fetch_article_metadata(self, article_ids: list[str]) -> list:
+        return []
+
+    async def fetch_article_body(self, article_id: str) -> str:
+        return ""
+
+    async def search_recaps(self, query: str, *, limit: int = 10) -> list[RecapHit]:
+        return []
+
+
+class RecapOnlyEvidence:
+    """No articles at all — nothing for the hydrator to request a body for."""
+
+    async def search_articles(self, query: str, **kwargs: object) -> list[ArticleHit]:
+        return []
+
+    async def fetch_article_metadata(self, article_ids: list[str]) -> list:
+        return []
+
+    async def fetch_article_body(self, article_id: str) -> str:
+        return ""
+
+    async def search_recaps(self, query: str, *, limit: int = 10) -> list[RecapHit]:
+        return [RecapHit(recap_id="recap-1", title="Recap One", score=1.0)]
+
+
+def _service(graph: object, repo: MemoryReportGateway, jobs: MemoryJobGateway) -> AcolyteConnectService:
+    settings = SimpleNamespace(checkpoint_enabled=True, default_model="fake-model")
+    return AcolyteConnectService(settings, repo, job_queue=jobs, graph=graph)  # type: ignore[bad-argument-type]
+
+
+# --- Finding 038: the checkpoint's stale error must not abort the re-run ---
+
+
+@pytest.mark.asyncio
+async def test_resume_after_upstream_recovery_clears_the_previous_attempts_error() -> None:
+    """scripts/resume_run.py re-runs a terminal, version-less checkpoint. The
+    failed attempt's error must not survive into the new attempt's
+    finalize_guard, or the resume can only ever reproduce no_evidence."""
+    llm = FakeLLM()
+    evidence = RecoveringEvidence()
+    repo = MemoryReportGateway()
+    jobs = MemoryJobGateway()
+    report = await repo.create_report("Test Report", "weekly_briefing")
+    run = await jobs.create_run(report.report_id, 1)
+    graph = build_report_graph(llm, evidence, repo, checkpointer=MemorySaver())
+    service = _service(graph, repo, jobs)
+
+    # Attempt 1: upstream is down — no_evidence, terminal checkpoint, no version.
+    await service.resume_pipeline(str(report.report_id), str(run.run_id), {"topic": _TOPIC})
+    failed = await jobs.get_run(run.run_id)
+    assert failed is not None
+    assert failed.run_status == "failed"
+    assert failed.failure_code == "no_evidence"
+
+    # Attempt 2: operator resumes once search-indexer is back.
+    evidence.recovered = True
+    await service.resume_pipeline(str(report.report_id), str(run.run_id), {"topic": _TOPIC})
+
+    resumed = await jobs.get_run(run.run_id)
+    assert resumed is not None
+    assert resumed.failure_code is None
+    assert resumed.run_status == "succeeded"
+    assert (await repo.get_report(report.report_id)).current_version == 1  # type: ignore[optional-member-access]
+
+
+# --- Finding 039: an empty content store must be its own, explicit failure ---
+
+
+@pytest.mark.asyncio
+async def test_resume_with_empty_content_store_fails_with_content_store_miss() -> None:
+    """The gatherer's search populated the LRU in the *previous* process; the
+    resumed run hydrates 0/N and must say so, not report a generic
+    end-of-pipeline no_content."""
+    llm = FakeLLM()
+    repo = MemoryReportGateway()
+    jobs = MemoryJobGateway()
+    report = await repo.create_report("Test Report", "weekly_briefing")
+    run = await jobs.create_run(report.report_id, 1)
+    graph = build_report_graph(
+        llm,
+        ArticleOnlyEvidence(),
+        repo,
+        content_store=MemoryContentStore(),  # fresh process — nothing cached
+        checkpointer=MemorySaver(),
+    )
+    service = _service(graph, repo, jobs)
+
+    await service.resume_pipeline(str(report.report_id), str(run.run_id), {"topic": _TOPIC})
+
+    failed = await jobs.get_run(run.run_id)
+    assert failed is not None
+    assert failed.run_status == "failed"
+    # The literal is what an operator reads out of report_runs.failure_code,
+    # and what start_run_uc's circuit breaker matches on — pin the string.
+    assert failed.failure_code == "content_store_miss"
+    assert (await repo.get_report(report.report_id)).current_version == 0  # type: ignore[optional-member-access]
+
+
+@pytest.mark.asyncio
+async def test_content_store_miss_aborts_before_the_writer_runs() -> None:
+    """Fail at the hydration boundary, not 70 minutes of LLM calls later."""
+    llm = FakeLLM()
+    repo = MemoryReportGateway()
+    report = await repo.create_report("Test Report", "weekly_briefing")
+
+    graph = build_report_graph(llm, ArticleOnlyEvidence(), repo, content_store=MemoryContentStore())
+    result = await graph.ainvoke(
+        {"report_id": str(report.report_id), "run_id": str(uuid4()), "brief": {"topic": _TOPIC}, "revision_count": 0}
+    )
+
+    assert result.get("curated")  # the curator did select the article
+    assert not result.get("sections")  # …but the writer never ran
+    assert not result.get("critique")
+
+
+@pytest.mark.asyncio
+async def test_recap_only_run_is_not_a_content_store_miss() -> None:
+    """Zero articles requested means zero hydrated is correct, not a miss."""
+    llm = FakeLLM()
+    repo = MemoryReportGateway()
+    report = await repo.create_report("Test Report", "weekly_briefing")
+
+    graph = build_report_graph(llm, RecapOnlyEvidence(), repo, content_store=MemoryContentStore())
+    result = await graph.ainvoke(
+        {"report_id": str(report.report_id), "run_id": str(uuid4()), "brief": {"topic": _TOPIC}, "revision_count": 0}
+    )
+
+    assert result.get("failure_code") != "content_store_miss"
+
+
+def test_resume_run_announces_that_its_content_store_starts_empty() -> None:
+    """scripts/resume_run.py builds a brand-new LRU. Article bodies only enter
+    it as a side effect of the gatherer's search, so a resume past the gatherer
+    hydrates 0/N — the operator must be told that up front instead of inferring
+    it from the failure code much later."""
+    with capture_logs() as logs:
+        _hyde_generator, content_store = _build_pipeline_deps(Settings(content_store_max_size=42), MagicMock())
+
+    assert isinstance(content_store, MemoryContentStore)
+    assert len(content_store) == 0
+    warnings = [e for e in logs if e.get("log_level") == "warning"]
+    assert warnings, "an empty content store on resume must be logged, not silent"
+    assert warnings[0].get("hydration_failure_code") == "content_store_miss"
+    assert warnings[0].get("max_size") == 42
+
+
+# --- Sanity: the brief round-trip resume_run.py performs stays intact ---
+
+
+@pytest.mark.asyncio
+async def test_resume_pipeline_accepts_a_brief_dict_from_the_repository() -> None:
+    """resume_run.py resolves run -> report -> brief.to_dict() before calling
+    resume_pipeline; the recovery fixes must not change that contract."""
+    llm = FakeLLM()
+    evidence = ArticleOnlyEvidence()
+    repo = MemoryReportGateway()
+    jobs = MemoryJobGateway()
+    report = await repo.create_report("Test Report", "weekly_briefing")
+    await repo.create_brief(report.report_id, ReportBrief(topic=_TOPIC, report_type="weekly_briefing"))
+    run = await jobs.create_run(report.report_id, 1)
+
+    content_store = MemoryContentStore()
+    await content_store.store("art-1", "Article One has a full body with plenty of relevant sentences to cite.")
+    graph = build_report_graph(llm, evidence, repo, content_store=content_store, checkpointer=MemorySaver())
+    service = _service(graph, repo, jobs)
+
+    brief = await repo.get_brief(report.report_id)
+    assert brief is not None
+    await service.resume_pipeline(str(report.report_id), str(run.run_id), brief.to_dict())
+
+    completed = await jobs.get_run(run.run_id)
+    assert completed is not None
+    assert completed.run_status == "succeeded"
+    assert completed.run_id == UUID(str(run.run_id))

--- a/alt-backend/app/adapter/augur_adapter/augur_adapter.go
+++ b/alt-backend/app/adapter/augur_adapter/augur_adapter.go
@@ -17,13 +17,31 @@ type RagClientInterface interface {
 	AnswerWithRAGStream(ctx context.Context, body rag_gateway.AnswerWithRAGStreamJSONRequestBody, reqEditors ...rag_gateway.RequestEditorFn) (*http.Response, error)
 }
 
+// upsertArticleTimeout is how long one UpsertIndex call may run before this
+// adapter gives up on it, independent of whatever budget the caller has.
+//
+// The caller is the outbox worker, whose job timeout is 5 minutes for a batch
+// of 10 events (see orchestrator/job/registry.go). Without a per-article
+// budget a single article that never answers consumes that whole window, and
+// the other nine claimed rows are released unattempted — so the worker's
+// throughput is set by its slowest article rather than by its batch size.
+// 60s is double the 10-30s a heavy article (500+KB, 100+ chunks) takes on the
+// local embedder, and a tenth of the job budget, so one stuck article costs
+// one article's worth of a tick instead of the whole tick.
+const upsertArticleTimeout = 60 * time.Second
+
 type AugurAdapter struct {
 	client RagClientInterface
+	// upsertTimeout is a field rather than a direct use of the constant so a
+	// test can shorten it; NewAugurAdapter is the only production path and
+	// always sets upsertArticleTimeout.
+	upsertTimeout time.Duration
 }
 
 func NewAugurAdapter(client RagClientInterface) rag_integration_port.RagIntegrationPort {
 	return &AugurAdapter{
-		client: client,
+		client:        client,
+		upsertTimeout: upsertArticleTimeout,
 	}
 }
 
@@ -43,22 +61,22 @@ func (a *AugurAdapter) UpsertArticle(ctx context.Context, input rag_integration_
 		UserId:      input.UserID,
 	}
 
-	resp, err := a.client.UpsertIndexWithResponse(ctx, reqBody)
+	callCtx, cancel := context.WithTimeout(ctx, a.upsertTimeout)
+	defer cancel()
+
+	resp, err := a.client.UpsertIndexWithResponse(callCtx, reqBody)
 	if err != nil {
-		if ctx.Err() != nil {
-			// The caller's own deadline (the outbox worker's per-tick job
-			// timeout) expired mid-request, not a rag-orchestrator failure.
-			// Classifying this transient would have the outbox worker
-			// release the row and retry it through the same job timeout
-			// again — for an article that legitimately takes this long,
-			// that stalls the whole worker for another full timeout window
-			// per attempt instead of once, head-of-line blocking every
-			// event behind it.
-			return fmt.Errorf("failed to call UpsertIndex: %w", err)
-		}
-		// A transport failure (dial/timeout/DNS) has the same chance of
-		// succeeding on retry as a 5xx below — the request never reached
-		// rag-orchestrator's handler either way.
+		// Every failure that arrives without a verdict from
+		// rag-orchestrator is retryable, and a context cancellation is the
+		// clearest case of one: the article was never rejected, it just
+		// never got its turn. That includes the caller's job context dying
+		// on SIGTERM, which is a redeploy rather than an article problem —
+		// treating it terminal wrote the row FAILED, and a FAILED row is
+		// outside the PENDING claim query, untouched by outbox-prune and
+		// reachable by no requeue path, so every deploy permanently
+		// un-indexed whichever article was mid-upsert. Retries are bounded
+		// by the outbox worker's own attempt budget, and one attempt is
+		// bounded by upsertArticleTimeout above.
 		return fmt.Errorf("%w: failed to call UpsertIndex: %w", rag_integration_port.ErrRagUpsertTransient, err)
 	}
 

--- a/alt-backend/app/adapter/augur_adapter/augur_adapter.go
+++ b/alt-backend/app/adapter/augur_adapter/augur_adapter.go
@@ -25,10 +25,18 @@ type RagClientInterface interface {
 // budget a single article that never answers consumes that whole window, and
 // the other nine claimed rows are released unattempted — so the worker's
 // throughput is set by its slowest article rather than by its batch size.
-// 60s is double the 10-30s a heavy article (500+KB, 100+ chunks) takes on the
-// local embedder, and a tenth of the job budget, so one stuck article costs
-// one article's worth of a tick instead of the whole tick.
-const upsertArticleTimeout = 60 * time.Second
+//
+// It is derived from that job budget rather than from the embedder, because
+// too tight a ceiling does not cost a slow article one attempt: a blown budget
+// is transient (below), so the row goes back to PENDING, is re-claimed and is
+// cut at the same point every tick until the worker's attempt budget runs out
+// and marks it FAILED — the same permanent loss the transient classification
+// exists to prevent. Two minutes is under half the job budget, so a stuck
+// article still leaves the rest of the batch most of the window, and well over
+// the 10-30s a heavy article (500+KB, 100+ chunks) takes on the local embedder
+// even with a cold model load, so an article the job budget would have
+// finished still finishes.
+const upsertArticleTimeout = 2 * time.Minute
 
 type AugurAdapter struct {
 	client RagClientInterface

--- a/alt-backend/app/adapter/augur_adapter/augur_adapter_test.go
+++ b/alt-backend/app/adapter/augur_adapter/augur_adapter_test.go
@@ -122,6 +122,37 @@ func TestAugurAdapter_UpsertArticle_ClassifiesFailures(t *testing.T) {
 		}
 	})
 
+	t.Run("the budget is not the binding constraint on a heavy article", func(t *testing.T) {
+		// The budget exists so one stuck article cannot spend the outbox
+		// worker's whole window and release the other nine claimed rows
+		// unattempted. But it is a ceiling on a call that used to inherit
+		// that window, so setting it below what a legitimately heavy article
+		// takes does not cost that article one attempt: a blown budget is
+		// transient (the case above), so the row returns to PENDING, is
+		// re-claimed next tick, and is cut at the same point again until the
+		// worker's attempt budget is spent and the row is marked terminally
+		// FAILED. That is the same permanent loss the transient
+		// classification exists to prevent, reached by a different road.
+		//
+		// A heavy article (500+KB, 100+ chunks) takes 10-30s on the local
+		// embedder; three times the top of that range is the headroom for a
+		// cold model load or a host under batch load. Articles that slow used
+		// to finish on the job's context and must still finish.
+		const heavyArticleUpsertUnderLoad = 90 * time.Second
+		// The timeout orchestrator/job/registry.go registers outbox-worker
+		// with, for a batch of ten.
+		const outboxWorkerJobBudget = 5 * time.Minute
+
+		if upsertArticleTimeout < heavyArticleUpsertUnderLoad {
+			t.Errorf("per-article budget %s is under the %s a heavy article can legitimately take: every such article is cut, released to PENDING and cut again until it is marked FAILED",
+				upsertArticleTimeout, heavyArticleUpsertUnderLoad)
+		}
+		if upsertArticleTimeout > outboxWorkerJobBudget/2 {
+			t.Errorf("per-article budget %s leaves under half of the %s job budget for the other nine rows of the batch",
+				upsertArticleTimeout, outboxWorkerJobBudget)
+		}
+	})
+
 	t.Run("400 from rag-orchestrator is NOT transient", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/alt-backend/app/adapter/augur_adapter/augur_adapter_test.go
+++ b/alt-backend/app/adapter/augur_adapter/augur_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"alt/orchestrator/gateway/rag_gateway"
 	"alt/orchestrator/port/rag_integration_port"
@@ -57,13 +58,13 @@ func TestAugurAdapter_UpsertArticle_ClassifiesFailures(t *testing.T) {
 		}
 	})
 
-	t.Run("caller's own context deadline expiring mid-request is NOT transient", func(t *testing.T) {
-		// This is the outbox worker's job timeout firing while
-		// UpsertIndexWithResponse is still in flight, not a
-		// rag-orchestrator-side failure. Classifying it transient would
-		// have the worker release the row and retry it into the same job
-		// timeout again on the very next tick — stalling the whole worker
-		// for another full timeout window per attempt instead of once.
+	t.Run("caller's job context dying mid-request IS transient", func(t *testing.T) {
+		// SIGTERM during a redeploy cancels the harvester's job context
+		// while UpsertIndexWithResponse is in flight. Nothing about this
+		// article failed — it simply never got its turn. Classifying it
+		// terminal wrote the row FAILED, which the PENDING-only claim
+		// query never re-fetches and outbox-prune never removes, so every
+		// redeploy permanently un-indexed whichever article was mid-upsert.
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client := NewMockRagClientInterface(ctrl)
@@ -79,8 +80,45 @@ func TestAugurAdapter_UpsertArticle_ClassifiesFailures(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error")
 		}
-		if errors.Is(err, rag_integration_port.ErrRagUpsertTransient) {
-			t.Errorf("a caller-context cancellation must not be classified transient, got: %v", err)
+		if !errors.Is(err, rag_integration_port.ErrRagUpsertTransient) {
+			t.Errorf("a caller-context cancellation must be classified transient so the row returns to PENDING, got: %v", err)
+		}
+	})
+
+	t.Run("one upsert cannot spend the caller's whole budget", func(t *testing.T) {
+		// Releasing a canceled upsert back to PENDING is only affordable
+		// because a single article cannot occupy the worker for the whole
+		// job timeout: without a budget of its own, one article that never
+		// returns starves the other nine rows of the batch until the job
+		// times out, and each retry costs another full window. The budget
+		// caps that at one article's worth, and the outbox's attempt
+		// budget caps how often it is paid.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := NewMockRagClientInterface(ctrl)
+		client.EXPECT().
+			UpsertIndexWithResponse(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ rag_gateway.UpsertIndexJSONRequestBody, _ ...rag_gateway.RequestEditorFn) (*rag_gateway.UpsertIndexResponse, error) {
+				<-ctx.Done() // the embedder never answers
+				return nil, ctx.Err()
+			})
+
+		// The caller's context carries no deadline at all, so anything
+		// that bounds this call has to come from the adapter itself.
+		adapter := &AugurAdapter{client: client, upsertTimeout: 50 * time.Millisecond}
+		done := make(chan error, 1)
+		go func() { done <- adapter.UpsertArticle(context.Background(), input) }()
+
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !errors.Is(err, rag_integration_port.ErrRagUpsertTransient) {
+				t.Errorf("a blown per-article budget must stay retryable, got: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("UpsertArticle never returned: it has no budget of its own and inherits the caller's")
 		}
 	})
 

--- a/alt-backend/app/config/backend_token_secret_failfast_test.go
+++ b/alt-backend/app/config/backend_token_secret_failfast_test.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeBackendTokenSecretFile emulates the Docker Secrets mount compose wires
+// as BACKEND_TOKEN_SECRET_FILE=/run/secrets/backend_token_secret.
+func writeBackendTokenSecretFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "backend_token_secret")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+	return path
+}
+
+// TestNewConfig_BackendTokenSecretFileFailsFast pins CLAUDE.md rule 9 for the
+// JWT signing secret. Every compose file points BACKEND_TOKEN_SECRET_FILE at a
+// mounted secret, and middleware/jwt_middleware.go plus
+// connect/v2/middleware/auth_interceptor.go verify every browser token against
+// the value it resolves to. An empty result is therefore not a disabled
+// feature: the container stays healthy while answering 401 to every
+// authenticated REST and Connect call, with nothing in the log to say why.
+//
+// The guard must not be keyed on APP_ENV — APP_ENV is set in no compose file,
+// so validateAuthConfig's env == "production" branch never fires in a real
+// deployment (the same trap validateImageProxyConfig documents).
+func TestNewConfig_BackendTokenSecretFileFailsFast(t *testing.T) {
+	emptySecretFile := writeBackendTokenSecretFile(t, "")
+	whitespaceSecretFile := writeBackendTokenSecretFile(t, "  \n\t ")
+	goodSecretFile := writeBackendTokenSecretFile(t, "dev-backend-token-secret-long-enough\n")
+	missingSecretFile := filepath.Join(t.TempDir(), "never-mounted")
+
+	tests := []struct {
+		name       string
+		envVars    map[string]string
+		wantErr    bool
+		errMsg     string
+		wantSecret string
+	}{
+		{
+			name: "empty secret file fails fast",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET_FILE": emptySecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			name: "whitespace-only secret file fails fast",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET_FILE": whitespaceSecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			name: "unreadable secret file fails fast",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET_FILE": missingSecretFile,
+			},
+			wantErr: true,
+			errMsg:  "BACKEND_TOKEN_SECRET_FILE",
+		},
+		{
+			name: "development is not exempt from the guard",
+			envVars: map[string]string{
+				"APP_ENV":                   "development",
+				"BACKEND_TOKEN_SECRET_FILE": emptySecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			// The old block re-read the file and assigned the trimmed result
+			// unconditionally, so an empty mount overwrote a perfectly good
+			// BACKEND_TOKEN_SECRET with "". A contradictory pair is a
+			// misconfiguration either way, so it exits non-zero rather than
+			// picking a winner silently.
+			name: "an empty mount is rejected even when BACKEND_TOKEN_SECRET is set",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET":      "env-supplied-backend-token-secret",
+				"BACKEND_TOKEN_SECRET_FILE": emptySecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			name: "non-empty secret file starts",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET_FILE": goodSecretFile,
+			},
+			wantSecret: "dev-backend-token-secret-long-enough",
+		},
+		{
+			name: "BACKEND_TOKEN_SECRET env var starts",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET": "env-supplied-backend-token-secret",
+			},
+			wantSecret: "env-supplied-backend-token-secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars := map[string]string{"IMAGE_PROXY_ENABLED": "false"}
+			for key, value := range tt.envVars {
+				envVars[key] = value
+			}
+			applyEnv(t, envVars)
+
+			cfg, err := NewConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NewConfig() expected error but got none")
+				}
+				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Errorf("NewConfig() error = %v, want to contain %s", err, tt.errMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NewConfig() unexpected error: %v", err)
+			}
+			if cfg.Auth.BackendTokenSecret != tt.wantSecret {
+				t.Errorf("Auth.BackendTokenSecret = %q, want %q", cfg.Auth.BackendTokenSecret, tt.wantSecret)
+			}
+		})
+	}
+}

--- a/alt-backend/app/config/binary.go
+++ b/alt-backend/app/config/binary.go
@@ -322,6 +322,14 @@ func ValidateHarvesterConfig(cfg *Config) error {
 }
 
 // ValidateDataHubConfig checks the upstreams DataHubService calls.
+//
+// INTERNAL_AUTH_SECRET is on this list because di/datahub hands it to
+// kratos_client, which puts it verbatim into the X-Internal-Auth header of
+// every auth-hub /internal/system-user call. Unset is not a disabled feature:
+// alt-data-hub would report healthy while auth-hub answered 401 to every
+// GetSystemUser call. NewConfig only catches INTERNAL_AUTH_SECRET_FILE that
+// resolves to empty, so the plain-unset case has to fail here (CLAUDE.md
+// rule 9).
 func ValidateDataHubConfig(cfg *Config) error {
 	required := []struct {
 		env   string
@@ -329,6 +337,7 @@ func ValidateDataHubConfig(cfg *Config) error {
 	}{
 		{"AUTH_HUB_URL", cfg.AuthHub.URL},
 		{"BACKEND_TOKEN_SECRET", cfg.Auth.BackendTokenSecret},
+		{"INTERNAL_AUTH_SECRET", cfg.Auth.InternalAuthSecret},
 		{"SOVEREIGN_URL", cfg.Sovereign.URL},
 		{"MQHUB_CONNECT_URL", cfg.MQHub.ConnectURL},
 	}

--- a/alt-backend/app/config/binary_test.go
+++ b/alt-backend/app/config/binary_test.go
@@ -21,9 +21,15 @@ func baseConfig() *Config {
 		Rag:           RAGConfig{OrchestratorURL: "http://rag-orchestrator:9010", OrchestratorConnectURL: "http://rag-orchestrator:9011"},
 		MQHub:         MQHubConfig{Enabled: true, ConnectURL: "http://mq-hub:9500"},
 		AuthHub:       AuthHubConfig{URL: "http://auth-hub:8888"},
-		Auth:          AuthConfig{BackendTokenSecret: "a-backend-token-secret-value"},
-		Sovereign:     SovereignConfig{URL: "http://knowledge-sovereign:9500"},
-		WebPush:       WebPushConfig{PublicKey: "a-vapid-public-key-value"},
+		// Two distinct secrets, as every environment must supply: the /internal
+		// shared bearer travels in a plaintext header and the signing key must
+		// not be reachable from there.
+		Auth: AuthConfig{
+			BackendTokenSecret: "a-backend-token-secret-value",
+			InternalAuthSecret: "a-distinct-internal-auth-secret-value",
+		},
+		Sovereign: SovereignConfig{URL: "http://knowledge-sovereign:9500"},
+		WebPush:   WebPushConfig{PublicKey: "a-vapid-public-key-value"},
 	}
 }
 

--- a/alt-backend/app/config/config.go
+++ b/alt-backend/app/config/config.go
@@ -332,13 +332,34 @@ func NewConfig() (*Config, error) {
 		}
 	}
 
-	// Load backend token secret from file if configured (Docker Secrets support)
+	// Load backend token secret from file if configured (Docker Secrets support).
+	//
+	// Unlike the two blocks above this one does NOT fall back to the env value
+	// on failure. middleware/jwt_middleware.go and
+	// connect/v2/middleware/auth_interceptor.go verify every browser token
+	// against this secret, and an empty one rejects all of them: the container
+	// stays healthy, /health answers 200, and every authenticated REST and
+	// Connect call answers 401 with nothing in the log to say why. That cannot
+	// be a fallback state, so a mounted-but-unreadable or mounted-but-empty
+	// secret exits non-zero here (CLAUDE.md rule 9).
+	//
+	// The guard is deliberately environment-independent. validateAuthConfig
+	// only requires the secret when APP_ENV == "production", and APP_ENV is set
+	// in no compose file — the same trap validateImageProxyConfig documents.
 	if config.Auth.BackendTokenSecretFile != "" {
 		content, err := os.ReadFile(config.Auth.BackendTokenSecretFile)
-		if err == nil {
-			config.Auth.BackendTokenSecret = strings.TrimSpace(string(content))
+		if err != nil {
+			return nil, fmt.Errorf("read BACKEND_TOKEN_SECRET_FILE %s: %w",
+				config.Auth.BackendTokenSecretFile, err)
 		}
-		// If file read fails, we fall back to the env var value (if any) or keep it empty
+		secret := strings.TrimSpace(string(content))
+		if secret == "" {
+			return nil, fmt.Errorf("BACKEND_TOKEN_SECRET_FILE=%s resolved to an empty secret: "+
+				"every authenticated request would be rejected with 401 while the container stayed healthy; "+
+				"mount a non-empty secret or set BACKEND_TOKEN_SECRET instead",
+				config.Auth.BackendTokenSecretFile)
+		}
+		config.Auth.BackendTokenSecret = secret
 	}
 
 	// Set defaults for JWT issuer and audience if not provided

--- a/alt-backend/app/config/config.go
+++ b/alt-backend/app/config/config.go
@@ -195,6 +195,19 @@ type AuthConfig struct {
 	BackendTokenSecretFile string `json:"-" env:"BACKEND_TOKEN_SECRET_FILE"`
 	BackendTokenIssuer     string `json:"backend_token_issuer" env:"BACKEND_TOKEN_ISSUER"`
 	BackendTokenAudience   string `json:"backend_token_audience" env:"BACKEND_TOKEN_AUDIENCE"`
+
+	// InternalAuthSecret is the shared bearer cmd/datahub puts in the
+	// X-Internal-Auth header of every auth-hub /internal/system-user call.
+	// di/datahub's composition root is its only consumer: it hands this — not
+	// BackendTokenSecret — to kratos_client.NewKratosClient.
+	//
+	// The two are separate because that header crosses the network in
+	// plaintext and lands in nginx access logs and OTel span attributes, and
+	// the HS256 key that signs every browser token must never reach those
+	// places. NewConfig exits non-zero if they are set to the same value, and
+	// auth-hub refuses to start on the same condition.
+	InternalAuthSecret     string `json:"-" env:"INTERNAL_AUTH_SECRET"`
+	InternalAuthSecretFile string `json:"-" env:"INTERNAL_AUTH_SECRET_FILE"`
 }
 
 type ServerConfig struct {
@@ -360,6 +373,38 @@ func NewConfig() (*Config, error) {
 				config.Auth.BackendTokenSecretFile)
 		}
 		config.Auth.BackendTokenSecret = secret
+	}
+
+	// Same shape for the /internal shared bearer, and for the same reason: an
+	// empty result is not a disabled feature. cmd/datahub would then send an
+	// empty X-Internal-Auth and auth-hub would answer 401 to every
+	// GetSystemUser call while both containers stayed healthy.
+	if config.Auth.InternalAuthSecretFile != "" {
+		content, err := os.ReadFile(config.Auth.InternalAuthSecretFile)
+		if err != nil {
+			return nil, fmt.Errorf("read INTERNAL_AUTH_SECRET_FILE %s: %w",
+				config.Auth.InternalAuthSecretFile, err)
+		}
+		secret := strings.TrimSpace(string(content))
+		if secret == "" {
+			return nil, fmt.Errorf("INTERNAL_AUTH_SECRET_FILE=%s resolved to an empty secret: "+
+				"auth-hub would reject every /internal/system-user call with 401 while the container stayed healthy; "+
+				"mount a non-empty secret or set INTERNAL_AUTH_SECRET instead",
+				config.Auth.InternalAuthSecretFile)
+		}
+		config.Auth.InternalAuthSecret = secret
+	}
+
+	// The two secrets exist precisely so the signing key stays inside the
+	// process. Handing both jobs one value again is the exposure this split
+	// removed, so it exits non-zero instead of degrading back to it. The guard
+	// is environment-independent for the same reason the one above is: APP_ENV
+	// is set in no compose file.
+	if config.Auth.InternalAuthSecret != "" &&
+		config.Auth.InternalAuthSecret == config.Auth.BackendTokenSecret {
+		return nil, fmt.Errorf("INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET: " +
+			"the /internal shared bearer travels in a plaintext X-Internal-Auth header and reaches " +
+			"access logs and OTel span attributes, which is no place for the JWT signing key")
 	}
 
 	// Set defaults for JWT issuer and audience if not provided

--- a/alt-backend/app/config/datahub_internal_auth_required_test.go
+++ b/alt-backend/app/config/datahub_internal_auth_required_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// INTERNAL_AUTH_SECRET belongs on cmd/datahub's required list for the same
+// reason BACKEND_TOKEN_SECRET does, and the failure it prevents is worse:
+// di/datahub hands this value to kratos_client, which puts it verbatim into
+// X-Internal-Auth. An unset variable is not a disabled feature — alt-data-hub
+// reports healthy, sends an empty header, and auth-hub's
+// middleware/internal_auth.go answers 401 to every GetSystemUser call
+// (CLAUDE.md rule 9).
+//
+// NewConfig's own guard only covers INTERNAL_AUTH_SECRET_FILE resolving to
+// empty, so with neither variable set nothing between startup and the first
+// 401 says anything at all.
+func TestValidateDataHubConfig_RequiresInternalAuthSecret(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Auth.InternalAuthSecret = ""
+
+	err := ValidateDataHubConfig(cfg)
+	if err == nil {
+		t.Fatal("expected an error naming INTERNAL_AUTH_SECRET")
+	}
+	if !strings.Contains(err.Error(), "INTERNAL_AUTH_SECRET") {
+		t.Errorf("error = %v, want it to name INTERNAL_AUTH_SECRET", err)
+	}
+}

--- a/alt-backend/app/config/internal_auth_secret_test.go
+++ b/alt-backend/app/config/internal_auth_secret_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// internalAuthEnvKeys are reset before every case so a value leaked from a
+// neighbouring test cannot decide a fail-fast assertion.
+var internalAuthEnvKeys = []string{
+	"APP_ENV",
+	"IMAGE_PROXY_ENABLED",
+	"BACKEND_TOKEN_SECRET",
+	"BACKEND_TOKEN_SECRET_FILE",
+	"INTERNAL_AUTH_SECRET",
+	"INTERNAL_AUTH_SECRET_FILE",
+}
+
+func applyInternalAuthEnv(t *testing.T, envVars map[string]string) {
+	t.Helper()
+	for _, key := range internalAuthEnvKeys {
+		t.Setenv(key, "")
+	}
+	t.Setenv("IMAGE_PROXY_ENABLED", "false")
+	for key, value := range envVars {
+		t.Setenv(key, value)
+	}
+}
+
+// writeInternalAuthSecretFile emulates the Docker Secrets mount compose wires
+// as INTERNAL_AUTH_SECRET_FILE=/run/secrets/internal_auth_secret.
+func writeInternalAuthSecretFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "internal_auth_secret")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+	return path
+}
+
+// TestNewConfig_InternalAuthSecret separates the /internal shared bearer from
+// the HS256 key that signs backend JWTs.
+//
+// cmd/datahub sends this value in a plaintext X-Internal-Auth header on every
+// auth-hub GetSystemUser call, so it reaches nginx access logs and OTel span
+// attributes. The signing key must never travel there, which makes the two
+// secrets two different values — and a config that sets them to the same
+// string exits non-zero rather than quietly restoring the old exposure.
+//
+// The _FILE guard follows BACKEND_TOKEN_SECRET_FILE's shape (CLAUDE.md rule 9):
+// a mounted-but-empty or unreadable secret is a misconfiguration, not a
+// disabled feature.
+func TestNewConfig_InternalAuthSecret(t *testing.T) {
+	emptySecretFile := writeInternalAuthSecretFile(t, "")
+	whitespaceSecretFile := writeInternalAuthSecretFile(t, "  \n\t ")
+	goodSecretFile := writeInternalAuthSecretFile(t, "dev-internal-auth-secret-long-enough\n")
+	missingSecretFile := filepath.Join(t.TempDir(), "never-mounted")
+
+	tests := []struct {
+		name       string
+		envVars    map[string]string
+		wantErr    bool
+		errMsg     string
+		wantSecret string
+	}{
+		{
+			name: "empty secret file fails fast",
+			envVars: map[string]string{
+				"INTERNAL_AUTH_SECRET_FILE": emptySecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			name: "whitespace-only secret file fails fast",
+			envVars: map[string]string{
+				"INTERNAL_AUTH_SECRET_FILE": whitespaceSecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			name: "unreadable secret file fails fast",
+			envVars: map[string]string{
+				"INTERNAL_AUTH_SECRET_FILE": missingSecretFile,
+			},
+			wantErr: true,
+			errMsg:  "INTERNAL_AUTH_SECRET_FILE",
+		},
+		{
+			name: "development is not exempt from the guard",
+			envVars: map[string]string{
+				"APP_ENV":                   "development",
+				"INTERNAL_AUTH_SECRET_FILE": emptySecretFile,
+			},
+			wantErr: true,
+			errMsg:  "resolved to an empty secret",
+		},
+		{
+			name: "reusing the JWT signing key is rejected",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET": "one-secret-doing-two-jobs-is-the-bug",
+				"INTERNAL_AUTH_SECRET": "one-secret-doing-two-jobs-is-the-bug",
+			},
+			wantErr: true,
+			errMsg:  "INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET",
+		},
+		{
+			name: "reusing the JWT signing key is rejected across env and mount",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET":      "dev-internal-auth-secret-long-enough",
+				"INTERNAL_AUTH_SECRET_FILE": goodSecretFile,
+			},
+			wantErr: true,
+			errMsg:  "INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET",
+		},
+		{
+			name: "non-empty secret file starts",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET":      "env-supplied-backend-token-secret",
+				"INTERNAL_AUTH_SECRET_FILE": goodSecretFile,
+			},
+			wantSecret: "dev-internal-auth-secret-long-enough",
+		},
+		{
+			name: "INTERNAL_AUTH_SECRET env var starts",
+			envVars: map[string]string{
+				"BACKEND_TOKEN_SECRET": "env-supplied-backend-token-secret",
+				"INTERNAL_AUTH_SECRET": "env-supplied-internal-auth-secret",
+			},
+			wantSecret: "env-supplied-internal-auth-secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyInternalAuthEnv(t, tt.envVars)
+
+			cfg, err := NewConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NewConfig() expected error but got none")
+				}
+				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Errorf("NewConfig() error = %v, want to contain %s", err, tt.errMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NewConfig() unexpected error: %v", err)
+			}
+			if cfg.Auth.InternalAuthSecret != tt.wantSecret {
+				t.Errorf("Auth.InternalAuthSecret = %q, want %q", cfg.Auth.InternalAuthSecret, tt.wantSecret)
+			}
+			if cfg.Auth.InternalAuthSecret == cfg.Auth.BackendTokenSecret {
+				t.Errorf("Auth.InternalAuthSecret must differ from Auth.BackendTokenSecret, both are %q",
+					cfg.Auth.InternalAuthSecret)
+			}
+		})
+	}
+}

--- a/alt-backend/app/dataplane/connect/datahubapi/handler.go
+++ b/alt-backend/app/dataplane/connect/datahubapi/handler.go
@@ -119,8 +119,11 @@ type Handler struct {
 	systemUser     SystemUserPort
 	recentArticles RecentArticlesUsecase
 
-	// Event publishing. The mq-hub publisher is genuinely optional — it
-	// carries notifications, and it says so itself through IsEnabled.
+	// Event publishing. The mq-hub publisher is switchable — it carries
+	// notifications, and it says so itself through IsEnabled — but switchable
+	// is not the same as omissible: "off" is a configuration the publisher
+	// reports, and a nil one is a composition root that forgot the option, so
+	// CreateArticle panics on it rather than skipping it.
 	eventPublisher event_publisher_port.EventPublisherPort
 
 	// The knowledge event sink is not: it is where CreateArticle appends the
@@ -315,9 +318,27 @@ func WithSummarizationPorts(
 }
 
 // WithEventPublisher configures the event publisher for domain events.
+//
+// The publisher can be switched off — mq-hub answers IsEnabled from its own
+// config — and that is a deployment saying "no notifications", not a wiring
+// mistake. The two are told apart here, where the boot log names which one
+// this process is in, and at the call site in CreateArticle, which panics on
+// the unwired one (CLAUDE.md rule 8 / ADR-000928). Logging rather than
+// panicking on nil: the composition root passes this option unconditionally,
+// so a nil arriving here is the field being nil, and the process that has to
+// stop is the one that reaches the publish, not the one that mounts the mux.
 func WithEventPublisher(ep event_publisher_port.EventPublisherPort) HandlerOption {
 	return func(h *Handler) {
 		h.eventPublisher = ep
+		switch {
+		case ep == nil:
+			h.logger.Error("datahub.event_publisher_unwired",
+				"detail", "DataHubService.CreateArticle will panic on its first call")
+		case ep.IsEnabled():
+			h.logger.Info("datahub.event_publisher_enabled")
+		default:
+			h.logger.Info("datahub.event_publisher_disabled")
+		}
 	}
 }
 
@@ -544,9 +565,23 @@ func (h *Handler) CreateArticle(ctx context.Context, req *connect.Request[datahu
 			errors.New("user_id is required and must be a UUID"))
 	}
 
-	var publishedAt time.Time
-	if req.Msg.PublishedAt != nil {
-		publishedAt = req.Msg.PublishedAt.AsTime()
+	// Not every feed item has a pubDate, and published_at is a message field:
+	// an omitted one arrives as a nil Timestamp. The absence travels as an
+	// absence to the ArticleCreated payload, which is written once and never
+	// again — see appendArticleCreated.
+	//
+	// The upsert and the mq-hub notification below still type it as a
+	// non-nullable time.Time, so they get the zero. For the upsert that is the
+	// 0001-01-01 that lands in articles.published_at, where NULL is the
+	// column's own "unknown" and what the knowledge backfill's
+	// COALESCE(published_at, created_at) reads. Carrying it through as a NULL
+	// needs CreateArticleParams to hold a *time.Time and the ON CONFLICT to
+	// COALESCE it — the port, the gateway and the driver rather than this
+	// handler.
+	publishedAtOrZero := timeOrZero(req.Msg.PublishedAt)
+	var publishedAt *time.Time
+	if !publishedAtOrZero.IsZero() {
+		publishedAt = &publishedAtOrZero
 	}
 
 	articleID, created, err := h.createArticle.CreateArticle(ctx, internal_article_port.CreateArticleParams{
@@ -556,7 +591,7 @@ func (h *Handler) CreateArticle(ctx context.Context, req *connect.Request[datahu
 		FeedID:      req.Msg.FeedId,
 		UserID:      req.Msg.UserId,
 		Language:    req.Msg.Language,
-		PublishedAt: publishedAt,
+		PublishedAt: publishedAtOrZero,
 	})
 	if err != nil {
 		h.logger.Error("CreateArticle failed", "error", err)
@@ -567,8 +602,20 @@ func (h *Handler) CreateArticle(ctx context.Context, req *connect.Request[datahu
 		return nil, err
 	}
 
+	// A publisher that reports itself off is a deployment without
+	// notifications; a nil one is a composition root that dropped the option,
+	// and skipping it would write the article, answer 200, and leave
+	// summarisation and indexing with nothing to consume — the two states must
+	// not look alike from in here (CLAUDE.md rule 8 / ADR-000928).
+	if h.eventPublisher == nil {
+		panic("datahubapi: event_publisher_port.EventPublisherPort is nil — " +
+			"DataHubService.CreateArticle is where mq-hub learns about an ingested article; " +
+			"wire it at the composition root, and wire a disabled publisher to turn it off " +
+			"(see .claude/rules/di-wiring.md)")
+	}
+
 	// Fire-and-forget: publish ArticleCreated event for downstream consumers
-	if h.eventPublisher != nil && h.eventPublisher.IsEnabled() {
+	if h.eventPublisher.IsEnabled() {
 		if created {
 			if pubErr := h.eventPublisher.PublishArticleCreated(ctx, event_publisher_port.ArticleCreatedEvent{
 				ArticleID:   articleID,
@@ -577,7 +624,7 @@ func (h *Handler) CreateArticle(ctx context.Context, req *connect.Request[datahu
 				Title:       req.Msg.Title,
 				URL:         req.Msg.Url,
 				Content:     req.Msg.Content,
-				PublishedAt: publishedAt,
+				PublishedAt: publishedAtOrZero,
 			}); pubErr != nil {
 				h.logger.Warn("failed to publish ArticleCreated event (non-fatal)",
 					"article_id", articleID, "error", pubErr)
@@ -589,7 +636,7 @@ func (h *Handler) CreateArticle(ctx context.Context, req *connect.Request[datahu
 			Title:       req.Msg.Title,
 			URL:         req.Msg.Url,
 			Content:     req.Msg.Content,
-			PublishedAt: publishedAt,
+			PublishedAt: publishedAtOrZero,
 		}); pubErr != nil {
 			h.logger.Warn("failed to publish ArticleUpdated event (non-fatal)",
 				"article_id", articleID, "error", pubErr)
@@ -626,12 +673,25 @@ func (h *Handler) appendArticleCreated(
 	articleID string,
 	userID uuid.UUID,
 	msg *datahubv1.CreateArticleRequest,
-	publishedAt time.Time,
+	publishedAt *time.Time,
 ) error {
 	if h.knowledgeEventPort == nil {
 		panic("datahubapi: knowledge_event_port.AppendKnowledgeEventPort is nil — " +
 			"DataHubService.CreateArticle is a Knowledge Home ArticleCreated producer and " +
 			"must be wired at the composition root (see .claude/rules/di-wiring.md)")
+	}
+
+	// An article whose feed gave no pubDate travels with an empty
+	// published_at, not with the formatted zero time. knowledge_events is
+	// INSERT-only, so whatever goes in here is what Knowledge Home reads
+	// forever, and the read model ranks recency over
+	// COALESCE(published_at, generated_at): a 0001-01-01 item scores as two
+	// millennia stale and never re-enters a recent or today window. Empty is
+	// the payload's "unknown" — the projector folds it to a NULL published_at
+	// and the ranking falls back to this event's own generated_at.
+	publishedAtWire := ""
+	if publishedAt != nil {
+		publishedAtWire = publishedAt.Format(time.RFC3339)
 	}
 
 	// Canonical wire schema — see domain.ArticleCreatedPayload comment and
@@ -641,7 +701,7 @@ func (h *Handler) appendArticleCreated(
 	payload, err := json.Marshal(domain.ArticleCreatedPayload{
 		ArticleID:   articleID,
 		Title:       msg.Title,
-		PublishedAt: publishedAt.Format(time.RFC3339),
+		PublishedAt: publishedAtWire,
 		TenantID:    userID.String(),
 		URL:         msg.Url,
 	})

--- a/alt-backend/app/dataplane/connect/datahubapi/procedures_test.go
+++ b/alt-backend/app/dataplane/connect/datahubapi/procedures_test.go
@@ -2,6 +2,7 @@ package datahubapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -468,6 +469,7 @@ func TestCreateArticle_Success(t *testing.T) {
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithEventPublisher(&stubEventPublisher{}),
 		WithKnowledgeEventPort(&stubKnowledgeEventPort{}))
 
 	mockCreate.EXPECT().
@@ -1003,6 +1005,10 @@ func TestCreateArticle_PublishesArticleCreatedEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCreate := mocks.NewMockCreateArticlePort(ctrl)
 	mockPublisher := mocks.NewMockEventPublisherPort(ctrl)
+	// IsEnabled is read twice: once by the option, which names the
+	// publisher's wiring state in the boot log, and once on the publish
+	// path itself.
+	mockPublisher.EXPECT().IsEnabled().Return(true).AnyTimes()
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
@@ -1023,7 +1029,6 @@ func TestCreateArticle_PublishesArticleCreatedEvent(t *testing.T) {
 		}).
 		Return("new-article-id", true, nil)
 
-	mockPublisher.EXPECT().IsEnabled().Return(true)
 	mockPublisher.EXPECT().
 		PublishArticleCreated(gomock.Any(), event_publisher_port.ArticleCreatedEvent{
 			ArticleID:   "new-article-id",
@@ -1054,13 +1059,56 @@ func TestCreateArticle_PublishesArticleCreatedEvent(t *testing.T) {
 	}
 }
 
-func TestCreateArticle_NilEventPublisher(t *testing.T) {
+// CLAUDE.md rule 8, the same refusal the knowledge event port gets one
+// function below: an unwired producer must not be mistakable for a switched
+// off one. mq-hub answers IsEnabled from its own configuration, so "publish
+// nothing" is a state this handler can legitimately be in — reached by wiring
+// a disabled publisher, never by omitting the option. Skipping a nil one
+// writes the article, answers 200, and leaves summarisation and indexing with
+// nothing to consume, which is the ADR-000928 failure mode exactly.
+//
+// This test replaces TestCreateArticle_NilEventPublisher, which pinned the
+// skip.
+func TestCreateArticle_PanicsWhenEventPublisherIsUnwired(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCreate := mocks.NewMockCreateArticlePort(ctrl)
 
 	// No WithEventPublisher — eventPublisher is nil
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithKnowledgeEventPort(&stubKnowledgeEventPort{}),
+	)
+
+	mockCreate.EXPECT().
+		CreateArticle(gomock.Any(), gomock.Any()).
+		Return("article-1", true, nil)
+
+	req := connect.NewRequest(&datahubv1.CreateArticleRequest{
+		Title:  "Test",
+		Url:    "http://example.com",
+		FeedId: "feed-1",
+		UserId: testTenantID,
+	})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("CreateArticle returned instead of panicking on an unwired event publisher")
+		}
+	}()
+	_, _ = h.CreateArticle(context.Background(), req)
+}
+
+// And the disabled half of the same distinction: a publisher that is wired and
+// reports itself off is a deployment choice, so the RPC succeeds and publishes
+// nothing.
+func TestCreateArticle_WiredButDisabledPublisherPublishesNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCreate := mocks.NewMockCreateArticlePort(ctrl)
+	publisher := &stubEventPublisher{}
+
+	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
+		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithEventPublisher(publisher),
 		WithKnowledgeEventPort(&stubKnowledgeEventPort{}),
 	)
 
@@ -1082,12 +1130,49 @@ func TestCreateArticle_NilEventPublisher(t *testing.T) {
 	if resp.Msg.ArticleId != "article-1" {
 		t.Errorf("expected article_id article-1, got %s", resp.Msg.ArticleId)
 	}
+	if len(publisher.created) != 0 {
+		t.Errorf("expected no publish while disabled, got %d", len(publisher.created))
+	}
 }
+
+// stubEventPublisher stands in for mq-hub wherever a test is about something
+// else. enabled is what the real gateway reads off its own client config, so
+// the zero value is a wired publisher that is switched off — the state the
+// handler must tell apart from a missing option.
+type stubEventPublisher struct {
+	enabled bool
+	created []event_publisher_port.ArticleCreatedEvent
+	updated []event_publisher_port.ArticleUpdatedEvent
+}
+
+func (s *stubEventPublisher) PublishArticleCreated(_ context.Context, e event_publisher_port.ArticleCreatedEvent) error {
+	s.created = append(s.created, e)
+	return nil
+}
+
+func (s *stubEventPublisher) PublishArticleUpdated(_ context.Context, e event_publisher_port.ArticleUpdatedEvent) error {
+	s.updated = append(s.updated, e)
+	return nil
+}
+
+func (s *stubEventPublisher) PublishSummarizeRequested(context.Context, event_publisher_port.SummarizeRequestedEvent) error {
+	return nil
+}
+
+func (s *stubEventPublisher) PublishIndexArticle(context.Context, event_publisher_port.IndexArticleEvent) error {
+	return nil
+}
+
+func (s *stubEventPublisher) IsEnabled() bool { return s.enabled }
 
 func TestCreateArticle_EventPublishFailureDoesNotFailRPC(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCreate := mocks.NewMockCreateArticlePort(ctrl)
 	mockPublisher := mocks.NewMockEventPublisherPort(ctrl)
+	// IsEnabled is read twice: once by the option, which names the
+	// publisher's wiring state in the boot log, and once on the publish
+	// path itself.
+	mockPublisher.EXPECT().IsEnabled().Return(true).AnyTimes()
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
@@ -1099,7 +1184,6 @@ func TestCreateArticle_EventPublishFailureDoesNotFailRPC(t *testing.T) {
 		CreateArticle(gomock.Any(), gomock.Any()).
 		Return("article-2", true, nil)
 
-	mockPublisher.EXPECT().IsEnabled().Return(true)
 	mockPublisher.EXPECT().
 		PublishArticleCreated(gomock.Any(), gomock.Any()).
 		Return(errors.New("redis connection refused"))
@@ -1125,6 +1209,10 @@ func TestCreateArticle_PublishesArticleUpdatedEventForUpsert(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCreate := mocks.NewMockCreateArticlePort(ctrl)
 	mockPublisher := mocks.NewMockEventPublisherPort(ctrl)
+	// IsEnabled is read twice: once by the option, which names the
+	// publisher's wiring state in the boot log, and once on the publish
+	// path itself.
+	mockPublisher.EXPECT().IsEnabled().Return(true).AnyTimes()
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
@@ -1138,7 +1226,6 @@ func TestCreateArticle_PublishesArticleUpdatedEventForUpsert(t *testing.T) {
 		CreateArticle(gomock.Any(), gomock.Any()).
 		Return("existing-article-id", false, nil)
 
-	mockPublisher.EXPECT().IsEnabled().Return(true)
 	mockPublisher.EXPECT().
 		PublishArticleUpdated(gomock.Any(), event_publisher_port.ArticleUpdatedEvent{
 			ArticleID:   "existing-article-id",
@@ -1173,6 +1260,10 @@ func TestCreateArticle_EventPublisherDisabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCreate := mocks.NewMockCreateArticlePort(ctrl)
 	mockPublisher := mocks.NewMockEventPublisherPort(ctrl)
+	// IsEnabled is read twice: once by the option, which names the
+	// publisher's wiring state in the boot log, and once on the publish
+	// path itself.
+	mockPublisher.EXPECT().IsEnabled().Return(false).AnyTimes()
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
@@ -1184,7 +1275,6 @@ func TestCreateArticle_EventPublisherDisabled(t *testing.T) {
 		CreateArticle(gomock.Any(), gomock.Any()).
 		Return("article-3", true, nil)
 
-	mockPublisher.EXPECT().IsEnabled().Return(false)
 	// PublishArticleCreated should NOT be called when disabled
 
 	req := connect.NewRequest(&datahubv1.CreateArticleRequest{
@@ -1456,6 +1546,7 @@ func TestCreateArticle_AppendsKnowledgeEvent(t *testing.T) {
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithEventPublisher(&stubEventPublisher{}),
 		WithKnowledgeEventPort(stub),
 	)
 
@@ -1490,6 +1581,68 @@ func TestCreateArticle_AppendsKnowledgeEvent(t *testing.T) {
 	}
 }
 
+// Not every feed item carries a pubDate, and published_at is a message field:
+// an omitted one arrives here as a nil Timestamp and used to be formatted into
+// the payload as the Go zero time, 0001-01-01.
+//
+// That is not a harmless placeholder. knowledge_events is INSERT-only, so the
+// value the projector reads is the value Knowledge Home keeps forever, and the
+// read model ranks recency over COALESCE(published_at, generated_at) — a
+// year-1 item scores as two millennia stale and never appears in a recent or
+// today window again. The payload's own "unknown" is the empty string, which
+// the projector folds to a NULL published_at and the ranking then replaces
+// with the event's generated_at.
+func TestCreateArticle_OmittedPublishedAtIsUnknownRatherThanYearOne(t *testing.T) {
+	publishedAt := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		publishedAt *timestamppb.Timestamp
+		want        string
+	}{
+		{name: "omitted", publishedAt: nil, want: ""},
+		{name: "sent", publishedAt: timestamppb.New(publishedAt), want: publishedAt.Format(time.RFC3339)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockCreate := mocks.NewMockCreateArticlePort(ctrl)
+			stub := &stubKnowledgeEventPort{}
+
+			h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
+				WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+				WithEventPublisher(&stubEventPublisher{}),
+				WithKnowledgeEventPort(stub),
+			)
+
+			mockCreate.EXPECT().
+				CreateArticle(gomock.Any(), gomock.Any()).
+				Return("article-published-at", true, nil)
+
+			req := connect.NewRequest(&datahubv1.CreateArticleRequest{
+				Title:       "Test Article",
+				Url:         "http://example.com/test",
+				FeedId:      "feed-1",
+				UserId:      testTenantID,
+				PublishedAt: tt.publishedAt,
+			})
+
+			if _, err := h.CreateArticle(context.Background(), req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var payload domain.ArticleCreatedPayload
+			if err := json.Unmarshal(stub.lastEvent.Payload, &payload); err != nil {
+				t.Fatalf("unmarshal ArticleCreated payload: %v", err)
+			}
+			if payload.PublishedAt != tt.want {
+				t.Errorf("ArticleCreated published_at = %q, want %q", payload.PublishedAt, tt.want)
+			}
+		})
+	}
+}
+
 // An upsert is where the repair happens, not where it is skipped.
 //
 // created=false says alt-db already held the (url, user_id) row; it says
@@ -1505,6 +1658,7 @@ func TestCreateArticle_AppendsKnowledgeEventOnUpsert(t *testing.T) {
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithEventPublisher(&stubEventPublisher{}),
 		WithKnowledgeEventPort(stub),
 	)
 
@@ -1545,6 +1699,7 @@ func TestCreateArticle_DedupedKnowledgeEventIsNotAFailure(t *testing.T) {
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithEventPublisher(&stubEventPublisher{}),
 		WithKnowledgeEventPort(stub),
 	)
 
@@ -1576,6 +1731,7 @@ func TestCreateArticle_KnowledgeEventFailureFailsRPC(t *testing.T) {
 
 	h := NewHandler(nil, nil, nil, nil, nil, &fakeSystemUser{}, &fakeRecentArticles{}, nil,
 		WithPhase2Ports(nil, mockCreate, nil, nil, nil, nil),
+		WithEventPublisher(&stubEventPublisher{}),
 		WithKnowledgeEventPort(stub),
 	)
 

--- a/alt-backend/app/dataplane/driver/kratos_client/client.go
+++ b/alt-backend/app/dataplane/driver/kratos_client/client.go
@@ -20,9 +20,11 @@ type KratosClient interface {
 
 // authHubClientImpl implements KratosClient by calling auth-hub.
 type authHubClientImpl struct {
-	authHubURL   string
-	sharedSecret string
-	httpClient   *http.Client
+	authHubURL string
+	// internalAuthSecret is auth-hub's INTERNAL_AUTH_SECRET, not its JWT
+	// signing key. See NewKratosClient.
+	internalAuthSecret string
+	httpClient         *http.Client
 }
 
 // systemUserResponse represents the response from auth-hub /internal/system-user endpoint.
@@ -33,10 +35,17 @@ type systemUserResponse struct {
 // NewKratosClient creates a new auth-hub client.
 // Note: Despite the name, this now calls auth-hub instead of Kratos directly.
 // This provides abstraction so alt-backend doesn't need to know about Kratos.
-func NewKratosClient(authHubURL string, sharedSecret string) KratosClient {
+//
+// internalAuthSecret must be config.Auth.InternalAuthSecret
+// (INTERNAL_AUTH_SECRET), never config.Auth.BackendTokenSecret. GetFirstIdentityID
+// puts this value verbatim into a plaintext X-Internal-Auth header on every
+// call, so it is copied into nginx access logs and OTel span attributes; the
+// HS256 key that signs every browser token must not be reachable from there.
+// auth-hub refuses to start when the two are the same value.
+func NewKratosClient(authHubURL string, internalAuthSecret string) KratosClient {
 	return &authHubClientImpl{
-		authHubURL:   authHubURL,
-		sharedSecret: sharedSecret,
+		authHubURL:         authHubURL,
+		internalAuthSecret: internalAuthSecret,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -51,7 +60,7 @@ func (c *authHubClientImpl) GetFirstIdentityID(ctx context.Context) (string, err
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("X-Internal-Auth", c.sharedSecret)
+	req.Header.Set("X-Internal-Auth", c.internalAuthSecret)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/alt-backend/app/di/admin_monitor_module.go
+++ b/alt-backend/app/di/admin_monitor_module.go
@@ -19,9 +19,21 @@ type AdminMonitorModule struct {
 	Facade  *admin_metrics_usecase.Facade
 }
 
+// newAdminMonitorModule emits the loud enabled/disabled/misconfigured signal
+// CLAUDE.md rule 8 / .claude/rules/di-wiring.md require, and never rewrites the
+// operator's flag.
+//
+// ADMIN_MONITOR_ENABLED=true with a driver that cannot be built used to log a
+// Warn and set Enabled=false, which made connect/v2/server.go announce
+// "AdminMonitorService disabled (config.AdminMonitor.Enabled=false)" about a
+// config value that said the opposite. An operator reading that line has no way
+// to tell a bad ADMIN_MONITOR_PROMETHEUS_URL from a flag they forgot to set,
+// and the admin UI's monitoring RPCs answer 404 either way. Enabled but
+// unbuildable is missing required config, so it exits non-zero (rule 9).
 func newAdminMonitorModule(cfg *config.Config, logger *slog.Logger) *AdminMonitorModule {
 	m := &AdminMonitorModule{Enabled: cfg.AdminMonitor.Enabled}
 	if !m.Enabled {
+		logger.Warn("admin_monitor_disabled", "reason", "ADMIN_MONITOR_ENABLED=false")
 		return m
 	}
 	client, err := prometheus_client.New(prometheus_client.Config{
@@ -29,9 +41,12 @@ func newAdminMonitorModule(cfg *config.Config, logger *slog.Logger) *AdminMonito
 		Timeout: cfg.AdminMonitor.QueryTimeout,
 	})
 	if err != nil {
-		logger.Warn("admin_monitor disabled: prometheus_client init failed", "err", err)
-		m.Enabled = false
-		return m
+		logger.Error("admin_monitor_misconfigured",
+			"reason", "ADMIN_MONITOR_ENABLED=true but the prometheus client could not be built",
+			"prometheus_url", cfg.AdminMonitor.PrometheusURL,
+			"err", err)
+		panic("ADMIN_MONITOR_ENABLED=true requires a usable ADMIN_MONITOR_PROMETHEUS_URL — " +
+			"refusing to start with the admin monitoring RPCs silently 404: " + err.Error())
 	}
 	gw := admin_metrics_gateway.New(admin_metrics_gateway.Config{
 		Client:         client,
@@ -41,5 +56,6 @@ func newAdminMonitorModule(cfg *config.Config, logger *slog.Logger) *AdminMonito
 	})
 	m.Port = gw
 	m.Facade = admin_metrics_usecase.NewFacade(gw, cfg.AdminMonitor.StreamInterval)
+	logger.Info("admin_monitor_enabled", "prometheus_url", cfg.AdminMonitor.PrometheusURL)
 	return m
 }

--- a/alt-backend/app/di/admin_monitor_module_test.go
+++ b/alt-backend/app/di/admin_monitor_module_test.go
@@ -1,0 +1,65 @@
+package di
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"alt/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func adminMonitorConfig(enabled bool, prometheusURL string) *config.Config {
+	return &config.Config{
+		AdminMonitor: config.AdminMonitorConfig{
+			Enabled:        enabled,
+			PrometheusURL:  prometheusURL,
+			QueryTimeout:   3 * time.Second,
+			CacheTTL:       10 * time.Second,
+			RateLimitRPS:   5,
+			RateLimitBurst: 10,
+			StreamInterval: 5 * time.Second,
+		},
+	}
+}
+
+// TestNewAdminMonitorModule pins CLAUDE.md rule 8 / di-wiring.md for the admin
+// observability pipeline. ADMIN_MONITOR_ENABLED=true is an operator decision,
+// so a driver that cannot be built is a misconfiguration, not an opt-out:
+// flipping Enabled back to false made connect/v2/server.go log
+// "AdminMonitorService disabled (config.AdminMonitor.Enabled=false)" about a
+// config value that says the opposite, and left every admin monitoring RPC
+// answering 404 with no way to tell a bad ADMIN_MONITOR_PROMETHEUS_URL from an
+// unset flag.
+func TestNewAdminMonitorModule(t *testing.T) {
+	t.Run("disabled flag leaves the module unwired without panicking", func(t *testing.T) {
+		var m *AdminMonitorModule
+		assert.NotPanics(t, func() {
+			m = newAdminMonitorModule(adminMonitorConfig(false, ""), discardLogger())
+		})
+		require.NotNil(t, m)
+		assert.False(t, m.Enabled)
+		assert.Nil(t, m.Facade)
+	})
+
+	t.Run("enabled with a usable prometheus url wires the facade", func(t *testing.T) {
+		m := newAdminMonitorModule(adminMonitorConfig(true, "http://prometheus:9090"), discardLogger())
+		require.NotNil(t, m)
+		assert.True(t, m.Enabled)
+		assert.NotNil(t, m.Port)
+		assert.NotNil(t, m.Facade)
+	})
+
+	t.Run("enabled but unbuildable driver panics instead of rewriting the flag", func(t *testing.T) {
+		assert.Panics(t, func() {
+			newAdminMonitorModule(adminMonitorConfig(true, ""), discardLogger())
+		})
+	})
+}

--- a/alt-backend/app/di/datahub/container.go
+++ b/alt-backend/app/di/datahub/container.go
@@ -175,8 +175,12 @@ type DataHubComponents struct {
 func NewDataHubComponents(pool *pgxpool.Pool, cfg *config.Config) *DataHubComponents {
 	altDB := alt_db.NewAltDBRepository(pool)
 
-	// Identity lookup for /v1/internal/system-user.
-	kratosCli := kratos_client.NewKratosClient(cfg.AuthHub.URL, cfg.Auth.BackendTokenSecret)
+	// Identity lookup for /v1/internal/system-user. The bearer is
+	// INTERNAL_AUTH_SECRET, which is what auth-hub's /internal group is keyed
+	// on — handing it BackendTokenSecret instead puts the HS256 signing key in
+	// a plaintext header and gets 403 on every call, since auth-hub refuses to
+	// start with the two secrets equal.
+	kratosCli := kratos_client.NewKratosClient(cfg.AuthHub.URL, cfg.Auth.InternalAuthSecret)
 
 	// Event publishing.
 	mqhubClient := mqhub_connect.NewClient(cfg.MQHub.ConnectURL, cfg.MQHub.Enabled)

--- a/alt-backend/app/di/datahub/container_internal_auth_test.go
+++ b/alt-backend/app/di/datahub/container_internal_auth_test.go
@@ -1,0 +1,61 @@
+package datahub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"alt/config"
+)
+
+// The bearer this root hands kratos_client is the one auth-hub's /internal
+// group is keyed on, and that is INTERNAL_AUTH_SECRET — not the HS256 signing
+// key. auth-hub refuses to start when the two are equal
+// (auth-hub/config/config.go), so a root wired to BackendTokenSecret does not
+// degrade: middleware/internal_auth.go answers 403 to every GetSystemUser call
+// while alt-data-hub stays healthy.
+//
+// Asserted at the wire rather than on the struct because the field is
+// unexported and the header is what auth-hub compares. GetFirstIdentityID puts
+// the value in verbatim (kratos_client/client.go), so a stub auth-hub reading
+// X-Internal-Auth sees exactly what the deployed one would.
+func TestDataHubComponents_KratosClientPresentsInternalAuthSecret(t *testing.T) {
+	const (
+		backendTokenSecret = "hs256-signing-key-that-must-not-reach-a-plaintext-header"
+		internalAuthSecret = "the-separate-internal-shared-bearer-value"
+	)
+
+	var presented string
+	authHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		presented = r.Header.Get("X-Internal-Auth")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user_id":"11111111-2222-3333-4444-555555555555"}`))
+	}))
+	defer authHub.Close()
+
+	cfg := &config.Config{
+		AppEnv:    "development",
+		AuthHub:   config.AuthHubConfig{URL: authHub.URL},
+		Auth:      config.AuthConfig{BackendTokenSecret: backendTokenSecret, InternalAuthSecret: internalAuthSecret},
+		MQHub:     config.MQHubConfig{Enabled: true, ConnectURL: "http://mq-hub:9500"},
+		Sovereign: config.SovereignConfig{URL: "http://knowledge-sovereign:9500"},
+		Recap:     config.RecapConfig{DefaultPageSize: 500, MaxPageSize: 2000, MaxRangeDays: 8},
+	}
+
+	// A nil pool is enough: nothing on this path touches the database, and the
+	// alternative would be a live Postgres for a header assertion.
+	components := NewDataHubComponents(nil, cfg)
+
+	if _, err := components.KratosClient.GetFirstIdentityID(context.Background()); err != nil {
+		t.Fatalf("GetFirstIdentityID() error = %v", err)
+	}
+
+	if presented == backendTokenSecret {
+		t.Fatalf("X-Internal-Auth carried BACKEND_TOKEN_SECRET; auth-hub keys /internal on " +
+			"INTERNAL_AUTH_SECRET and answers 403 to every GetSystemUser call")
+	}
+	if presented != internalAuthSecret {
+		t.Errorf("X-Internal-Auth = %q, want INTERNAL_AUTH_SECRET %q", presented, internalAuthSecret)
+	}
+}

--- a/alt-backend/app/mocks/mock_today_digest_port.go
+++ b/alt-backend/app/mocks/mock_today_digest_port.go
@@ -58,44 +58,6 @@ func (mr *MockGetTodayDigestPortMockRecorder) GetTodayDigest(ctx, userID, date a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTodayDigest", reflect.TypeOf((*MockGetTodayDigestPort)(nil).GetTodayDigest), ctx, userID, date)
 }
 
-// MockUpsertTodayDigestPort is a mock of UpsertTodayDigestPort interface.
-type MockUpsertTodayDigestPort struct {
-	ctrl     *gomock.Controller
-	recorder *MockUpsertTodayDigestPortMockRecorder
-	isgomock struct{}
-}
-
-// MockUpsertTodayDigestPortMockRecorder is the mock recorder for MockUpsertTodayDigestPort.
-type MockUpsertTodayDigestPortMockRecorder struct {
-	mock *MockUpsertTodayDigestPort
-}
-
-// NewMockUpsertTodayDigestPort creates a new mock instance.
-func NewMockUpsertTodayDigestPort(ctrl *gomock.Controller) *MockUpsertTodayDigestPort {
-	mock := &MockUpsertTodayDigestPort{ctrl: ctrl}
-	mock.recorder = &MockUpsertTodayDigestPortMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockUpsertTodayDigestPort) EXPECT() *MockUpsertTodayDigestPortMockRecorder {
-	return m.recorder
-}
-
-// UpsertTodayDigest mocks base method.
-func (m *MockUpsertTodayDigestPort) UpsertTodayDigest(ctx context.Context, digest domain.TodayDigest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertTodayDigest", ctx, digest)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpsertTodayDigest indicates an expected call of UpsertTodayDigest.
-func (mr *MockUpsertTodayDigestPortMockRecorder) UpsertTodayDigest(ctx, digest any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTodayDigest", reflect.TypeOf((*MockUpsertTodayDigestPort)(nil).UpsertTodayDigest), ctx, digest)
-}
-
 // MockGetProjectionFreshnessPort is a mock of GetProjectionFreshnessPort interface.
 type MockGetProjectionFreshnessPort struct {
 	ctrl     *gomock.Controller

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler.go
@@ -9,9 +9,12 @@ import (
 	"math"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 
 	articlesv2 "alt/gen/proto/alt/articles/v2"
 	"alt/gen/proto/alt/articles/v2/articlesv2connect"
@@ -80,6 +83,11 @@ type Handler struct {
 	// is allowed to have in flight. Sending claims a slot, the goroutine
 	// returns it. See maxConcurrentCacheWarms.
 	warmSlots chan struct{}
+
+	// Throttle state for the shed warning. See logCacheWarmShed.
+	warmShedMu      sync.Mutex
+	warmShedCount   int
+	lastWarmShedLog time.Time
 }
 
 // NewHandler creates a new Article service handler.
@@ -133,7 +141,72 @@ const (
 	// parks on the per-host limiter, so an unbounded fan-out grows with the
 	// arrival rate instead of the completion rate.
 	maxConcurrentCacheWarms = 32
+
+	// warmShedLogInterval throttles the shed warning. The warning has to be
+	// loud — shedding is thrown-away work — but one line per dropped warm is
+	// hundreds per second exactly when the pool is saturated and the log is
+	// least readable, so it is emitted once per window with the number of
+	// occurrences it stands for (same shape as host_rate_limiter's
+	// degraded_to_local warning).
+	warmShedLogInterval = 30 * time.Second
 )
+
+// These OTel counters close a specific gap: the shed used to be a
+// DebugContext line and nothing else, so above debug level — which is where
+// production runs — a saturated warm pool and a batch with nothing to warm
+// were the same observation. Both leave the response whole and the log silent,
+// and the only symptom is images that never warm.
+//
+// The started counter is what makes the shed counter readable: a zero shed
+// count next to a zero started count means idle, next to a non-zero started
+// count means healthy. Alert on the ratio, not the raw shed rate.
+var (
+	warmMeterOnce           sync.Once
+	cacheWarmStartedCounter metric.Int64Counter
+	cacheWarmShedCounter    metric.Int64Counter
+)
+
+func initCacheWarmMetrics() {
+	warmMeterOnce.Do(func() {
+		meter := otel.Meter("alt-backend.image-cache-warm")
+		cacheWarmStartedCounter, _ = meter.Int64Counter("alt_backend_image_cache_warm_started_total",
+			metric.WithDescription("OGP cache warms that claimed a warm-pool slot and were detached"))
+		cacheWarmShedCounter, _ = meter.Int64Counter("alt_backend_image_cache_warm_shed_total",
+			metric.WithDescription("OGP cache warms dropped because the warm pool was already full; a sustained rate means warms arrive faster than the per-host limiter lets them finish"))
+	})
+}
+
+// logCacheWarmShed records one dropped warm and emits the throttled warning
+// that stands for the window's worth of them.
+//
+// The per-URL detail stays at debug level for the lines the throttle swallows,
+// so turning the level down still answers "which images went uncached".
+func (h *Handler) logCacheWarmShed(ctx context.Context, ogURL string) {
+	cacheWarmShedCounter.Add(ctx, 1)
+
+	h.warmShedMu.Lock()
+	h.warmShedCount++
+	count := h.warmShedCount
+	now := time.Now()
+	shouldLog := h.lastWarmShedLog.IsZero() || now.Sub(h.lastWarmShedLog) >= warmShedLogInterval
+	if shouldLog {
+		h.lastWarmShedLog = now
+	}
+	h.warmShedMu.Unlock()
+
+	if !shouldLog {
+		h.logger.DebugContext(ctx, "cache warm shed, warm pool saturated",
+			"url", ogURL, "operation", "BatchPrefetchImages")
+		return
+	}
+
+	h.logger.WarnContext(ctx, "image_cache_warm.shed",
+		"url", ogURL,
+		"occurrences", count,
+		"pool_size", maxConcurrentCacheWarms,
+		"operation", "BatchPrefetchImages",
+		"impact", "each dropped warm leaves one image uncached on the next view")
+}
 
 // withFailureScope stamps the blast radius onto a Connect error.
 func withFailureScope(err *connect.Error, scope string) *connect.Error {
@@ -742,12 +815,13 @@ func (h *Handler) BatchPrefetchImages(
 	// one costs a goroutine holding a request context for up to a minute, and
 	// the queue would only ever grow because warms arrive faster than the
 	// per-host limiter lets them finish.
+	initCacheWarmMetrics()
 	for _, ogURL := range ogURLs {
 		select {
 		case h.warmSlots <- struct{}{}:
+			cacheWarmStartedCounter.Add(ctx, 1)
 		default:
-			h.logger.DebugContext(ctx, "cache warm shed, warm pool saturated",
-				"url", ogURL, "operation", "BatchPrefetchImages")
+			h.logCacheWarmShed(ctx, ogURL)
 			continue
 		}
 

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler.go
@@ -75,14 +75,20 @@ type Handler struct {
 	deps   ArticleHandlerDeps
 	logger *slog.Logger
 	cfg    *config.Config
+
+	// warmSlots is the fixed pool of detached cache warms BatchPrefetchImages
+	// is allowed to have in flight. Sending claims a slot, the goroutine
+	// returns it. See maxConcurrentCacheWarms.
+	warmSlots chan struct{}
 }
 
 // NewHandler creates a new Article service handler.
 func NewHandler(deps ArticleHandlerDeps, cfg *config.Config, logger *slog.Logger) *Handler {
 	return &Handler{
-		deps:   deps,
-		logger: logger,
-		cfg:    cfg,
+		deps:      deps,
+		logger:    logger,
+		cfg:       cfg,
+		warmSlots: make(chan struct{}, maxConcurrentCacheWarms),
 	}
 }
 
@@ -110,6 +116,23 @@ const (
 	// is still ours — excusing either from the breaker would hide a real
 	// outage behind "the site is slow".
 	FailureScopeHost = "host"
+
+	// maxArticlesPageSize is the largest page the cursor RPCs will serve.
+	//
+	// It sits one below the usecases' own ceiling of 100 on purpose: these
+	// handlers ask for limit+1 rows so they can answer has_more without a
+	// separate COUNT, so a page of 100 would fetch 101 and the usecase would
+	// reject it. Clamping to 100 turned the documented maximum page size into
+	// an opaque CodeInternal.
+	maxArticlesPageSize = 99
+
+	// maxConcurrentCacheWarms bounds the detached OGP cache warms a handler
+	// may hold at once. BatchPrefetchImages hands each warm a WithoutCancel
+	// context and a 60-second budget, so a warm outlives the RPC that asked
+	// for it; the Connect listener has no rate limit of its own and WarmCache
+	// parks on the per-host limiter, so an unbounded fan-out grows with the
+	// arrival rate instead of the completion rate.
+	maxConcurrentCacheWarms = 32
 )
 
 // withFailureScope stamps the blast radius onto a Connect error.
@@ -285,8 +308,8 @@ func (h *Handler) FetchArticlesCursor(
 	if limit <= 0 {
 		limit = 20 // default
 	}
-	if limit > 100 {
-		limit = 100
+	if limit > maxArticlesPageSize {
+		limit = maxArticlesPageSize
 	}
 
 	// Parse cursor if provided
@@ -384,8 +407,8 @@ func (h *Handler) FetchArticlesByTag(
 	if limit <= 0 {
 		limit = 20 // default
 	}
-	if limit > 100 {
-		limit = 100
+	if limit > maxArticlesPageSize {
+		limit = maxArticlesPageSize
 	}
 
 	// Parse cursor if provided
@@ -713,9 +736,24 @@ func (h *Handler) BatchPrefetchImages(
 
 	// Warm cache for images in background. WithoutCancel keeps request values
 	// (trace/auth metadata) while allowing work to finish after the RPC returns.
+	//
+	// Bounded by warmSlots and shed — not queued — when the pool is full: a
+	// dropped warm costs one uncached image on the next view, while a queued
+	// one costs a goroutine holding a request context for up to a minute, and
+	// the queue would only ever grow because warms arrive faster than the
+	// per-host limiter lets them finish.
 	for _, ogURL := range ogURLs {
+		select {
+		case h.warmSlots <- struct{}{}:
+		default:
+			h.logger.DebugContext(ctx, "cache warm shed, warm pool saturated",
+				"url", ogURL, "operation", "BatchPrefetchImages")
+			continue
+		}
+
 		ogURLCopy := ogURL
 		go func() {
+			defer func() { <-h.warmSlots }()
 			warmCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
 			defer cancel()
 			h.deps.ImageProxy.WarmCache(warmCtx, ogURLCopy)

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler_limit_clamp_test.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler_limit_clamp_test.go
@@ -1,0 +1,109 @@
+package articles
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	articlesv2 "alt/gen/proto/alt/articles/v2"
+
+	"alt/config"
+	"alt/domain"
+	"alt/orchestrator/usecase/fetch_articles_usecase"
+	"alt/shared/usecase/fetch_articles_by_tag_usecase"
+	"alt/utils/logger"
+)
+
+// The article cursor RPCs ask their usecase for limit+1 rows so they can answer
+// has_more without a COUNT. The usecases reject anything above 100, so the
+// handler ceiling must leave room for that extra probe row — clamping the
+// caller's limit to 100 turned the documented maximum page size into an opaque
+// Internal error instead of a page.
+
+// limitRecordingArticlesPort records the limit the handler asked for, so the
+// test can prove the probe row stays inside the usecase's ceiling.
+type limitRecordingArticlesPort struct {
+	articles  []*domain.Article
+	lastLimit int
+}
+
+func (f *limitRecordingArticlesPort) FetchArticlesWithCursor(_ context.Context, _ *time.Time, limit int) ([]*domain.Article, error) {
+	f.lastLimit = limit
+	return f.articles, nil
+}
+
+func (f *limitRecordingArticlesPort) FetchArticleIDsWithCursor(_ context.Context, _ *time.Time, limit int) ([]uuid.UUID, error) {
+	f.lastLimit = limit
+	return nil, nil
+}
+
+type limitRecordingByTagPort struct {
+	articles  []*domain.TagTrailArticle
+	lastLimit int
+}
+
+func (f *limitRecordingByTagPort) FetchArticlesByTag(_ context.Context, _ string, _ *time.Time, limit int) ([]*domain.TagTrailArticle, error) {
+	f.lastLimit = limit
+	return f.articles, nil
+}
+
+func (f *limitRecordingByTagPort) FetchArticlesByTagName(_ context.Context, _ string, _ *time.Time, limit int) ([]*domain.TagTrailArticle, error) {
+	f.lastLimit = limit
+	return f.articles, nil
+}
+
+func TestFetchArticlesCursor_MaxLimitIsServedNotRejected(t *testing.T) {
+	logger.InitLogger()
+
+	port := &limitRecordingArticlesPort{}
+	handler := NewHandler(ArticleHandlerDeps{
+		FetchArticlesCursor: fetch_articles_usecase.NewFetchArticlesCursorUsecase(port),
+	}, &config.Config{}, slog.Default())
+
+	_, err := handler.FetchArticlesCursor(createAuthContext(),
+		connect.NewRequest(&articlesv2.FetchArticlesCursorRequest{Limit: 100}))
+
+	require.NoError(t, err)
+	require.LessOrEqual(t, port.lastLimit, 100,
+		"the has_more probe row pushed the fetch past the usecase ceiling")
+}
+
+func TestFetchArticlesByTag_MaxLimitIsServedNotRejected(t *testing.T) {
+	logger.InitLogger()
+
+	port := &limitRecordingByTagPort{}
+	handler := NewHandler(ArticleHandlerDeps{
+		FetchArticlesByTag: fetch_articles_by_tag_usecase.NewFetchArticlesByTagUsecase(port),
+	}, &config.Config{}, slog.Default())
+
+	tagName := "go"
+	_, err := handler.FetchArticlesByTag(createAuthContext(),
+		connect.NewRequest(&articlesv2.FetchArticlesByTagRequest{TagName: &tagName, Limit: 100}))
+
+	require.NoError(t, err)
+	require.LessOrEqual(t, port.lastLimit, 100,
+		"the has_more probe row pushed the fetch past the usecase ceiling")
+}
+
+// An over-sized limit must be clamped down to the same served ceiling rather
+// than rejected, which is what the handlers already promised by clamping.
+func TestFetchArticlesCursor_OverMaxLimitIsClampedNotRejected(t *testing.T) {
+	logger.InitLogger()
+
+	port := &limitRecordingArticlesPort{}
+	handler := NewHandler(ArticleHandlerDeps{
+		FetchArticlesCursor: fetch_articles_usecase.NewFetchArticlesCursorUsecase(port),
+	}, &config.Config{}, slog.Default())
+
+	_, err := handler.FetchArticlesCursor(createAuthContext(),
+		connect.NewRequest(&articlesv2.FetchArticlesCursorRequest{Limit: 50000}))
+
+	require.NoError(t, err)
+	require.LessOrEqual(t, port.lastLimit, 100,
+		"the has_more probe row pushed the fetch past the usecase ceiling")
+}

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler_prefetch_bound_test.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler_prefetch_bound_test.go
@@ -1,0 +1,118 @@
+package articles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	articlesv2 "alt/gen/proto/alt/articles/v2"
+
+	"alt/config"
+	"alt/domain"
+	"alt/orchestrator/usecase/image_proxy_usecase"
+	"alt/utils/logger"
+)
+
+// blockingImageCache parks every warm inside GetCachedImage — the first thing
+// WarmCache does — so the test can count how many warms are alive at once
+// without racing their completion.
+type blockingImageCache struct {
+	started atomic.Int64
+	release chan struct{}
+}
+
+func (c *blockingImageCache) GetCachedImage(_ context.Context, _ string) (*domain.ImageProxyCacheEntry, error) {
+	c.started.Add(1)
+	<-c.release
+	return nil, errors.New("cache unavailable")
+}
+
+func (c *blockingImageCache) SaveCachedImage(_ context.Context, _ *domain.ImageProxyCacheEntry) error {
+	return nil
+}
+
+func (c *blockingImageCache) CleanupExpiredImages(_ context.Context) (int64, error) { return 0, nil }
+
+// stubImageSigner mints proxy URLs in the shape WarmCache parses, and refuses
+// to verify them so the warm stops before it would need an HTTP client.
+type stubImageSigner struct{}
+
+func (stubImageSigner) GenerateProxyURL(imageURL string) string {
+	return "/v1/images/proxy/sig/" + imageURL
+}
+
+func (stubImageSigner) VerifyAndDecode(_, _ string) (string, error) {
+	return "", errors.New("not verifiable in test")
+}
+
+// stubOgImageURLs hands every requested article a distinct image URL, so one
+// RPC is worth as many warms as it has article ids.
+type stubOgImageURLs struct{}
+
+func (stubOgImageURLs) FetchOgImageURLsByArticleIDs(_ context.Context, articleIDs []string) (map[string]string, error) {
+	out := make(map[string]string, len(articleIDs))
+	for _, id := range articleIDs {
+		out[id] = "https://example.com/" + id + ".jpg"
+	}
+	return out, nil
+}
+
+// BatchPrefetchImages detaches its cache warming with context.WithoutCancel and
+// a 60-second budget, so a warm outlives the RPC that asked for it. The Connect
+// listener has no rate limit of its own and WarmCache parks on a per-host
+// limiter, so without a ceiling the live goroutine count tracks the arrival
+// rate rather than the completion rate — a few hundred rps is tens of thousands
+// of goroutines holding a request context each.
+func TestBatchPrefetchImages_CacheWarmingIsBounded(t *testing.T) {
+	logger.InitLogger()
+
+	cache := &blockingImageCache{release: make(chan struct{})}
+	t.Cleanup(func() { close(cache.release) })
+
+	handler := NewHandler(ArticleHandlerDeps{
+		OgImageURLs: stubOgImageURLs{},
+		ImageProxy: image_proxy_usecase.NewImageProxyUsecase(
+			nil, nil, cache, stubImageSigner{}, nil, nil, 0, 0, 0),
+	}, &config.Config{}, slog.Default())
+	ctx := createAuthContext()
+
+	const (
+		callCount      = 40
+		idsPerCall     = 10 // the handler's own per-RPC truncation
+		wouldBeStarted = callCount * idsPerCall
+	)
+
+	for call := range callCount {
+		articleIDs := make([]string, 0, idsPerCall)
+		for i := range idsPerCall {
+			articleIDs = append(articleIDs, fmt.Sprintf("article-%d-%d", call, i))
+		}
+
+		resp, err := handler.BatchPrefetchImages(ctx,
+			connect.NewRequest(&articlesv2.BatchPrefetchImagesRequest{ArticleIds: articleIDs}))
+		require.NoError(t, err)
+		require.Len(t, resp.Msg.Images, idsPerCall,
+			"shedding a warm must not shrink the response the caller asked for")
+	}
+
+	// Nothing can finish while the cache is parked, so every warm that ever
+	// started is still alive. Give the scheduler a moment to start them.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cache.started.Load() > maxConcurrentCacheWarms {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	require.LessOrEqual(t, cache.started.Load(), int64(maxConcurrentCacheWarms),
+		"%d requests fanned out unbounded (up to %d live warms), each holding a request context for 60s",
+		callCount, wouldBeStarted)
+}

--- a/alt-backend/app/orchestrator/connect/v2/articles/handler_warm_shed_observability_test.go
+++ b/alt-backend/app/orchestrator/connect/v2/articles/handler_warm_shed_observability_test.go
@@ -1,0 +1,116 @@
+package articles
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	articlesv2 "alt/gen/proto/alt/articles/v2"
+
+	"alt/config"
+	"alt/orchestrator/usecase/image_proxy_usecase"
+	"alt/utils/logger"
+)
+
+// sumWarmCounter totals every int64 Sum data point recorded under name,
+// regardless of attributes, across an already-Collect()ed ResourceMetrics.
+func sumWarmCounter(rm metricdata.ResourceMetrics, name string) int64 {
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+		}
+	}
+	return total
+}
+
+// Bounding the warm pool (see TestBatchPrefetchImages_CacheWarmingIsBounded) is
+// only half the job: the shed warms are real work thrown away, and production
+// runs above debug level, so a saturated pool used to look exactly like a quiet
+// one — the response is intact, the log is silent, and the only symptom is
+// images that never warm. Every other shed/degrade path in this codebase is
+// loud (outboxReleaseFailedCounter, host_rate_limiter.degraded_to_local,
+// logImageProxyWiringState), so this one must be too.
+//
+// The started counter is what makes the shed counter readable: "shed 0" alone
+// cannot distinguish a pool that never filled from a batch that had nothing to
+// warm.
+func TestBatchPrefetchImages_ShedWarmIsObservable(t *testing.T) {
+	logger.InitLogger()
+
+	reader := sdkmetric.NewManualReader()
+	prevProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prevProvider) })
+
+	// Info level is what production runs at: a DebugContext line is invisible
+	// there, which is the whole defect.
+	var logs bytes.Buffer
+	handlerLogger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cache := &blockingImageCache{release: make(chan struct{})}
+	t.Cleanup(func() { close(cache.release) })
+
+	handler := NewHandler(ArticleHandlerDeps{
+		OgImageURLs: stubOgImageURLs{},
+		ImageProxy: image_proxy_usecase.NewImageProxyUsecase(
+			nil, nil, cache, stubImageSigner{}, nil, nil, 0, 0, 0),
+	}, &config.Config{}, handlerLogger)
+	ctx := createAuthContext()
+
+	const (
+		callCount  = 10
+		idsPerCall = 10 // the handler's own per-RPC truncation
+		attempted  = callCount * idsPerCall
+	)
+
+	for call := range callCount {
+		articleIDs := make([]string, 0, idsPerCall)
+		for i := range idsPerCall {
+			articleIDs = append(articleIDs, fmt.Sprintf("article-%d-%d", call, i))
+		}
+		_, err := handler.BatchPrefetchImages(ctx,
+			connect.NewRequest(&articlesv2.BatchPrefetchImagesRequest{ArticleIds: articleIDs}))
+		require.NoError(t, err)
+	}
+
+	// Nothing can release a slot while the cache is parked, so the split
+	// between claimed and shed is decided synchronously inside the RPCs and
+	// there is nothing to wait for.
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	assert.Equal(t, int64(maxConcurrentCacheWarms),
+		sumWarmCounter(rm, "alt_backend_image_cache_warm_started_total"),
+		"warms that claimed a slot must be counted, or a shed rate has no denominator")
+	assert.Equal(t, int64(attempted-maxConcurrentCacheWarms),
+		sumWarmCounter(rm, "alt_backend_image_cache_warm_shed_total"),
+		"every dropped warm must reach a counter; %d of %d were thrown away", attempted-maxConcurrentCacheWarms, attempted)
+
+	// Loud in the log too, but throttled: one line per shed URL would be
+	// hundreds per second exactly when the log is least readable.
+	shedLines := strings.Count(logs.String(), "image_cache_warm.shed")
+	assert.Equal(t, 1, shedLines,
+		"the shed warning must be emitted once per window with an occurrence count, not once per dropped warm")
+	assert.Contains(t, logs.String(), `"level":"WARN"`,
+		"a saturated warm pool must be visible above debug level")
+}

--- a/alt-backend/app/orchestrator/job/feed_collector.go
+++ b/alt-backend/app/orchestrator/job/feed_collector.go
@@ -106,7 +106,7 @@ func CollectMultipleFeeds(ctx context.Context, feedLinks []domain.FeedLink, rate
 
 		feed, err := fetchWithRetryOn403(ctx, func() (*rssFeed.Feed, error) {
 			return fp.ParseURL(feedURL.String())
-		}, feedURL.String())
+		}, feedURL.String(), rateLimiter)
 		if err != nil {
 			logger.Logger.ErrorContext(ctx, "Error parsing feed", "url", feedURL.String(), "error", err)
 			errors = append(errors, err)
@@ -208,16 +208,28 @@ func is403Error(err error) bool {
 
 const max403Retries = 3
 
+// unlimitedRetryInterval is the retry unit for a caller with no host limiter to
+// ask: CLAUDE.md rule 2's floor, which is what the limiter would have been
+// handing out turns at.
+const unlimitedRetryInterval = 5 * time.Second
+
 // fetchWithRetryOn403 retries the fetch with exponential backoff when a 403 is received.
 // After max403Retries, the 403 error is returned and treated as persistent by the caller.
-func fetchWithRetryOn403(ctx context.Context, fetchFn func() (*rssFeed.Feed, error), feedURL string) (*rssFeed.Feed, error) {
+//
+// A retry is another request to the same publisher, so it goes through the host
+// limiter exactly like the first attempt did. It used to sleep its own 1s/2s/4s
+// ladder and re-enter gofeed directly, which put four requests on one host
+// inside seven seconds — under rule 2's floor, and unseen by both the
+// in-process bucket and the shared slot, which only ever heard about attempt
+// one.
+func fetchWithRetryOn403(ctx context.Context, fetchFn func() (*rssFeed.Feed, error), feedURL string, rateLimiter *rate_limiter.HostRateLimiter) (*rssFeed.Feed, error) {
 	feed, err := fetchFn()
 	if err == nil || !is403Error(err) {
 		return feed, err
 	}
 
 	for attempt := 1; attempt <= max403Retries; attempt++ {
-		backoff := time.Duration(1<<uint(attempt-1)) * time.Second // 1s, 2s, 4s
+		backoff := backoffFor403Retry(rateLimiter, feedURL, attempt)
 		slog.WarnContext(ctx, "403 received, retrying with exponential backoff",
 			"url", feedURL, "attempt", attempt, "backoff", backoff)
 
@@ -227,6 +239,16 @@ func fetchWithRetryOn403(ctx context.Context, fetchFn func() (*rssFeed.Feed, err
 		case <-time.After(backoff):
 		}
 
+		// The backoff above is this feed's own penalty; the retry still has to
+		// be handed a turn like every other request to the host, or it jumps
+		// the queue of the feeds waiting on the same publisher and the shared
+		// slot never learns the request happened.
+		if rateLimiter != nil {
+			if waitErr := rateLimiter.WaitForHost(ctx, feedURL); waitErr != nil {
+				return nil, fmt.Errorf("rate limiting failed before 403 retry: %w", waitErr)
+			}
+		}
+
 		feed, err = fetchFn()
 		if err == nil || !is403Error(err) {
 			return feed, err
@@ -234,6 +256,19 @@ func fetchWithRetryOn403(ctx context.Context, fetchFn func() (*rssFeed.Feed, err
 	}
 
 	return nil, err
+}
+
+// backoffFor403Retry returns how long to hold before the given retry attempt.
+// The unit is the host's own interval — the one the limiter hands out turns at,
+// widened if a 429 already backed that host off — so the ladder still doubles
+// (1x, 2x, 4x) but does it inside the rate-limit budget instead of underneath
+// it.
+func backoffFor403Retry(rateLimiter *rate_limiter.HostRateLimiter, feedURL string, attempt int) time.Duration {
+	interval := unlimitedRetryInterval
+	if rateLimiter != nil {
+		interval = rateLimiter.RetryAfterFor(feedURL)
+	}
+	return time.Duration(1<<uint(attempt-1)) * interval
 }
 
 // is429Error returns true if the error indicates rate limiting by the target site.

--- a/alt-backend/app/orchestrator/job/feed_collector.go
+++ b/alt-backend/app/orchestrator/job/feed_collector.go
@@ -213,6 +213,11 @@ const max403Retries = 3
 // handing out turns at.
 const unlimitedRetryInterval = 5 * time.Second
 
+// base403RetryBackoff is the unit of the retry ladder when a limiter is holding
+// the host to an interval: this feed's own penalty for the 403, paid on top of
+// the turn the retry waits for anyway.
+const base403RetryBackoff = 1 * time.Second
+
 // fetchWithRetryOn403 retries the fetch with exponential backoff when a 403 is received.
 // After max403Retries, the 403 error is returned and treated as persistent by the caller.
 //
@@ -258,17 +263,25 @@ func fetchWithRetryOn403(ctx context.Context, fetchFn func() (*rssFeed.Feed, err
 	return nil, err
 }
 
-// backoffFor403Retry returns how long to hold before the given retry attempt.
-// The unit is the host's own interval — the one the limiter hands out turns at,
-// widened if a 429 already backed that host off — so the ladder still doubles
-// (1x, 2x, 4x) but does it inside the rate-limit budget instead of underneath
-// it.
+// backoffFor403Retry returns how long to hold before the given retry attempt:
+// a doubling 1s/2s/4s ladder, clamped to the interval the limiter is already
+// enforcing.
+//
+// The unit used to be that interval rather than a second, which charged it
+// twice — the retry waits for a host turn regardless (see the WaitForHost call
+// above) — and, since a 429 widens the interval up to an hour, let one
+// publisher answering nothing but 403 hold the collector's tick for hours.
+// Holding longer than one interval buys nothing the limiter is not already
+// buying, so the clamp is the ceiling and the ladder is the floor.
+//
+// With no limiter wired there is no turn to wait for, so the ladder carries
+// CLAUDE.md rule 2's floor by itself.
 func backoffFor403Retry(rateLimiter *rate_limiter.HostRateLimiter, feedURL string, attempt int) time.Duration {
-	interval := unlimitedRetryInterval
-	if rateLimiter != nil {
-		interval = rateLimiter.RetryAfterFor(feedURL)
+	step := time.Duration(1 << uint(attempt-1))
+	if rateLimiter == nil {
+		return step * unlimitedRetryInterval
 	}
-	return time.Duration(1<<uint(attempt-1)) * interval
+	return min(step*base403RetryBackoff, rateLimiter.RetryAfterFor(feedURL))
 }
 
 // is429Error returns true if the error indicates rate limiting by the target site.

--- a/alt-backend/app/orchestrator/job/feed_collector_403_backoff_test.go
+++ b/alt-backend/app/orchestrator/job/feed_collector_403_backoff_test.go
@@ -1,0 +1,79 @@
+package job
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"alt/domain"
+	"alt/utils/logger"
+	"alt/utils/rate_limiter"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The 403 ladder is this feed's own penalty for the 403; the host's interval is
+// not its unit. Multiplying the two charges the interval twice — every retry
+// already waits for a host turn — and on a host an earlier 429 backed off (the
+// backoff caps at an hour) it turns three retries into hours, during which the
+// collector's tick is held by one publisher that answers nothing but 403.
+//
+// Each case gives the limiter enough burst that every attempt gets its turn
+// immediately, so what these two seconds measure is the ladder alone.
+func TestCollectMultipleFeeds_403LadderIsNotScaledByTheHostInterval(t *testing.T) {
+	logger.InitLogger()
+	allowLoopbackFeedHost(t)
+
+	// productionHostInterval is what compose runs the feed collector at.
+	const productionHostInterval = 10 * time.Second
+
+	tests := []struct {
+		name      string
+		widenHost func(limiter *rate_limiter.HostRateLimiter, host string)
+	}{
+		{
+			name:      "at the host's configured interval",
+			widenHost: func(*rate_limiter.HostRateLimiter, string) {},
+		},
+		{
+			name: "at an interval an earlier 429 widened",
+			widenHost: func(limiter *rate_limiter.HostRateLimiter, host string) {
+				limiter.RecordRateLimitHit(host, time.Hour) // the ceiling RecordRateLimitHit clamps to
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.WriteHeader(http.StatusForbidden)
+			}))
+			defer server.Close()
+
+			feedURL, err := url.Parse(server.URL + "/feed.xml")
+			require.NoError(t, err)
+
+			limiter := rate_limiter.NewHostRateLimiter(productionHostInterval, 1+max403Retries)
+			tt.widenHost(limiter, feedURL.Host)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			feedLinks := []domain.FeedLink{{ID: uuid.New(), URL: feedURL.String()}}
+			_, err = CollectMultipleFeeds(ctx, feedLinks, limiter, nil)
+			require.Error(t, err, "a feed that answers 403 to every attempt must fail the collection")
+
+			assert.GreaterOrEqual(t, requests.Load(), int64(2),
+				"the first 403 retry must reach the publisher inside two seconds; a ladder whose unit is the %s host interval holds it far longer than that",
+				productionHostInterval)
+		})
+	}
+}

--- a/alt-backend/app/orchestrator/job/feed_collector_403_retry_test.go
+++ b/alt-backend/app/orchestrator/job/feed_collector_403_retry_test.go
@@ -1,0 +1,77 @@
+package job
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"alt/domain"
+	"alt/utils/logger"
+	"alt/utils/rate_limiter"
+
+	"github.com/google/uuid"
+	rssFeed "github.com/mmcdole/gofeed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A 403 retry is another request to the same publisher, so it has to queue for
+// the same host slot the first attempt took. The retry loop used to sleep
+// 1s/2s/4s of its own and go straight back into gofeed, which put four requests
+// on one host inside seven seconds — below CLAUDE.md rule 2's floor and
+// invisible to both the in-process bucket and the shared arbiter.
+func TestCollectMultipleFeeds_403RetriesTakeAHostSlot(t *testing.T) {
+	logger.InitLogger()
+	allowLoopbackFeedHost(t)
+
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	store := &recordingSlotStore{}
+	limiter := rate_limiter.NewCoordinatedHostRateLimiter(time.Millisecond, 1, rate_limiter.Coordination{
+		Store:     store,
+		Namespace: rate_limiter.NamespaceExternalAPI,
+		Owner:     "alt-harvester/test",
+	})
+
+	feedURL, err := url.Parse(server.URL + "/feed.xml")
+	require.NoError(t, err)
+
+	feedLinks := []domain.FeedLink{{ID: uuid.New(), URL: feedURL.String()}}
+	_, err = CollectMultipleFeeds(context.Background(), feedLinks, limiter, nil)
+	require.Error(t, err, "a feed that answers 403 to every attempt must fail the collection")
+
+	require.Equal(t, int64(1+max403Retries), requests.Load(),
+		"the retry ladder itself is unchanged: one attempt plus max403Retries")
+	assert.Len(t, store.recorded(), 1+max403Retries,
+		"every attempt is a request to the publisher and must arbitrate for the host slot")
+}
+
+// With no limiter wired there is nothing else tracking the host, so the backoff
+// alone has to hold rule 2's floor. The deadline here is well under that floor
+// and well over the second the old ladder waited, so a retry escaping the
+// interval shows up as a second call to the publisher.
+func TestFetchWithRetryOn403_WithoutLimiter_HoldsTheExternalAPIFloor(t *testing.T) {
+	logger.InitLogger()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	attempts := 0
+	_, err := fetchWithRetryOn403(ctx, func() (*rssFeed.Feed, error) {
+		attempts++
+		return nil, errorWithMessage("http error: 403 Forbidden")
+	}, "https://example.com/feed.xml", nil)
+
+	require.Error(t, err, "the context runs out before the backoff does")
+	assert.Equal(t, 1, attempts,
+		"a 403 retry may not reach the publisher inside the 5-second external-API interval")
+}

--- a/alt-backend/app/orchestrator/job/feed_collector_test.go
+++ b/alt-backend/app/orchestrator/job/feed_collector_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"alt/utils/rate_limiter"
+
 	rssFeed "github.com/mmcdole/gofeed"
 )
 
@@ -511,6 +513,14 @@ func TestIs403Error(t *testing.T) {
 	}
 }
 
+// fastRetryLimiter keeps the retry ladder inside the test's own budget. The
+// backoff is measured in host intervals, so a millisecond interval makes the
+// retries immediate without changing how many of them there are — and the
+// limiter is what these subtests exercise the retries through.
+func fastRetryLimiter() *rate_limiter.HostRateLimiter {
+	return rate_limiter.NewHostRateLimiter(time.Millisecond)
+}
+
 func TestFetchWithRetryOn403(t *testing.T) {
 	t.Run("first attempt succeeds without retry", func(t *testing.T) {
 		expectedFeed := &rssFeed.Feed{Title: "Test Feed"}
@@ -520,7 +530,7 @@ func TestFetchWithRetryOn403(t *testing.T) {
 			return expectedFeed, nil
 		}
 
-		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed")
+		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed", fastRetryLimiter())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -543,7 +553,7 @@ func TestFetchWithRetryOn403(t *testing.T) {
 			return expectedFeed, nil
 		}
 
-		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed")
+		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed", fastRetryLimiter())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -566,7 +576,7 @@ func TestFetchWithRetryOn403(t *testing.T) {
 			return expectedFeed, nil
 		}
 
-		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed")
+		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed", fastRetryLimiter())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -585,7 +595,7 @@ func TestFetchWithRetryOn403(t *testing.T) {
 			return nil, errorWithMessage("HTTP error: 403 Forbidden")
 		}
 
-		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed")
+		feed, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed", fastRetryLimiter())
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -607,7 +617,7 @@ func TestFetchWithRetryOn403(t *testing.T) {
 			return nil, errorWithMessage("HTTP error: 404 Not Found")
 		}
 
-		_, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed")
+		_, err := fetchWithRetryOn403(context.Background(), fetchFn, "https://example.com/feed", fastRetryLimiter())
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -625,7 +635,7 @@ func TestFetchWithRetryOn403(t *testing.T) {
 			return nil, errorWithMessage("HTTP error: 403 Forbidden")
 		}
 
-		_, err := fetchWithRetryOn403(ctx, fetchFn, "https://example.com/feed")
+		_, err := fetchWithRetryOn403(ctx, fetchFn, "https://example.com/feed", fastRetryLimiter())
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/alt-backend/app/orchestrator/job/outbox_worker.go
+++ b/alt-backend/app/orchestrator/job/outbox_worker.go
@@ -56,9 +56,12 @@ const outboxClaimBatchSize = 10
 // exactly how the budget went stale the first time (see maxOutboxUpsertAttempts).
 const outboxWorkerTickInterval = 5 * time.Second
 
-// maxOutboxUpsertAttempts bounds how many times a transient RAG upsert
-// failure (see rag_integration_port.ErrRagUpsertTransient) is released back
-// to PENDING before the row is given up as terminally FAILED.
+// maxOutboxUpsertAttempts bounds how many times a row is released back to
+// PENDING before it is given up as terminally FAILED. One budget covers both
+// of the row's side effects — a transient RAG upsert failure (see
+// rag_integration_port.ErrRagUpsertTransient) and a failed ArticleCreated
+// append — because what it rations is claim slots, and a row occupies one
+// whichever leg sent it back.
 //
 // There is no attempt_count column on outbox_events, so this count lives in
 // process memory (outboxRetryTracker) and resets on every harvester restart.
@@ -79,15 +82,21 @@ const outboxWorkerTickInterval = 5 * time.Second
 // unbounded and unattended.
 const maxOutboxUpsertAttempts = 24
 
-// outboxRetryTracker counts consecutive transient UpsertArticle failures per
-// outbox row, across worker ticks, in process memory only.
+// outboxRetryTracker counts consecutive delivery failures per outbox row,
+// across worker ticks, in process memory only. It also remembers which rows
+// already got their RAG upsert in, so a row released for the sake of its
+// second side effect does not pay for the first one twice.
 type outboxRetryTracker struct {
-	mu       sync.Mutex
-	attempts map[string]int
+	mu          sync.Mutex
+	attempts    map[string]int
+	ragUpserted map[string]bool
 }
 
 func newOutboxRetryTracker() *outboxRetryTracker {
-	return &outboxRetryTracker{attempts: make(map[string]int)}
+	return &outboxRetryTracker{
+		attempts:    make(map[string]int),
+		ragUpserted: make(map[string]bool),
+	}
 }
 
 // recordFailure increments and returns the attempt count for id.
@@ -98,13 +107,31 @@ func (t *outboxRetryTracker) recordFailure(id string) int {
 	return t.attempts[id]
 }
 
+// markRagUpserted records that id's article reached the RAG index.
+func (t *outboxRetryTracker) markRagUpserted(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ragUpserted[id] = true
+}
+
+// ragUpsertDone reports whether this process already delivered id's article to
+// the RAG index. Only ever false-negative: a restart forgets, and the row is
+// upserted again — which is safe, the upsert is idempotent on article_id, and
+// costs one embedding run rather than a missed one.
+func (t *outboxRetryTracker) ragUpsertDone(id string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.ragUpserted[id]
+}
+
 // clear forgets id. Called once a row reaches a terminal status (PROCESSED or
-// FAILED) so a long-running harvester process does not grow this map by one
+// FAILED) so a long-running harvester process does not grow these maps by one
 // entry per outbox row for the life of the process.
 func (t *outboxRetryTracker) clear(id string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	delete(t.attempts, id)
+	delete(t.ragUpserted, id)
 }
 
 // These OTel counters are this file's fix for a specific gap: before this
@@ -199,19 +226,31 @@ func processOutboxEvents(ctx context.Context, repo outboxRepository, ragIntegrat
 			// codebase: the outbox is the sole delivery route into the RAG
 			// index, not a reliability backstop for a separate direct-call
 			// path.
-			if err := ragIntegration.UpsertArticle(ctx, upsertInput); err != nil {
-				handleUpsertFailure(ctx, repo, retries, event.ID, err)
-				// Knowledge Home must not wait on RAG success (ADR-000578):
-				// still attempt ArticleCreated. Emit failure on this branch
-				// cannot reopen a terminally FAILED row — orphan repair
-				// covers that case. On a transient RAG release the next
-				// tick retries both side effects (ArticleCreated is
-				// dedupe-safe).
-				if emitErr := emitArticleCreatedEvent(ctx, knowledgeEventPort, event.Payload); emitErr != nil {
-					logger.Logger.ErrorContext(ctx, "ArticleCreated emit failed after RAG upsert failure",
-						"event_id", event.ID, "error", emitErr)
+			//
+			// It is skipped for a row this process already upserted, which is
+			// a row released only because its ArticleCreated append failed.
+			// Repeating the upsert would re-run 10-30s of embedding for a
+			// document already in the index, and it is exactly the rows in
+			// that state that a sovereign outage re-claims every tick.
+			if retries.ragUpsertDone(event.ID) {
+				logger.Logger.InfoContext(ctx, "Skipping RAG upsert already delivered in an earlier tick, retrying ArticleCreated only",
+					"event_id", event.ID)
+			} else {
+				if err := ragIntegration.UpsertArticle(ctx, upsertInput); err != nil {
+					handleUpsertFailure(ctx, repo, retries, event.ID, err)
+					// Knowledge Home must not wait on RAG success (ADR-000578):
+					// still attempt ArticleCreated. Emit failure on this branch
+					// cannot reopen a terminally FAILED row — orphan repair
+					// covers that case. On a transient RAG release the next
+					// tick retries both side effects (ArticleCreated is
+					// dedupe-safe).
+					if emitErr := emitArticleCreatedEvent(ctx, knowledgeEventPort, event.Payload); emitErr != nil {
+						logger.Logger.ErrorContext(ctx, "ArticleCreated emit failed after RAG upsert failure",
+							"event_id", event.ID, "error", emitErr)
+					}
+					continue
 				}
-				continue
+				retries.markRagUpserted(event.ID)
 			}
 
 			// ACK only after both side effects are durable. Marking
@@ -221,13 +260,7 @@ func processOutboxEvents(ctx context.Context, repo outboxRepository, ragIntegrat
 			// via SummaryVersionCreated with blank title/url and Trail
 			// fell back to article:<uuid>.
 			if err := emitArticleCreatedEvent(ctx, knowledgeEventPort, event.Payload); err != nil {
-				logger.Logger.ErrorContext(ctx, "ArticleCreated emit failed after RAG success; releasing outbox event for retry",
-					"event_id", event.ID, "error", err)
-				if releaseForRetry(ctx, repo, event.ID) {
-					outboxRetriedCounter.Add(ctx, 1)
-				} else {
-					outboxReleaseFailedCounter.Add(ctx, 1)
-				}
+				handleArticleCreatedFailure(ctx, repo, retries, event.ID, err)
 				continue
 			}
 
@@ -288,6 +321,37 @@ func handleUpsertFailure(ctx context.Context, repo outboxRepository, retries *ou
 	retries.clear(eventID)
 	markProcessed(ctx, repo, eventID, domain.OutboxFailed, err.Error())
 	outboxFailedCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "non_retryable_error")))
+}
+
+// handleArticleCreatedFailure decides whether a row whose RAG upsert
+// succeeded but whose ArticleCreated append did not gets another try.
+//
+// Every append failure is transient by construction — an invalid payload is
+// skipped inside emitArticleCreatedEvent rather than returned — so unlike
+// handleUpsertFailure there is no permanent class to sort out here. What it
+// does share is the budget: the release used to be unconditional, which made
+// this the one delivery path with no ceiling at all. The claim is oldest-first
+// LIMIT 10, so an unbounded release is not "this row waits" but "this row
+// occupies a tenth of every tick and every newer article waits behind it",
+// for as long as knowledge-sovereign is down.
+func handleArticleCreatedFailure(ctx context.Context, repo outboxRepository, retries *outboxRetryTracker, eventID string, err error) {
+	attempt := retries.recordFailure(eventID)
+	if attempt < maxOutboxUpsertAttempts {
+		logger.Logger.WarnContext(ctx, "ArticleCreated emit failed after RAG success; releasing outbox event for retry",
+			"event_id", eventID, "attempt", attempt, "max_attempts", maxOutboxUpsertAttempts, "error", err)
+		if releaseForRetry(ctx, repo, eventID) {
+			outboxRetriedCounter.Add(ctx, 1)
+		} else {
+			outboxReleaseFailedCounter.Add(ctx, 1)
+		}
+		return
+	}
+
+	logger.Logger.ErrorContext(ctx, "ArticleCreated emit exhausted retries, marking outbox event FAILED",
+		"event_id", eventID, "attempts", attempt, "error", err)
+	retries.clear(eventID)
+	markProcessed(ctx, repo, eventID, domain.OutboxFailed, err.Error())
+	outboxFailedCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "article_created_retries_exhausted")))
 }
 
 // releaseForRetry returns a transiently-failed event to PENDING on a context

--- a/alt-backend/app/orchestrator/job/outbox_worker.go
+++ b/alt-backend/app/orchestrator/job/outbox_worker.go
@@ -57,11 +57,13 @@ const outboxClaimBatchSize = 10
 const outboxWorkerTickInterval = 5 * time.Second
 
 // maxOutboxUpsertAttempts bounds how many times a row is released back to
-// PENDING before it is given up as terminally FAILED. One budget covers both
-// of the row's side effects — a transient RAG upsert failure (see
+// PENDING before it is given up as terminally FAILED. Both of the row's side
+// effects draw on it — a transient RAG upsert failure (see
 // rag_integration_port.ErrRagUpsertTransient) and a failed ArticleCreated
 // append — because what it rations is claim slots, and a row occupies one
-// whichever leg sent it back.
+// whichever leg sent it back. Delivering one of them refreshes it (see
+// markRagUpserted): the two legs talk to two different services, and a budget
+// sized to outlast one service's redeploy is not a budget they can split.
 //
 // There is no attempt_count column on outbox_events, so this count lives in
 // process memory (outboxRetryTracker) and resets on every harvester restart.
@@ -107,11 +109,21 @@ func (t *outboxRetryTracker) recordFailure(id string) int {
 	return t.attempts[id]
 }
 
-// markRagUpserted records that id's article reached the RAG index.
+// markRagUpserted records that id's article reached the RAG index, and returns
+// the attempt budget to full.
+//
+// Reaching the index is progress, and the budget is sized to outlast one
+// downstream service being redeployed (see maxOutboxUpsertAttempts). The row's
+// two legs talk to two different services, so carrying a budget spent on a
+// rag-orchestrator outage over to the ArticleCreated leg hands that leg a
+// window far shorter than the one it was sized for — at worst a single attempt
+// — and ends the row FAILED on the tick both side effects were finally making
+// progress. ragUpserted deliberately survives: the upsert must not be re-run.
 func (t *outboxRetryTracker) markRagUpserted(id string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.ragUpserted[id] = true
+	delete(t.attempts, id)
 }
 
 // ragUpsertDone reports whether this process already delivered id's article to
@@ -329,11 +341,12 @@ func handleUpsertFailure(ctx context.Context, repo outboxRepository, retries *ou
 // Every append failure is transient by construction — an invalid payload is
 // skipped inside emitArticleCreatedEvent rather than returned — so unlike
 // handleUpsertFailure there is no permanent class to sort out here. What it
-// does share is the budget: the release used to be unconditional, which made
-// this the one delivery path with no ceiling at all. The claim is oldest-first
-// LIMIT 10, so an unbounded release is not "this row waits" but "this row
-// occupies a tenth of every tick and every newer article waits behind it",
-// for as long as knowledge-sovereign is down.
+// shares is the budget's size, not its remainder: a row whose upsert landed
+// starts this count from zero (markRagUpserted). The release used to be
+// unconditional, which made this the one delivery path with no ceiling at all.
+// The claim is oldest-first LIMIT 10, so an unbounded release is not "this row
+// waits" but "this row occupies a tenth of every tick and every newer article
+// waits behind it", for as long as knowledge-sovereign is down.
 func handleArticleCreatedFailure(ctx context.Context, repo outboxRepository, retries *outboxRetryTracker, eventID string, err error) {
 	attempt := retries.recordFailure(eventID)
 	if attempt < maxOutboxUpsertAttempts {

--- a/alt-backend/app/orchestrator/job/outbox_worker_retry_budget_test.go
+++ b/alt-backend/app/orchestrator/job/outbox_worker_retry_budget_test.go
@@ -1,0 +1,112 @@
+package job
+
+import (
+	"alt/domain"
+	"alt/orchestrator/port/rag_integration_port"
+	"alt/utils/logger"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recoveringRagIntegration fails its first `failures` upserts transiently and
+// succeeds from then on: a rag-orchestrator outage that ends while the row is
+// still inside its retry budget.
+type recoveringRagIntegration struct {
+	failures int
+	err      error
+	upserts  int
+}
+
+func (r *recoveringRagIntegration) RetrieveContext(_ context.Context, _ string, _ []string) ([]rag_integration_port.RagContext, error) {
+	return nil, nil
+}
+
+func (r *recoveringRagIntegration) UpsertArticle(_ context.Context, _ rag_integration_port.UpsertArticleInput) error {
+	r.upserts++
+	if r.upserts <= r.failures {
+		return r.err
+	}
+	return nil
+}
+
+func (r *recoveringRagIntegration) Answer(_ context.Context, _ rag_integration_port.AnswerInput) (<-chan string, error) {
+	return nil, nil
+}
+
+// TestProcessOutboxEvents_RagUpsertLands_RefreshesTheAttemptBudget pins what
+// maxOutboxUpsertAttempts is a budget *for*: outlasting one downstream service
+// being redeployed. The row's two legs talk to two different services —
+// rag-orchestrator and knowledge-sovereign — so spending the budget on an
+// outage of the first and then charging the remainder to an outage of the
+// second gives the second leg a window far shorter than the one the budget was
+// sized for. In the extreme below it gets a single attempt, and the row is
+// marked terminally FAILED on the very tick both of its side effects were
+// finally making progress.
+func TestProcessOutboxEvents_RagUpsertLands_RefreshesTheAttemptBudget(t *testing.T) {
+	logger.InitLogger()
+
+	eventID := uuid.New().String()
+	repo := &mockOutboxRepo{events: []domain.OutboxEvent{outboxUpsertEventFixture(eventID)}}
+	// rag-orchestrator is down for all but the last tick of the budget.
+	rag := &recoveringRagIntegration{
+		failures: maxOutboxUpsertAttempts - 1,
+		err:      fmt.Errorf("%w: RAG UpsertIndex returned status 503", rag_integration_port.ErrRagUpsertTransient),
+	}
+	// knowledge-sovereign is down throughout.
+	knowledgePort := &stubKnowledgeEventPort{err: fmt.Errorf("sovereign AppendKnowledgeEvent: unavailable")}
+	retries := newOutboxRetryTracker()
+
+	for tick := 1; tick < maxOutboxUpsertAttempts; tick++ {
+		require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+		require.Equal(t, "PENDING", repo.statusOf(eventID),
+			"tick %d: the RAG outage is still inside the %d-attempt budget", tick, maxOutboxUpsertAttempts)
+	}
+
+	// The tick rag-orchestrator comes back: the upsert lands, the append does not.
+	require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+	require.Equal(t, maxOutboxUpsertAttempts, rag.upserts, "the last tick's upsert must have been attempted and succeeded")
+
+	assert.Equal(t, "PENDING", repo.statusOf(eventID),
+		"the RAG leg just delivered; the ArticleCreated leg must not inherit a budget the RAG outage already spent")
+}
+
+// TestProcessOutboxEvents_RefreshedAttemptBudget_IsStillBounded is the other
+// half: refreshing the budget on progress is a reset, not an exemption. With
+// the upsert delivered and knowledge-sovereign still down, the ArticleCreated
+// leg spends its own budget and the row ends FAILED, rather than holding the
+// head of the oldest-first claim while every newer article queues behind it.
+func TestProcessOutboxEvents_RefreshedAttemptBudget_IsStillBounded(t *testing.T) {
+	logger.InitLogger()
+
+	eventID := uuid.New().String()
+	repo := &mockOutboxRepo{events: []domain.OutboxEvent{outboxUpsertEventFixture(eventID)}}
+	rag := &recoveringRagIntegration{
+		failures: 1,
+		err:      fmt.Errorf("%w: RAG UpsertIndex returned status 503", rag_integration_port.ErrRagUpsertTransient),
+	}
+	knowledgePort := &stubKnowledgeEventPort{err: fmt.Errorf("sovereign AppendKnowledgeEvent: unavailable")}
+	retries := newOutboxRetryTracker()
+
+	// One tick of RAG outage, so the shared counter is already non-zero when
+	// the upsert lands on the next one.
+	require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+	require.Equal(t, "PENDING", repo.statusOf(eventID))
+
+	for attempt := 1; attempt <= maxOutboxUpsertAttempts; attempt++ {
+		require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+		if attempt < maxOutboxUpsertAttempts {
+			require.Equal(t, "PENDING", repo.statusOf(eventID),
+				"ArticleCreated attempt %d of %d must still be retried", attempt, maxOutboxUpsertAttempts)
+		}
+	}
+
+	assert.Equal(t, "FAILED", repo.statusOf(eventID),
+		"a sovereign outage outliving the ArticleCreated leg's own budget must still end the row")
+	assert.Equal(t, 2, rag.upserts,
+		"the delivered upsert must not be re-run once per tick while only the append is failing")
+}

--- a/alt-backend/app/orchestrator/job/outbox_worker_test.go
+++ b/alt-backend/app/orchestrator/job/outbox_worker_test.go
@@ -109,14 +109,17 @@ func TestEmitArticleCreatedEvent(t *testing.T) {
 	})
 }
 
-// successRagIntegration is a RagIntegrationPort that always succeeds UpsertArticle.
-type successRagIntegration struct{}
+// successRagIntegration is a RagIntegrationPort that always succeeds
+// UpsertArticle, counting the calls: an upsert is the 10-30s embedding run,
+// so "how many times was it called" is the cost this worker is spending.
+type successRagIntegration struct{ upserts int }
 
 func (s *successRagIntegration) RetrieveContext(_ context.Context, _ string, _ []string) ([]rag_integration_port.RagContext, error) {
 	return nil, nil
 }
 
 func (s *successRagIntegration) UpsertArticle(_ context.Context, _ rag_integration_port.UpsertArticleInput) error {
+	s.upserts++
 	return nil
 }
 
@@ -234,9 +237,13 @@ func (m *mockOutboxRepo) statusOf(id string) string {
 	return status
 }
 
-// blockingRagIntegration simulates the local embedder taking longer than the
-// job timeout: UpsertArticle only returns once the caller's context is done,
-// the same way a 500KB+ article with 100+ chunks legitimately can.
+// blockingRagIntegration simulates the local embedder still working when the
+// job context dies: UpsertArticle only returns once the caller's context is
+// done, the same way a 500KB+ article with 100+ chunks legitimately can.
+//
+// It returns the error augur_adapter produces for that case — transient —
+// rather than a bare ctx.Err(), so tests driving this stub describe the real
+// classification instead of a taxonomy no implementation returns.
 type blockingRagIntegration struct {
 	started chan struct{}
 }
@@ -248,7 +255,7 @@ func (b *blockingRagIntegration) RetrieveContext(_ context.Context, _ string, _ 
 func (b *blockingRagIntegration) UpsertArticle(ctx context.Context, _ rag_integration_port.UpsertArticleInput) error {
 	close(b.started)
 	<-ctx.Done()
-	return ctx.Err()
+	return fmt.Errorf("%w: failed to call UpsertIndex: %w", rag_integration_port.ErrRagUpsertTransient, ctx.Err())
 }
 
 func (b *blockingRagIntegration) Answer(_ context.Context, _ rag_integration_port.AnswerInput) (<-chan string, error) {
@@ -295,17 +302,16 @@ func outboxUpsertEventFixture(id string) domain.OutboxEvent {
 	}
 }
 
-// TestProcessOutboxEvents_CancelMidProcessing_MarksInFlightEventFailed is a
-// worker-layer unit test: GIVEN a plain (non-transient) error from
-// UpsertArticle — which is what a job-timeout cancellation now produces
-// through the real classifier, see augur_adapter_test.go's "context deadline
-// exceeded" case and the integration test right below this one — the worker
-// must mark the row FAILED, not leave it PROCESSING. blockingRagIntegration
-// stands in for any RagIntegrationPort implementation raising that kind of
-// error; it does not by itself prove augur_adapter classifies a caller-side
-// timeout this way, which is why the adapter-level and integration tests
-// exist as a separate, non-bypassable check on that classification.
-func TestProcessOutboxEvents_CancelMidProcessing_MarksInFlightEventFailed(t *testing.T) {
+// TestProcessOutboxEvents_CancelMidProcessing_ReleasesInFlightEventForRetry is
+// a worker-layer unit test: GIVEN the transient error a canceled UpsertArticle
+// produces, the row must end PENDING — not PROCESSING (invisible to the
+// PENDING-only claim query) and not FAILED (invisible to it forever).
+// blockingRagIntegration stands in for any RagIntegrationPort implementation
+// raising that kind of error; it does not by itself prove augur_adapter
+// classifies a caller-side cancellation this way, which is why the
+// adapter-level and integration tests exist as a separate, non-bypassable
+// check on that classification.
+func TestProcessOutboxEvents_CancelMidProcessing_ReleasesInFlightEventForRetry(t *testing.T) {
 	logger.InitLogger()
 
 	eventID := uuid.New().String()
@@ -333,19 +339,21 @@ func TestProcessOutboxEvents_CancelMidProcessing_MarksInFlightEventFailed(t *tes
 		t.Fatal("processOutboxEvents did not return promptly after context cancellation")
 	}
 
-	assert.Equal(t, "FAILED", repo.statusOf(eventID), "in-flight event must end FAILED, not stuck PROCESSING")
+	assert.Equal(t, "PENDING", repo.statusOf(eventID), "in-flight event must be released for retry, not stuck PROCESSING nor terminally FAILED")
 }
 
-// TestProcessOutboxEvents_JobTimeoutMidUpsert_ThroughRealAdapter_EndsFailedNotRetried
+// TestProcessOutboxEvents_JobCanceledMidUpsert_ThroughRealAdapter_ReleasesForRetry
 // is the integration check the test above cannot be: it wires the real
-// augur_adapter.AugurAdapter (not a stub that bypasses its classification) so
-// a mutation reinstating defect 2 — augur_adapter marking a caller-context
-// cancellation transient — actually turns this test red. Without going
-// through the real adapter, a job-timeout mid-upsert would be classified
-// ErrRagUpsertTransient and released to PENDING instead of failing once,
-// costing the worker another full job timeout on the very next tick (see
-// augur_adapter.go's transport-error branch).
-func TestProcessOutboxEvents_JobTimeoutMidUpsert_ThroughRealAdapter_EndsFailedNotRetried(t *testing.T) {
+// augur_adapter.AugurAdapter (not a stub that bypasses its classification), so
+// it pins what the harvester actually does when SIGTERM cancels the job
+// context mid-upsert during a redeploy.
+//
+// That row must come back as PENDING. Ending it FAILED — the pre-fix
+// behavior — took it out of the PENDING-only claim query for good: nothing
+// re-claims a FAILED row, outbox-prune does not delete it, and there is no
+// requeue path, so whichever article was mid-upsert stayed out of the RAG
+// index permanently, once per deploy.
+func TestProcessOutboxEvents_JobCanceledMidUpsert_ThroughRealAdapter_ReleasesForRetry(t *testing.T) {
 	logger.InitLogger()
 
 	eventID := uuid.New().String()
@@ -382,8 +390,8 @@ func TestProcessOutboxEvents_JobTimeoutMidUpsert_ThroughRealAdapter_EndsFailedNo
 		t.Fatal("processOutboxEvents did not return promptly after context cancellation")
 	}
 
-	assert.Equal(t, "FAILED", repo.statusOf(eventID),
-		"a job-timeout mid-upsert, classified by the real adapter, must end FAILED on the first attempt — not be released for a same-worker retry that burns another full job timeout")
+	assert.Equal(t, "PENDING", repo.statusOf(eventID),
+		"a job-context cancellation mid-upsert, classified by the real adapter, must release the row for retry — a FAILED row is claimed by nobody, pruned by nothing and requeued by no path")
 }
 
 func TestProcessOutboxEvents_CancelMidBatch_ResetsUnattemptedClaimedEventsToPending(t *testing.T) {
@@ -421,7 +429,7 @@ func TestProcessOutboxEvents_CancelMidBatch_ResetsUnattemptedClaimedEventsToPend
 		t.Fatal("processOutboxEvents did not return promptly after context cancellation")
 	}
 
-	assert.Equal(t, "FAILED", repo.statusOf(blockedID), "in-flight event must end FAILED, not stuck PROCESSING")
+	assert.Equal(t, "PENDING", repo.statusOf(blockedID), "in-flight event must be released for retry, not stuck PROCESSING nor terminally FAILED")
 	assert.Equal(t, "PENDING", repo.statusOf(unattemptedID1), "unattempted claimed event must be released back to PENDING")
 	assert.Equal(t, "PENDING", repo.statusOf(unattemptedID2), "unattempted claimed event must be released back to PENDING")
 }
@@ -516,6 +524,62 @@ func TestProcessOutboxEvents_TransientRagFailure_SurvivesRealisticRedeployWindow
 
 	assert.Equal(t, "PENDING", repo.statusOf(eventID),
 		"a %s outage (%d ticks) must not exhaust the %d-attempt retry budget", observedWorstCaseRedeploy, ticksInWindow, maxOutboxUpsertAttempts)
+}
+
+// TestProcessOutboxEvents_ArticleCreatedFailure_ExhaustsRetryBudgetThenFails
+// puts the ArticleCreated leg on the same attempt budget as the RAG leg.
+//
+// The release after a failed append used to be unconditional, so a
+// knowledge-sovereign outage pinned the same rows at the front of the
+// oldest-first claim forever: every tick re-claimed them, and (before the
+// skip below) re-ran their embeddings, while newer articles queued behind an
+// event that would never make progress until sovereign came back.
+func TestProcessOutboxEvents_ArticleCreatedFailure_ExhaustsRetryBudgetThenFails(t *testing.T) {
+	logger.InitLogger()
+
+	eventID := uuid.New().String()
+	repo := &mockOutboxRepo{events: []domain.OutboxEvent{outboxUpsertEventFixture(eventID)}}
+	rag := &successRagIntegration{}
+	knowledgePort := &stubKnowledgeEventPort{err: fmt.Errorf("sovereign AppendKnowledgeEvent: unavailable")}
+	retries := newOutboxRetryTracker()
+
+	for attempt := 1; attempt <= maxOutboxUpsertAttempts; attempt++ {
+		require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+		if attempt < maxOutboxUpsertAttempts {
+			require.Equal(t, "PENDING", repo.statusOf(eventID), "attempt %d of %d must still be retried", attempt, maxOutboxUpsertAttempts)
+		}
+	}
+
+	assert.Equal(t, "FAILED", repo.statusOf(eventID),
+		"a sovereign outage outliving the attempt budget must end the row, not hold the head of the claim queue indefinitely")
+}
+
+// TestProcessOutboxEvents_ArticleCreatedRetry_DoesNotReUpsertToRag pins the
+// other half of that fix: a row released only because the ArticleCreated
+// append failed has already delivered its RAG upsert, so retrying it must
+// retry the append alone. Re-running the 10-30s embedding for an index entry
+// that is already there is what made a sovereign outage cost the whole batch
+// its tick.
+func TestProcessOutboxEvents_ArticleCreatedRetry_DoesNotReUpsertToRag(t *testing.T) {
+	logger.InitLogger()
+
+	eventID := uuid.New().String()
+	repo := &mockOutboxRepo{events: []domain.OutboxEvent{outboxUpsertEventFixture(eventID)}}
+	rag := &successRagIntegration{}
+	knowledgePort := &stubKnowledgeEventPort{err: fmt.Errorf("sovereign AppendKnowledgeEvent: unavailable")}
+	retries := newOutboxRetryTracker()
+
+	require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+	require.Equal(t, "PENDING", repo.statusOf(eventID))
+	require.Equal(t, 1, rag.upserts)
+
+	knowledgePort.err = nil
+	require.NoError(t, processOutboxEvents(context.Background(), repo, rag, knowledgePort, retries))
+
+	assert.Equal(t, "PROCESSED", repo.statusOf(eventID))
+	assert.Equal(t, 1, rag.upserts,
+		"the RAG upsert already succeeded on the first tick; the retry exists for the ArticleCreated append alone")
+	assert.Len(t, knowledgePort.events, 2, "the append must be retried (dedupe-safe upstream)")
 }
 
 // releaseFailingOutboxRepo simulates the release-to-PENDING RPC itself

--- a/alt-backend/app/orchestrator/port/today_digest_port/port.go
+++ b/alt-backend/app/orchestrator/port/today_digest_port/port.go
@@ -13,10 +13,9 @@ type GetTodayDigestPort interface {
 	GetTodayDigest(ctx context.Context, userID uuid.UUID, date time.Time) (domain.TodayDigest, error)
 }
 
-// UpsertTodayDigestPort writes to the today digest projection.
-type UpsertTodayDigestPort interface {
-	UpsertTodayDigest(ctx context.Context, digest domain.TodayDigest) error
-}
+// There is deliberately no write port here. today_digest_view is folded from
+// the event log by knowledge-sovereign's knowledge_home_projector, which is its
+// only writer; alt-backend reads it and nothing more.
 
 // GetProjectionFreshnessPort returns the last updated_at for a projector checkpoint.
 type GetProjectionFreshnessPort interface {

--- a/alt-backend/app/orchestrator/rest/article_handlers.go
+++ b/alt-backend/app/orchestrator/rest/article_handlers.go
@@ -20,6 +20,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// maxArticlesPageSize is the largest page the cursor handlers will serve.
+//
+// It sits one below the usecases' own ceiling of 100 on purpose: these
+// handlers ask for limit+1 rows so they can answer has_more without a separate
+// COUNT, so a page of 100 would fetch 101 and the usecase would reject it.
+// Clamping to 100 turned the documented maximum page size into an opaque 500.
+const maxArticlesPageSize = 99
+
 func fetchArticleRoutes(v1 *echo.Group, container *di.ApplicationComponents, cfg *config.Config) {
 	authMiddleware := middleware_custom.NewAuthMiddleware(logger.Logger, cfg)
 	articles := v1.Group("/articles", authMiddleware.RequireAuth())
@@ -169,8 +177,8 @@ func handleFetchArticlesCursor(container *di.ApplicationComponents) echo.Handler
 				return HandleValidationError(c, "Invalid limit parameter", "limit", limitStr)
 			}
 			limit = parsedLimit
-			if limit > 100 {
-				limit = 100
+			if limit > maxArticlesPageSize {
+				limit = maxArticlesPageSize
 			}
 		}
 
@@ -265,8 +273,8 @@ func handleFetchArticlesByTag(container *di.ApplicationComponents) echo.HandlerF
 				return HandleValidationError(c, "Invalid limit parameter", "limit", limitStr)
 			}
 			limit = parsedLimit
-			if limit > 100 {
-				limit = 100
+			if limit > maxArticlesPageSize {
+				limit = maxArticlesPageSize
 			}
 		}
 

--- a/alt-backend/app/orchestrator/rest/article_limit_clamp_test.go
+++ b/alt-backend/app/orchestrator/rest/article_limit_clamp_test.go
@@ -1,0 +1,124 @@
+package rest
+
+import (
+	"alt/di"
+	"alt/domain"
+	"alt/orchestrator/usecase/fetch_articles_usecase"
+	"alt/shared/usecase/fetch_articles_by_tag_usecase"
+	"alt/utils/logger"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// The article cursor handlers ask their usecase for limit+1 rows so they can
+// answer has_more without a COUNT. The usecases reject anything above 100, so
+// the handler ceiling must leave room for that extra probe row — clamping the
+// caller's limit to 100 made the documented maximum page size come back as an
+// opaque 500 instead of a page.
+
+// limitRecordingCursorPort records the limit the handler asked for, so the
+// test can prove the probe row stays inside the usecase's ceiling.
+type limitRecordingCursorPort struct {
+	articles  []*domain.Article
+	lastLimit int
+}
+
+func (s *limitRecordingCursorPort) FetchArticlesWithCursor(_ context.Context, _ *time.Time, limit int) ([]*domain.Article, error) {
+	s.lastLimit = limit
+	return s.articles, nil
+}
+
+func (s *limitRecordingCursorPort) FetchArticleIDsWithCursor(_ context.Context, _ *time.Time, limit int) ([]uuid.UUID, error) {
+	s.lastLimit = limit
+	return nil, nil
+}
+
+type limitRecordingByTagPort struct {
+	articles  []*domain.TagTrailArticle
+	lastLimit int
+}
+
+func (s *limitRecordingByTagPort) FetchArticlesByTag(_ context.Context, _ string, _ *time.Time, limit int) ([]*domain.TagTrailArticle, error) {
+	s.lastLimit = limit
+	return s.articles, nil
+}
+
+func (s *limitRecordingByTagPort) FetchArticlesByTagName(_ context.Context, _ string, _ *time.Time, limit int) ([]*domain.TagTrailArticle, error) {
+	s.lastLimit = limit
+	return s.articles, nil
+}
+
+func recordArticleLimitRequest(t *testing.T, handler echo.HandlerFunc, target string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req = req.WithContext(domain.SetUserContext(req.Context(), &domain.UserContext{
+		UserID:    uuid.New(),
+		Email:     "test@example.com",
+		Role:      domain.UserRoleUser,
+		TenantID:  uuid.New(),
+		SessionID: "test-session",
+		LoginAt:   time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}))
+	rec := httptest.NewRecorder()
+
+	if err := handler(echo.New().NewContext(req, rec)); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return rec
+}
+
+func TestHandleFetchArticlesCursor_MaxLimitIsServedNotRejected(t *testing.T) {
+	logger.InitLogger()
+
+	port := &limitRecordingCursorPort{}
+	handler := handleFetchArticlesCursor(&di.ApplicationComponents{
+		FetchArticlesCursorUsecase: fetch_articles_usecase.NewFetchArticlesCursorUsecase(port),
+	})
+
+	rec := recordArticleLimitRequest(t, handler, "/v1/articles/fetch/cursor?limit=100")
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	require.LessOrEqual(t, port.lastLimit, 100,
+		"the has_more probe row pushed the fetch past the usecase ceiling")
+}
+
+func TestHandleFetchArticlesByTag_MaxLimitIsServedNotRejected(t *testing.T) {
+	logger.InitLogger()
+
+	port := &limitRecordingByTagPort{}
+	handler := handleFetchArticlesByTag(&di.ApplicationComponents{
+		FetchArticlesByTagUsecase: fetch_articles_by_tag_usecase.NewFetchArticlesByTagUsecase(port),
+	})
+
+	rec := recordArticleLimitRequest(t, handler, "/v1/articles/by-tag?tag_name=go&limit=100")
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	require.LessOrEqual(t, port.lastLimit, 100,
+		"the has_more probe row pushed the fetch past the usecase ceiling")
+}
+
+// An over-sized limit must be clamped down to the same served ceiling rather
+// than rejected, which is what the handlers already promised by clamping.
+func TestHandleFetchArticlesCursor_OverMaxLimitIsClampedNotRejected(t *testing.T) {
+	logger.InitLogger()
+
+	port := &limitRecordingCursorPort{}
+	handler := handleFetchArticlesCursor(&di.ApplicationComponents{
+		FetchArticlesCursorUsecase: fetch_articles_usecase.NewFetchArticlesCursorUsecase(port),
+	})
+
+	rec := recordArticleLimitRequest(t, handler, "/v1/articles/fetch/cursor?limit=50000")
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	require.LessOrEqual(t, port.lastLimit, 100,
+		"the has_more probe row pushed the fetch past the usecase ceiling")
+}

--- a/alt-backend/app/orchestrator/rest/augur_auth_test.go
+++ b/alt-backend/app/orchestrator/rest/augur_auth_test.go
@@ -1,0 +1,63 @@
+package rest
+
+import (
+	"alt/config"
+	"alt/di"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	echomiddleware "github.com/labstack/echo/v4/middleware"
+	"github.com/stretchr/testify/require"
+)
+
+// Finding [022]: the Augur RAG pair was the only user-facing surface on this
+// router without RequireAuth() — `g.GET("/rag/context", …)` went onto the bare
+// /v1 group and `e.POST("/sse/v1/rag/answer", …)` straight onto the root Echo
+// instance. Anything that can reach :9000 (the compose network, or loopback on
+// the host) could pull user-derived knowledge context and spend LLM budget with
+// no JWT and no tenant scoping.
+//
+// Recover() is installed so that an unauthenticated request slipping past a
+// missing guard hits the handler with a nil usecase and produces a
+// distinguishable 500 (panic recovered) instead of crashing the test binary.
+func TestRegisterAugurRoutes_RequiresAuth(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		target string
+		body   string
+	}{
+		{
+			name:   "retrieve context",
+			method: http.MethodGet,
+			target: "/v1/rag/context?q=ai",
+		},
+		{
+			name:   "answer",
+			method: http.MethodPost,
+			target: "/sse/v1/rag/answer",
+			body:   `{"messages":[{"role":"user","content":"hello"}],"stream":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			e.Use(echomiddleware.Recover())
+			v1 := e.Group("/v1")
+			RegisterAugurRoutes(e, v1, &di.ApplicationComponents{}, &config.Config{})
+
+			req := httptest.NewRequest(tt.method, tt.target, strings.NewReader(tt.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code,
+				"unauthenticated %s %s must be rejected with 401, got %d: %s",
+				tt.method, tt.target, rec.Code, rec.Body.String())
+		})
+	}
+}

--- a/alt-backend/app/orchestrator/rest/augur_handler.go
+++ b/alt-backend/app/orchestrator/rest/augur_handler.go
@@ -1,10 +1,13 @@
 package rest
 
 import (
+	"alt/config"
 	"alt/di"
+	middleware_custom "alt/middleware"
 	"alt/orchestrator/port/rag_integration_port"
 	"alt/orchestrator/usecase/answer_chat_usecase"
 	"alt/orchestrator/usecase/retrieve_context_usecase"
+	"alt/utils/logger"
 	"encoding/json"
 	"net/http"
 
@@ -242,8 +245,23 @@ func splitLines(s string) []string {
 	return lines
 }
 
-func RegisterAugurRoutes(e *echo.Echo, g *echo.Group, container *di.ApplicationComponents) {
+// RegisterAugurRoutes registers the Augur (RAG) surface. Both endpoints return
+// user-derived knowledge context and spend LLM budget, so they require a valid
+// JWT exactly like every other /v1 group in routes.go — before this guard they
+// were the only user-facing routes reachable anonymously from the compose
+// network or 127.0.0.1:9000.
+func RegisterAugurRoutes(e *echo.Echo, g *echo.Group, container *di.ApplicationComponents, cfg *config.Config) {
+	authMiddleware := middleware_custom.NewAuthMiddleware(logger.Logger, cfg)
+
 	handler := NewAugurHandler(container.RetrieveContextUsecase, container.AnswerChatUsecase)
-	g.GET("/rag/context", handler.RetrieveContext)
-	e.POST("/sse/v1/rag/answer", handler.Answer)
+
+	rag := g.Group("/rag", authMiddleware.RequireAuth())
+	rag.GET("/context", handler.RetrieveContext)
+
+	// The streaming answer keeps its root-mounted /sse/v1/... path and takes
+	// RequireAuth as per-route middleware instead: the BodyLimit, Timeout and
+	// Gzip skippers in routes.go all key off `strings.Contains(c.Path(), "/sse/")`,
+	// so relocating it under /v1 would silently re-impose the 2MB body limit,
+	// the read timeout and gzip framing on an SSE response.
+	e.POST("/sse/v1/rag/answer", handler.Answer, authMiddleware.RequireAuth())
 }

--- a/alt-backend/app/orchestrator/rest/routes.go
+++ b/alt-backend/app/orchestrator/rest/routes.go
@@ -133,7 +133,7 @@ func RegisterRoutes(ctx context.Context, e *echo.Echo, container *di.Application
 	// `services.datahub.v1.DataHubService/ListRecapArticles` に移行済。
 	registerScrapingDomainRoutes(v1, container, cfg)
 	registerDashboardRoutes(v1, container, cfg)
-	RegisterAugurRoutes(e, v1, container)
+	RegisterAugurRoutes(e, v1, container, cfg)
 	// /v1/internal/* is deliberately absent here — and no longer exists at all.
 	// It moved to cmd/datahub with the split, and ADR-000954 D6 then folded its
 	// two routes into services.datahub.v1.DataHubService, so there is no handler

--- a/alt-backend/app/orchestrator/usecase/track_home_action_usecase/dedupe_key_test.go
+++ b/alt-backend/app/orchestrator/usecase/track_home_action_usecase/dedupe_key_test.go
@@ -1,0 +1,147 @@
+package track_home_action_usecase
+
+import (
+	"alt/domain"
+	"alt/utils/logger"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dedupingUserEventPort models what sovereign actually does with dedupe_key
+// instead of recording every call: the column gates a partial unique index
+// conditioned on a non-empty key, so an append carrying a key the registry has
+// already seen is an ON CONFLICT DO NOTHING no-op, not a new row. Counting rows
+// here answers the question the user actually has — "did my retry leave a
+// duplicate behind?" — rather than pinning the shape of the key.
+type dedupingUserEventPort struct {
+	rows []domain.KnowledgeUserEvent
+	seen map[string]bool
+}
+
+func (m *dedupingUserEventPort) AppendKnowledgeUserEvent(_ context.Context, event domain.KnowledgeUserEvent) error {
+	if m.seen == nil {
+		m.seen = make(map[string]bool)
+	}
+	if event.DedupeKey != "" && m.seen[event.DedupeKey] {
+		return nil
+	}
+	m.seen[event.DedupeKey] = true
+	m.rows = append(m.rows, event)
+	return nil
+}
+
+// dedupingKnowledgeEventPort is the knowledge_events half of the same model.
+// err is settable between calls so a test can fail one attempt and let the
+// retry through, which is exactly the sequence the fatal append created.
+type dedupingKnowledgeEventPort struct {
+	rows []domain.KnowledgeEvent
+	seen map[string]bool
+	err  error
+}
+
+func (m *dedupingKnowledgeEventPort) AppendKnowledgeEvent(_ context.Context, event domain.KnowledgeEvent) (int64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	if m.seen == nil {
+		m.seen = make(map[string]bool)
+	}
+	if event.DedupeKey != "" && m.seen[event.DedupeKey] {
+		return 0, nil
+	}
+	m.seen[event.DedupeKey] = true
+	m.rows = append(m.rows, event)
+	return int64(len(m.rows)), nil
+}
+
+func TestTrackHomeActionUsecase_RetryAfterFatalAppendDoesNotDuplicate(t *testing.T) {
+	logger.InitLogger()
+
+	userID := uuid.New()
+	tenantID := uuid.New()
+	const itemKey = "article:test-uuid"
+
+	// The knowledge_events append is fatal, so Execute can return an error with
+	// the user event already committed, and the client's only recourse is to
+	// re-issue the same action. That retry has to land on the same dedupe key:
+	// append-first buys idempotency from the dedupe registry, not from the
+	// caller, so a key that moves between attempts stacks a second user event
+	// on top of the first and the guarantee is gone.
+	userPort := &dedupingUserEventPort{}
+	knPort := &dedupingKnowledgeEventPort{err: errors.New("sovereign unavailable")}
+	uc := NewTrackHomeActionUsecase(userPort, knPort, nil, nil, nil, nil, nil)
+
+	require.Error(t, uc.Execute(context.Background(), userID, tenantID, "dismiss", itemKey, ""))
+	require.Len(t, userPort.rows, 1, "the user event lands before the append that fails")
+
+	// A retry is issued some milliseconds later — never inside the millisecond
+	// the first attempt happened to occupy.
+	time.Sleep(5 * time.Millisecond)
+	knPort.err = nil
+
+	require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "dismiss", itemKey, ""))
+
+	assert.Len(t, userPort.rows, 1,
+		"retrying one user action must not leave a second user event behind")
+	assert.Len(t, knPort.rows, 1,
+		"the retry is the first knowledge event for this action, and the only one")
+}
+
+func TestTrackHomeActionUsecase_DedupeKeySurvivesRetryWithClientKey(t *testing.T) {
+	logger.InitLogger()
+
+	userID := uuid.New()
+	tenantID := uuid.New()
+	const itemKey = "article:test-uuid"
+
+	// metadata_json is the only channel a client has for a retry-stable key
+	// without a proto change, so an idempotency_key found there decides the
+	// dedupe key outright.
+	t.Run("same idempotency_key collapses the retry", func(t *testing.T) {
+		userPort := &dedupingUserEventPort{}
+		uc := NewTrackHomeActionUsecase(userPort, &dedupingKnowledgeEventPort{}, nil, nil, nil, nil, nil)
+		const metadata = `{"idempotency_key":"action-42"}`
+
+		require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "open", itemKey, metadata))
+		time.Sleep(5 * time.Millisecond)
+		require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "open", itemKey, metadata))
+
+		assert.Len(t, userPort.rows, 1, "a client that supplies a key gets exact idempotency")
+	})
+
+	t.Run("distinct idempotency_keys keep two deliberate opens apart", func(t *testing.T) {
+		userPort := &dedupingUserEventPort{}
+		uc := NewTrackHomeActionUsecase(userPort, &dedupingKnowledgeEventPort{}, nil, nil, nil, nil, nil)
+
+		require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "open", itemKey, `{"idempotency_key":"a"}`))
+		require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "open", itemKey, `{"idempotency_key":"b"}`))
+
+		assert.Len(t, userPort.rows, 2, "two keys means the client meant two actions")
+	})
+}
+
+func TestTrackHomeActionUsecase_DistinctActionsInOneBucketStayDistinct(t *testing.T) {
+	logger.InitLogger()
+
+	userID := uuid.New()
+	tenantID := uuid.New()
+	const itemKey = "article:test-uuid"
+
+	// Clicking "rust" and then "go" on one item seconds apart is two facts, not
+	// a retry. Quantising the clock coarsely enough to recognise a retry must
+	// not swallow them, so the metadata has to reach the key too.
+	userPort := &dedupingUserEventPort{}
+	uc := NewTrackHomeActionUsecase(userPort, &dedupingKnowledgeEventPort{}, nil, nil, nil, nil, nil)
+
+	require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "tag_click", itemKey, `{"tag":"rust"}`))
+	require.NoError(t, uc.Execute(context.Background(), userID, tenantID, "tag_click", itemKey, `{"tag":"go"}`))
+
+	assert.Len(t, userPort.rows, 2,
+		"two different tags clicked on one item are two events, not one deduped away")
+}

--- a/alt-backend/app/orchestrator/usecase/track_home_action_usecase/usecase.go
+++ b/alt-backend/app/orchestrator/usecase/track_home_action_usecase/usecase.go
@@ -206,10 +206,18 @@ func (u *TrackHomeActionUsecase) Execute(ctx context.Context, userID uuid.UUID, 
 		Payload:       knowledgePayload,
 	}
 
+	// Fatal, and deliberately ahead of every projection write below.
+	// knowledge_events is the only durable record of the action: the read
+	// models it feeds (knowledge_home_items in particular) are TRUNCATEd and
+	// replayed by RebuildProjection. Writing dismissed_at through to the
+	// projection after a failed append would survive only until the next
+	// reproject, at which point the dismissed item returns to the Home rail
+	// while the caller was told the action succeeded. Failing here instead
+	// lets the client retry the whole action.
 	if _, err := u.knowledgeEventPort.AppendKnowledgeEvent(ctx, knowledgeEvent); err != nil {
 		logger.Logger.ErrorContext(ctx, "failed to append knowledge event for action",
-			"error", err, "action_type", actionType)
-		// Non-fatal: user event was already recorded
+			"error", err, "action_type", actionType, "item_key", itemKey)
+		return fmt.Errorf("track home action: append knowledge event: %w", err)
 	}
 
 	if actionType == "dismiss" && u.dismissPort != nil {

--- a/alt-backend/app/orchestrator/usecase/track_home_action_usecase/usecase.go
+++ b/alt-backend/app/orchestrator/usecase/track_home_action_usecase/usecase.go
@@ -11,6 +11,8 @@ import (
 	"alt/shared/port/knowledge_event_port"
 	"alt/utils/logger"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +27,20 @@ import (
 // `articles` row (item_key = "article:<uuid>"). Used to gate the article-URL
 // payload enrichment so non-article home items skip the lookup entirely.
 const articleItemKeyPrefix = "article:"
+
+// metadataIdempotencyKeyField is the metadata_json field through which a client
+// hands us its own retry-stable key. metadata_json is the only channel the
+// TrackHomeAction RPC has for one without a proto change.
+const metadataIdempotencyKeyField = "idempotency_key"
+
+// dedupeBucket is how coarsely the clock is quantised when the client supplies
+// no idempotency key. A retry has to land in the same bucket as the attempt it
+// repeats to be recognised as a retry, so the width has to exceed any realistic
+// retry delay; it also bounds how long two byte-identical repeats of an action
+// collapse into one event. The sibling impression path
+// (track_home_seen_usecase) buckets at 5 minutes, but actions are far rarer and
+// each carries more signal, so this is deliberately tighter.
+const dedupeBucket = time.Minute
 
 // Valid action types.
 var validActionTypes = map[string]string{
@@ -84,6 +100,66 @@ func NewTrackHomeActionUsecase(
 	}
 }
 
+// buildDedupeKey derives the at-least-once key that both appends of one action
+// share. sovereign rejects an empty dedupe_key outright: the value gates a
+// partial unique index conditioned on the key being non-empty, so an empty one
+// would silently disable dedup rather than fail.
+//
+// The key has to survive a retry. The knowledge_events append below is fatal,
+// so Execute can return an error with the user event already committed, and the
+// caller's only recovery is to re-issue the same action — append-first buys
+// idempotency from the dedupe registry, which only collapses the second append
+// when the key is byte-identical. A key carrying now.UnixMilli() cannot do
+// that: the retry lands on a new millisecond, so it stacks a duplicate row.
+// The same resolution failed in the other direction too — two genuinely
+// distinct actions issued inside one millisecond collided and the second was
+// deduped away.
+//
+// A client-supplied idempotency key is stable by construction, so it decides
+// the key whenever one is present. Otherwise the clock is quantised into a
+// coarse bucket and combined with a fingerprint of the action's metadata: a
+// retry inside the bucket collapses, while two different actions on one item
+// (two tags clicked, two searches run) keep distinct keys. The residual hole is
+// a retry that straddles a bucket boundary, which is bounded and far narrower
+// than "every retry duplicates".
+func buildDedupeKey(userID uuid.UUID, actionType string, itemKey string, metadataJSON string, now time.Time) string {
+	prefix := fmt.Sprintf("%s:%s:%s", userID, actionType, itemKey)
+
+	// Still namespaced by the action tuple, so a client that reuses one key by
+	// mistake collapses only its own repeats of that exact action.
+	if clientKey := clientIdempotencyKey(metadataJSON); clientKey != "" {
+		return prefix + ":" + clientKey
+	}
+
+	bucket := now.UTC().Truncate(dedupeBucket).Format(time.RFC3339)
+	return fmt.Sprintf("%s:%s:%s", prefix, bucket, metadataFingerprint(metadataJSON))
+}
+
+// clientIdempotencyKey pulls the caller-supplied retry key out of metadata_json.
+// Metadata that is absent, malformed, or carries no key is not an error here:
+// the field is optional and free-form, and the time bucket still yields a
+// usable key.
+func clientIdempotencyKey(metadataJSON string) string {
+	if metadataJSON == "" {
+		return ""
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+		return ""
+	}
+	key, _ := meta[metadataIdempotencyKeyField].(string)
+	return key
+}
+
+// metadataFingerprint keeps two different actions on one item inside the same
+// bucket apart — clicking tag "rust" then tag "go" is two facts, not a retry.
+// A retry replays the same serialized metadata byte for byte, so hashing the
+// raw string is enough and avoids re-encoding differences of our own making.
+func metadataFingerprint(metadataJSON string) string {
+	sum := sha256.Sum256([]byte(metadataJSON))
+	return hex.EncodeToString(sum[:8])
+}
+
 // Execute records a user action on a knowledge home item.
 func (u *TrackHomeActionUsecase) Execute(ctx context.Context, userID uuid.UUID, tenantID uuid.UUID, actionType string, itemKey string, metadataJSON string) error {
 	eventType, ok := validActionTypes[actionType]
@@ -105,10 +181,7 @@ func (u *TrackHomeActionUsecase) Execute(ctx context.Context, userID uuid.UUID, 
 	now := time.Now()
 
 	// One action is one fact, so both appends below carry the same key.
-	// sovereign rejects an empty dedupe_key outright: it gates a
-	// `WHERE dedupe_key != ''` partial unique index, so an empty value would
-	// silently disable at-least-once dedup rather than fail.
-	dedupeKey := fmt.Sprintf("%s:%s:%s:%d", userID, actionType, itemKey, now.UnixMilli())
+	dedupeKey := buildDedupeKey(userID, actionType, itemKey, metadataJSON, now)
 
 	// Record user event
 	payload, _ := json.Marshal(map[string]string{

--- a/alt-backend/app/orchestrator/usecase/track_home_action_usecase/usecase_test.go
+++ b/alt-backend/app/orchestrator/usecase/track_home_action_usecase/usecase_test.go
@@ -456,6 +456,54 @@ func TestTrackHomeActionUsecase_ArticleURLRetry(t *testing.T) {
 	})
 }
 
+func TestTrackHomeActionUsecase_KnowledgeEventAppendFailureIsFatal(t *testing.T) {
+	logger.InitLogger()
+
+	userID := uuid.New()
+	tenantID := uuid.New()
+	itemKey := "article:test-uuid"
+
+	// knowledge_home_items is a disposable projection: RebuildProjection
+	// TRUNCATEs it and replays knowledge_events. A dismiss whose append failed
+	// therefore has no record to replay, so write-through alone puts the item
+	// back on the Home rail at the next reproject while the user was told the
+	// dismiss stuck. The event log is the only durable answer — if it rejects
+	// the append, the action did not happen.
+	t.Run("dismiss append failure skips write-through and fails the call", func(t *testing.T) {
+		knPort := &mockKnowledgeEventPort{err: errors.New("sovereign unavailable")}
+		dismissPort := &mockDismissPort{}
+		uc := NewTrackHomeActionUsecase(&mockUserEventPort{}, knPort, nil, nil, dismissPort, &mockActiveProjectionVersionPort{}, nil)
+
+		err := uc.Execute(context.Background(), userID, tenantID, "dismiss", itemKey, "")
+
+		require.Error(t, err, "a dismiss that never reached the event log must not report success")
+		assert.Contains(t, err.Error(), "sovereign unavailable")
+		assert.Empty(t, dismissPort.calls,
+			"the read model must not be written when the event it derives from was rejected")
+	})
+
+	t.Run("non dismiss append failure also fails the call", func(t *testing.T) {
+		knPort := &mockKnowledgeEventPort{err: errors.New("sovereign unavailable")}
+		uc := NewTrackHomeActionUsecase(&mockUserEventPort{}, knPort, nil, nil, nil, nil, nil)
+
+		err := uc.Execute(context.Background(), userID, tenantID, "open", itemKey, "")
+
+		require.Error(t, err, "a lost open event silently drops the signal the Home rail is ranked on")
+	})
+
+	t.Run("append failure skips the recall signal", func(t *testing.T) {
+		knPort := &mockKnowledgeEventPort{err: errors.New("sovereign unavailable")}
+		recallPort := &mockRecallSignalPort{}
+		uc := NewTrackHomeActionUsecase(&mockUserEventPort{}, knPort, nil, recallPort, nil, nil, nil)
+
+		err := uc.Execute(context.Background(), userID, tenantID, "open", itemKey, "")
+
+		require.Error(t, err)
+		assert.Empty(t, recallPort.appendedSignals,
+			"a signal derived from an event that was never appended is unreproducible")
+	})
+}
+
 func TestTrackHomeActionUsecase_UserEventCarriesDedupeKey(t *testing.T) {
 	userID := uuid.New()
 	tenantID := uuid.New()

--- a/alt-backend/app/shared/driver/alt_db/config.go
+++ b/alt-backend/app/shared/driver/alt_db/config.go
@@ -2,6 +2,7 @@ package alt_db
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -73,14 +74,21 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
+// getEnvIntOrDefault は key を int として読む。defaultValue に落ちるのは
+// 変数が未設定のときだけで、設定されているのに使えない値（非数値 / int 範囲外）は
+// 起動失敗にする。黙って既定値に落とすと、起動ログは実効値しか出さないので
+// compose の DB_MAX_CONNS=40 が 20 で動いていることが運用から見えない
+// （CLAUDE.md rule 9: fail-fast startup config）。
 func getEnvIntOrDefault(key string, defaultValue int) int {
-	if value := os.Getenv(key); value != "" {
-		if intValue, err := strconv.ParseInt(value, 10, 64); err == nil {
-			// Check bounds for int type (platform-dependent)
-			if intValue <= int64(^int(0)>>1) && intValue >= int64(-^int(0)>>1)-1 {
-				return int(intValue)
-			}
-		}
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
 	}
-	return defaultValue
+	// Atoi は bitSize=0（= int）でパースするので、プラットフォーム依存の
+	// int 範囲外は ErrRange として返ってくる。
+	intValue, err := strconv.Atoi(value)
+	if err != nil {
+		panic(fmt.Errorf("invalid %s=%q: must be an integer in [%d, %d]: %w", key, value, math.MinInt, math.MaxInt, err))
+	}
+	return intValue
 }

--- a/alt-backend/app/shared/driver/alt_db/config_env_int_test.go
+++ b/alt-backend/app/shared/driver/alt_db/config_env_int_test.go
@@ -1,0 +1,78 @@
+package alt_db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compose/core.yaml gives alt-data-hub DB_MAX_CONNS=40 / DB_MIN_CONNS=10.
+// プールはその値で作られなければならない - 既定の 20/5 に落ちても起動ログは
+// 実効値を出すので、黙って捨てられたことが誰にも見えない。
+func TestNewDatabaseConfigFromEnv_PoolSizesComeFromEnv(t *testing.T) {
+	t.Setenv("DB_MAX_CONNS", "40")
+	t.Setenv("DB_MIN_CONNS", "10")
+
+	config := NewDatabaseConfigFromEnv()
+
+	assert.Equal(t, 40, config.MaxConns)
+	assert.Equal(t, 10, config.MinConns)
+}
+
+func TestBuildConnectionString_ConnectTimeoutComesFromEnv(t *testing.T) {
+	t.Setenv("DB_CONNECT_TIMEOUT_SECONDS", "5")
+
+	config := &DatabaseConfig{
+		Host:     "localhost",
+		Port:     "5432",
+		User:     "testuser",
+		Password: "testpass",
+		DBName:   "testdb",
+	}
+
+	assert.Contains(t, config.BuildConnectionString(), "connect_timeout=5")
+}
+
+// 設定されているが使えない値は「既定値で続行」ではなく起動失敗（CLAUDE.md rule 9）。
+func TestNewDatabaseConfigFromEnv_RejectsUnusableValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "non-numeric", key: "DB_MAX_CONNS", value: "forty"},
+		{name: "out of int range", key: "DB_MIN_CONNS", value: "99999999999999999999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.key, tt.value)
+
+			err := recoveredError(t, func() { NewDatabaseConfigFromEnv() })
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.key)
+			assert.Contains(t, err.Error(), tt.value)
+		})
+	}
+}
+
+// recoveredError runs fn and returns the error it panicked with, failing the
+// test when fn returns normally instead.
+func recoveredError(t *testing.T, fn func()) (recovered error) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected startup to fail, but it returned normally")
+		}
+		err, ok := r.(error)
+		if !ok {
+			t.Fatalf("expected panic with error, got %T: %v", r, r)
+		}
+		recovered = err
+	}()
+	fn()
+	return nil
+}

--- a/alt-backend/app/shared/driver/sovereign_client/contract/article_created_datahub_consumer_test.go
+++ b/alt-backend/app/shared/driver/sovereign_client/contract/article_created_datahub_consumer_test.go
@@ -17,13 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"alt/dataplane/connect/datahubapi"
-	"alt/dataplane/port/internal_article_port"
 	"alt/domain"
 	datahubv1 "alt/gen/proto/services/datahub/v1"
 	sovereignv1 "alt/gen/proto/services/sovereign/v1"
 	"alt/gen/proto/services/sovereign/v1/sovereignv1connect"
-	"alt/orchestrator/usecase/fetch_recent_articles_usecase"
 )
 
 // This file pins the *second* ArticleCreated producer: the
@@ -38,31 +35,10 @@ import (
 // message the handler is free to never send. This is the same shape as the
 // datahub_gateway consumer pacts, which drive real gateways.
 
-// articleUpsertWriter answers CreateArticle the way the upsert does for an
-// article alt-db already holds: same id, created=false.
-type articleUpsertWriter struct {
-	articleID string
-	created   bool
-}
-
-func (w articleUpsertWriter) CreateArticle(context.Context, internal_article_port.CreateArticleParams) (string, bool, error) {
-	return w.articleID, w.created, nil
-}
-
-// The two required constructor arguments of datahubapi.NewHandler. Neither
-// procedure is exercised here; they exist because a handler cannot be built
-// without them.
-type unusedSystemUser struct{}
-
-func (unusedSystemUser) GetFirstIdentityID(context.Context) (string, error) {
-	return "", fmt.Errorf("GetSystemUser is not part of this contract")
-}
-
-type unusedRecentArticles struct{}
-
-func (unusedRecentArticles) Execute(context.Context, fetch_recent_articles_usecase.FetchRecentArticlesInput) (*fetch_recent_articles_usecase.FetchRecentArticlesOutput, error) {
-	return nil, fmt.Errorf("ListRecentArticles is not part of this contract")
-}
+// The handler under contract, the article writer standing in for alt-db and
+// the two unused constructor arguments live in create_article_handler_test.go,
+// which carries no build tag: the wiring they encode has to be checked where
+// libpact_ffi is not installed too.
 
 // connectAppender is the handler's knowledge event port, speaking to the Pact
 // mock server over the generated Connect client.
@@ -192,13 +168,8 @@ func TestCreateArticleAppendsArticleCreatedForAnExistingArticle(t *testing.T) {
 		ExecuteTest(t, func(config consumer.MockServerConfig) error {
 			appender.client = newSovereignClient(config)
 
-			h := datahubapi.NewHandler(nil, nil, nil, nil, nil,
-				unusedSystemUser{}, unusedRecentArticles{}, nil,
-				datahubapi.WithPhase2Ports(nil,
-					articleUpsertWriter{articleID: articleID, created: false},
-					nil, nil, nil, nil),
-				datahubapi.WithKnowledgeEventPort(appender),
-			)
+			h := newCreateArticleHandler(appender,
+				articleUpsertWriter{articleID: articleID, created: false})
 
 			_, err := h.CreateArticle(context.Background(), connect.NewRequest(&datahubv1.CreateArticleRequest{
 				Title:  articleTitle,

--- a/alt-backend/app/shared/driver/sovereign_client/contract/create_article_handler_test.go
+++ b/alt-backend/app/shared/driver/sovereign_client/contract/create_article_handler_test.go
@@ -1,0 +1,120 @@
+package contract
+
+// The DataHubService handler the two CreateArticle pacts drive, and a guard
+// that it can actually be driven.
+//
+// This file carries no `contract` build tag on purpose. The pact tests link
+// libpact_ffi, so they only run where that library is installed; the handler
+// they build is ordinary Go and its wiring can break without any of them
+// running. CreateArticle panics on a dependency the composition root dropped
+// (CLAUDE.md rule 8), and a pact whose handler panics on its first call fails
+// as "no interaction received" on the one machine that can run it. The guard
+// below builds the same handler through the same constructor and calls the
+// same procedure, so the ordinary `go test ./...` sweep is where that is
+// found.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"alt/dataplane/connect/datahubapi"
+	"alt/dataplane/port/internal_article_port"
+	"alt/domain"
+	datahubv1 "alt/gen/proto/services/datahub/v1"
+	"alt/orchestrator/usecase/fetch_recent_articles_usecase"
+	"alt/shared/driver/mqhub_connect"
+	"alt/shared/gateway/event_publisher_gateway"
+	"alt/shared/port/knowledge_event_port"
+)
+
+// articleUpsertWriter answers CreateArticle the way the upsert does for an
+// article alt-db already holds: same id, created=false.
+type articleUpsertWriter struct {
+	articleID string
+	created   bool
+}
+
+func (w articleUpsertWriter) CreateArticle(context.Context, internal_article_port.CreateArticleParams) (string, bool, error) {
+	return w.articleID, w.created, nil
+}
+
+// The two required constructor arguments of datahubapi.NewHandler. Neither
+// procedure is exercised here; they exist because a handler cannot be built
+// without them.
+type unusedSystemUser struct{}
+
+func (unusedSystemUser) GetFirstIdentityID(context.Context) (string, error) {
+	return "", fmt.Errorf("GetSystemUser is not part of this contract")
+}
+
+type unusedRecentArticles struct{}
+
+func (unusedRecentArticles) Execute(context.Context, fetch_recent_articles_usecase.FetchRecentArticlesInput) (*fetch_recent_articles_usecase.FetchRecentArticlesOutput, error) {
+	return nil, fmt.Errorf("ListRecentArticles is not part of this contract")
+}
+
+// newCreateArticleHandler builds the data plane handler under contract, with
+// the knowledge event sink the caller wants to observe and the article writer
+// standing in for alt-db.
+//
+// The mq-hub publisher is wired even though no pact here covers a
+// notification: it is a required dependency of CreateArticle, and "this
+// contract is not about mq-hub" is said by handing over a publisher that
+// reports itself off, never by omitting the option — the second one panics
+// (CLAUDE.md rule 8 / ADR-000928). The production gateway over a disabled
+// mqhub_connect.Client is that publisher: NewClient(_, false) builds no HTTP
+// client and opens nothing, so it costs less than a stub and cannot drift
+// from what the composition root wires when notifications are switched off.
+func newCreateArticleHandler(
+	appender knowledge_event_port.AppendKnowledgeEventPort,
+	writer internal_article_port.CreateArticlePort,
+) *datahubapi.Handler {
+	return datahubapi.NewHandler(nil, nil, nil, nil, nil,
+		unusedSystemUser{}, unusedRecentArticles{}, nil,
+		datahubapi.WithPhase2Ports(nil, writer, nil, nil, nil, nil),
+		datahubapi.WithKnowledgeEventPort(appender),
+		datahubapi.WithEventPublisher(event_publisher_gateway.NewEventPublisherGateway(
+			mqhub_connect.NewClient("", false), nil)),
+	)
+}
+
+// recordingAppender accepts every event and keeps the last one.
+type recordingAppender struct {
+	last  domain.KnowledgeEvent
+	calls int
+}
+
+func (a *recordingAppender) AppendKnowledgeEvent(_ context.Context, event domain.KnowledgeEvent) (int64, error) {
+	a.last = event
+	a.calls++
+	return 1, nil
+}
+
+// TestCreateArticleHandlerUnderContractIsFullyWired pins that the handler the
+// CreateArticle pacts build answers the procedure they drive instead of
+// panicking on a dependency nobody handed it.
+func TestCreateArticleHandlerUnderContractIsFullyWired(t *testing.T) {
+	const (
+		tenantID  = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+		articleID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	)
+
+	appender := &recordingAppender{}
+	h := newCreateArticleHandler(appender, articleUpsertWriter{articleID: articleID, created: false})
+
+	resp, err := h.CreateArticle(context.Background(), connect.NewRequest(&datahubv1.CreateArticleRequest{
+		Title:  "Knowledge Home must not show a blank title",
+		Url:    "https://example.com/articles/blank-title",
+		FeedId: "33333333-4444-5555-6666-777777777777",
+		UserId: tenantID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, articleID, resp.Msg.GetArticleId())
+	assert.Equal(t, 1, appender.calls, "the pact's single interaction is this append")
+	assert.Equal(t, domain.EventArticleCreated, appender.last.EventType)
+}

--- a/alt-backend/app/shared/driver/sovereign_client/write_ports.go
+++ b/alt-backend/app/shared/driver/sovereign_client/write_ports.go
@@ -84,18 +84,11 @@ func (c *Client) ClearSupersedeState(ctx context.Context, userID uuid.UUID, item
 	})
 }
 
-// UpsertTodayDigest implements today_digest_port.UpsertTodayDigestPort.
-func (c *Client) UpsertTodayDigest(ctx context.Context, digest domain.TodayDigest) error {
-	payload, err := json.Marshal(digest)
-	if err != nil {
-		return fmt.Errorf("sovereign UpsertTodayDigest marshal: %w", err)
-	}
-	return c.ApplyProjectionMutation(ctx, knowledge_sovereign_port.ProjectionMutation{
-		MutationType: knowledge_sovereign_port.MutationUpsertTodayDigest,
-		EntityID:     fmt.Sprintf("digest:%s", digest.UserID),
-		Payload:      payload,
-	})
-}
+// There is deliberately no UpsertTodayDigest here. knowledge-sovereign's
+// knowledge_home_projector is the sole writer of today_digest_view: its rows are
+// additive deltas folded from the event log, so a direct write from alt-backend
+// would be a state the log cannot reproduce. The driver enforces this by
+// requiring last_event_seq, which only a fold can supply.
 
 // UpsertRecallCandidate implements recall_candidate_port.UpsertRecallCandidatePort.
 func (c *Client) UpsertRecallCandidate(ctx context.Context, candidate domain.RecallCandidate) error {

--- a/alt-butterfly-facade/internal/handler/bff_handler.go
+++ b/alt-butterfly-facade/internal/handler/bff_handler.go
@@ -4,6 +4,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -395,12 +396,27 @@ func (h *BFFHandler) executeRequest(r *http.Request, userID, endpoint string, bo
 	}
 	defer resp.Body.Close()
 
-	// Record success/failure for the endpoint's dependency-class circuit breaker
-	h.recordOutcome(endpoint, resp.StatusCode, resp.Header)
+	// Read the response body before charging the breaker. A body that ends
+	// mid-stream is a failed response whatever its status line said, and
+	// recording the outcome first got that backwards twice over: the breaker
+	// banked a success (so a backend dying halfway through every response
+	// never trips it, and a half-open trial passes on a torn body) and the
+	// truncated bytes went on to be cached, handing every caller a parse
+	// error behind X-Cache: HIT for the rest of the endpoint's TTL.
+	respBody, err := io.ReadAll(resp.Body)
+
+	// Invalidation stays keyed on the status line: a 2xx means the mutation
+	// already landed upstream, so read-your-writes has to hold even when the
+	// response carrying it was cut short.
 	h.invalidateUnreadProjectionOnMutation(userID, endpoint, resp.StatusCode)
 
-	// Read response body
-	respBody, _ := io.ReadAll(resp.Body)
+	if err != nil {
+		h.recordFailure(endpoint)
+		return nil, fmt.Errorf("read backend response body: %w", err)
+	}
+
+	// Record success/failure for the endpoint's dependency-class circuit breaker
+	h.recordOutcome(endpoint, resp.StatusCode, resp.Header)
 
 	// Cache successful responses (epoch-fenced when applicable)
 	if h.shouldCacheResponse(r.Method, endpoint, resp.StatusCode) {

--- a/alt-butterfly-facade/internal/handler/bff_handler_upstream_body_test.go
+++ b/alt-butterfly-facade/internal/handler/bff_handler_upstream_body_test.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBFFHandler_TruncatedBackendBody_IsNotServedAsSuccess drives the shape of
+// failure alt-backend produces when it dies mid-body: the status line and
+// headers arrive, the body does not. What the BFF holds afterwards is a prefix
+// of a JSON document, and serving that prefix under the 200 the status line
+// promised is strictly worse than a 502 — the truncated bytes are charged to
+// the dependency-class breaker as a success and stored in the cache, so every
+// caller for the endpoint's whole TTL gets a parse error out of an
+// X-Cache: HIT instead of an error it can retry.
+func TestBFFHandler_TruncatedBackendBody_IsNotServedAsSuccess(t *testing.T) {
+	const endpoint = "/alt.feeds.v2.FeedService/GetUnreadCount"
+	const fullBody = `{"count":42}`
+
+	var truncate atomic.Bool
+	truncate.Store(true)
+
+	mockBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !truncate.Load() {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(fullBody))
+			return
+		}
+		// Promise more bytes than we deliver and flush the prefix so the
+		// client really does see a 200, then abort the connection:
+		// io.ReadAll on the client side ends in io.ErrUnexpectedEOF.
+		w.Header().Set("Content-Length", "64")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"count":4`))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	}))
+	defer mockBackend.Close()
+
+	secret := []byte("test-secret-key")
+	config := BFFConfig{
+		EnableCache:          true,
+		EnableCircuitBreaker: true,
+		CacheMaxSize:         100,
+		// Well above the single failure this test provokes, so the breaker
+		// stays closed and the recovery request below is really answered by
+		// the backend rather than rejected by an open circuit.
+		CBFailureThreshold: 5,
+		CBSuccessThreshold: 1,
+		CBOpenTimeout:      time.Minute,
+	}
+	handler := createTestBFFHandlerWithBackend(t, mockBackend.URL, secret, config)
+	token := createTestToken(t, secret)
+
+	req := httptest.NewRequest("POST", endpoint, nil)
+	req.Header.Set("X-Alt-Backend-Token", token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code,
+		"a body that ended mid-stream must surface as 502, not as the 200 its status line claimed")
+
+	stats := handler.GetCircuitBreakerClassStats()
+	require.NotNil(t, stats)
+	require.NotNil(t, stats.Projection)
+	assert.Equal(t, int64(1), stats.Projection.TotalFailures,
+		"the truncated response must be charged to the breaker as a failure")
+	assert.Equal(t, int64(0), stats.Projection.TotalSuccesses,
+		"and never as a success — otherwise a dying backend keeps the circuit closed")
+
+	cacheStats := handler.GetCacheStats()
+	require.NotNil(t, cacheStats)
+	assert.Equal(t, 0, cacheStats.Size, "a truncated body must not enter the cache")
+
+	// The backend recovers. The next caller must get the real body from the
+	// backend, not the truncated prefix out of a cache entry.
+	truncate.Store(false)
+
+	req2 := httptest.NewRequest("POST", endpoint, nil)
+	req2.Header.Set("X-Alt-Backend-Token", token)
+	rec2 := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, "MISS", rec2.Header().Get("X-Cache"))
+	assert.Equal(t, fullBody, rec2.Body.String())
+}
+
+// TestBFFHandler_TruncatedBackendBody_DedupPathAlsoFails is the same defect
+// reached through the deduplicator: executeRequest is shared, but the dedup
+// path returns its result to every in-flight caller of the same key, so a
+// truncated body swallowed there is fanned out instead of merely cached.
+func TestBFFHandler_TruncatedBackendBody_DedupPathAlsoFails(t *testing.T) {
+	const endpoint = "/alt.feeds.v2.FeedService/GetUnreadCount"
+
+	mockBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "64")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"count":4`))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	}))
+	defer mockBackend.Close()
+
+	secret := []byte("test-secret-key")
+	config := BFFConfig{
+		EnableCache:          true,
+		EnableDedup:          true,
+		EnableCircuitBreaker: true,
+		CacheMaxSize:         100,
+		CBFailureThreshold:   5,
+		CBSuccessThreshold:   1,
+		CBOpenTimeout:        time.Minute,
+		DedupWindow:          100 * time.Millisecond,
+	}
+	handler := createTestBFFHandlerWithBackend(t, mockBackend.URL, secret, config)
+	token := createTestToken(t, secret)
+
+	req := httptest.NewRequest("POST", endpoint, nil)
+	req.Header.Set("X-Alt-Backend-Token", token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code,
+		"the dedup path must not fan a truncated body out to its waiters as a 200")
+
+	cacheStats := handler.GetCacheStats()
+	require.NotNil(t, cacheStats)
+	assert.Equal(t, 0, cacheStats.Size, "a truncated body must not enter the cache")
+}

--- a/alt-butterfly-facade/internal/handler/rest_proxy_handler.go
+++ b/alt-butterfly-facade/internal/handler/rest_proxy_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -38,6 +39,15 @@ func NewRESTProxyHandler(
 
 // ServeHTTP implements http.Handler.
 func (h *RESTProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Bound the upstream call, like AdminProxyHandler does. The backend client
+	// runs with http.Client.Timeout unset on purpose, so this deadline is the
+	// only thing that frees the handler goroutine when alt-backend accepts the
+	// request and never answers — the server's WriteTimeout only hangs up on
+	// the caller's connection.
+	ctx, cancel := context.WithTimeout(r.Context(), h.requestTimeout)
+	defer cancel()
+	r = r.WithContext(ctx)
+
 	// Extract and validate JWT token
 	token := r.Header.Get(middleware.BackendTokenHeader)
 	_, err := h.authInterceptor.ValidateToken(token)

--- a/alt-butterfly-facade/internal/handler/rest_proxy_handler_timeout_test.go
+++ b/alt-butterfly-facade/internal/handler/rest_proxy_handler_timeout_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"alt-butterfly-facade/internal/client"
+)
+
+// TestRESTProxyHandler_AppliesRequestTimeout pins the deadline on the REST
+// proxy path. The backend client deliberately runs with http.Client.Timeout
+// unset, so if ServeHTTP does not put a deadline on the request context an
+// alt-backend that accepts the connection but never answers keeps this
+// handler goroutine — and its client connection — alive forever.
+// WriteTimeout on the server only hangs up on the caller; it never unblocks
+// the handler.
+func TestRESTProxyHandler_AppliesRequestTimeout(t *testing.T) {
+	release := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Accept the request and never write a response.
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer backend.Close()
+	defer close(release)
+
+	backendClient := client.NewBackendClientWithTransport(
+		backend.URL,
+		100*time.Millisecond,
+		100*time.Millisecond,
+		http.DefaultTransport,
+	)
+	handler := NewRESTProxyHandler(
+		backendClient,
+		[]byte(testRESTSecret),
+		testRESTIssuer,
+		testRESTAudience,
+		nil,
+		100*time.Millisecond,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/feeds", nil)
+	req.Header.Set("X-Alt-Backend-Token", createTestJWT(t))
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.ServeHTTP(rec, req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeHTTP never returned: requestTimeout is stored but not applied, so a silent backend pins the handler goroutine indefinitely")
+	}
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code,
+		"an upstream that blows the request deadline must surface as 502, not as a hung goroutine")
+}

--- a/alt-butterfly-facade/internal/server/aggregate_body_read_test.go
+++ b/alt-butterfly-facade/internal/server/aggregate_body_read_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"alt-butterfly-facade/internal/handler"
+)
+
+// TestServer_Aggregate_TruncatedBackendBodyIsNotBankedAsSuccess pins the other
+// half of the fan-out deadline. A backend that answers with headers promptly
+// and then stalls mid-body has its body read cut off at RequestTimeout, so the
+// read error is the normal way the deadline surfaces once the response line has
+// already arrived. Swallowing it reports the upstream's original 200 with a
+// truncated JSON prefix in Data — the caller cannot tell a short answer from a
+// complete one.
+func TestServer_Aggregate_TruncatedBackendBodyIsNotBankedAsSuccess(t *testing.T) {
+	release := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Answer the status line, then die halfway through the body.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"feedAmount":{"amount":`))
+		w.(http.Flusher).Flush()
+
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer backend.Close()
+	defer close(release)
+
+	secret := []byte("test-secret")
+	cfg := Config{
+		BackendURL:       backend.URL,
+		Secret:           secret,
+		Issuer:           "auth-hub",
+		Audience:         "alt-backend",
+		RequestTimeout:   150 * time.Millisecond,
+		StreamingTimeout: 5 * time.Minute,
+	}
+	srv := NewServerWithTransport(cfg, nil, http.DefaultTransport)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/aggregate",
+		strings.NewReader(`{"queries":["feed_stats"]}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Alt-Backend-Token", createValidToken(t, secret))
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.ServeHTTP(rec, req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("/v1/aggregate never returned")
+	}
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp handler.AggregationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp),
+		"a truncated backend body must not leave the aggregate response unencodable: %q", rec.Body.String())
+	require.Len(t, resp.Results, 1)
+
+	result := resp.Results["feed_stats"]
+	require.NotNil(t, result)
+	assert.Equal(t, http.StatusBadGateway, result.StatusCode,
+		"a body cut off by the request deadline is a failed fetch, not the upstream's 200")
+	assert.Contains(t, result.Error, "context deadline exceeded")
+	assert.Empty(t, result.Data, "the truncated prefix must not be handed to the caller as data")
+}

--- a/alt-butterfly-facade/internal/server/aggregate_timeout_test.go
+++ b/alt-butterfly-facade/internal/server/aggregate_timeout_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"alt-butterfly-facade/internal/handler"
+)
+
+// TestServer_Aggregate_FanOutHonoursRequestTimeout pins the deadline on the
+// /v1/aggregate fan-out. AggregationHandler blocks on a WaitGroup until every
+// query goroutine finishes, and the backend client runs with
+// http.Client.Timeout unset, so a fetcher built on a deadline-less context
+// leaks N goroutines per request whenever alt-backend stops answering.
+func TestServer_Aggregate_FanOutHonoursRequestTimeout(t *testing.T) {
+	release := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Accept the request and never write a response.
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer backend.Close()
+	defer close(release)
+
+	secret := []byte("test-secret")
+	cfg := Config{
+		BackendURL:       backend.URL,
+		Secret:           secret,
+		Issuer:           "auth-hub",
+		Audience:         "alt-backend",
+		RequestTimeout:   150 * time.Millisecond,
+		StreamingTimeout: 5 * time.Minute,
+	}
+	srv := NewServerWithTransport(cfg, nil, http.DefaultTransport)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/aggregate",
+		strings.NewReader(`{"queries":["feed_stats","unread_count"]}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Alt-Backend-Token", createValidToken(t, secret))
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.ServeHTTP(rec, req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("/v1/aggregate never returned: the fan-out fetcher builds its request on a deadline-less context, so a silent backend strands every query goroutine")
+	}
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp handler.AggregationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Results, 2)
+
+	for query, result := range resp.Results {
+		assert.Equal(t, http.StatusBadGateway, result.StatusCode, "query %q", query)
+		assert.Contains(t, result.Error, "context deadline exceeded",
+			"query %q must fail on the request deadline, not on something else", query)
+	}
+}

--- a/alt-butterfly-facade/internal/server/server.go
+++ b/alt-butterfly-facade/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -110,7 +111,7 @@ func NewServerWithTransports(
 
 	// Create aggregation handler
 	aggregationHandler := handler.NewAggregationHandler(
-		createQueryFetcher(backendClient),
+		createQueryFetcher(backendClient, cfg.RequestTimeout),
 		cfg.Secret,
 		cfg.Issuer,
 		cfg.Audience,
@@ -404,10 +405,22 @@ type TelemetryStatsSlice struct {
 }
 
 // createQueryFetcher creates a query fetcher function for the aggregation handler.
-func createQueryFetcher(backendClient *client.BackendClient) handler.QueryFetcher {
+//
+// requestTimeout bounds each fan-out call. AggregationHandler blocks on a
+// WaitGroup until every query goroutine returns, and the backend client runs
+// with http.Client.Timeout unset, so a request built on a deadline-less
+// context strands N goroutines per aggregation whenever alt-backend stops
+// answering. QueryFetcher takes no context, so the inbound request's
+// cancellation cannot reach here yet — see the note on the deadline below.
+func createQueryFetcher(backendClient *client.BackendClient, requestTimeout time.Duration) handler.QueryFetcher {
 	return func(path string, token string, body []byte) (*handler.AggregatedResult, error) {
+		// Deadline only, not inbound cancellation: widening QueryFetcher to
+		// carry the caller's context is the remaining half of this fix.
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+
 		// Create a mock request to forward
-		req, err := http.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, path, bytes.NewReader(body))
 		if err != nil {
 			return &handler.AggregatedResult{
 				Error:      err.Error(),
@@ -426,7 +439,19 @@ func createQueryFetcher(backendClient *client.BackendClient) handler.QueryFetche
 		}
 		defer resp.Body.Close()
 
-		respBody, _ := io.ReadAll(resp.Body)
+		// A body that ends mid-stream is a failed fetch whatever its status
+		// line said, and the deadline above is now the ordinary way that
+		// happens: a backend that answers headers promptly and then stalls has
+		// its read cut off here, not at ForwardRequest. Swallowing the error
+		// would report the upstream's 200 with a truncated JSON prefix in Data
+		// — the same defect already fixed in BFFHandler.forwardToBackend.
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return &handler.AggregatedResult{
+				Error:      err.Error(),
+				StatusCode: http.StatusBadGateway,
+			}, nil
+		}
 
 		return &handler.AggregatedResult{
 			Data:       respBody,

--- a/alt-frontend-sv/src/lib/api/client/core.test.ts
+++ b/alt-frontend-sv/src/lib/api/client/core.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$app/environment", () => ({ browser: true }));
+vi.mock("$app/paths", () => ({ base: "" }));
+
+function jsonResponse(body: unknown, status: number, statusText: string) {
+	return new Response(JSON.stringify(body), {
+		status,
+		statusText,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/**
+ * Stand-in for this BFF's /api/auth/csrf plus one guarded write route.
+ * auth-hub mints a new HMAC token on every call and the BFF mirrors it into
+ * the browser-wide `csrf_token` cookie (src/lib/server/auth.ts), so only the
+ * most recently issued token ever validates — that is what makes a per-tab
+ * token cache reject every write once a second tab has loaded.
+ */
+function createFakeBff() {
+	let issued = 0;
+	let cookieToken: string | null = null;
+	let rotateBeforeNextWrite = false;
+	const issuedTokens: string[] = [];
+	const writeTokens: (string | null)[] = [];
+
+	/** Models any tab hitting GET /api/auth/csrf: new token, cookie overwritten. */
+	function issueToken(): string {
+		issued += 1;
+		cookieToken = `csrf-token-${issued}`;
+		issuedTokens.push(cookieToken);
+		return cookieToken;
+	}
+
+	const fetchImpl = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : String(input);
+
+			if (url.endsWith("/api/auth/csrf")) {
+				return jsonResponse({ csrf_token: issueToken() }, 200, "OK");
+			}
+
+			const method = (init?.method ?? "GET").toUpperCase();
+			if (method === "GET") {
+				return jsonResponse({ ok: true }, 200, "OK");
+			}
+
+			if (rotateBeforeNextWrite) {
+				rotateBeforeNextWrite = false;
+				issueToken();
+			}
+
+			const headers = (init?.headers ?? {}) as Record<string, string>;
+			const provided = headers["X-CSRF-Token"] ?? null;
+			writeTokens.push(provided);
+
+			if (!provided || provided !== cookieToken) {
+				return jsonResponse({ error: "invalid csrf token" }, 403, "Forbidden");
+			}
+			return jsonResponse({ ok: true }, 200, "OK");
+		},
+	);
+
+	return {
+		fetchImpl,
+		issueToken,
+		issuedTokens,
+		writeTokens,
+		currentCookieToken: () => cookieToken,
+		rotateOnNextWrite: () => {
+			rotateBeforeNextWrite = true;
+		},
+	};
+}
+
+describe("client CSRF token handling", () => {
+	let bff: ReturnType<typeof createFakeBff>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		bff = createFakeBff();
+		vi.stubGlobal("fetch", bff.fetchImpl);
+	});
+
+	it("keeps writes working after another tab has re-issued the shared token", async () => {
+		const { callClientAPI } = await import("./core");
+
+		await expect(
+			callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+		).resolves.toEqual({ ok: true });
+
+		// A second tab opens and fetches its own token; the cookie now holds it.
+		bff.issueToken();
+
+		await expect(
+			callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+		).resolves.toEqual({ ok: true });
+	});
+
+	it("hands out-of-band callers a token that matches the current cookie", async () => {
+		const { getClientCSRFToken } = await import("./core");
+
+		await getClientCSRFToken();
+		bff.issueToken();
+
+		await expect(getClientCSRFToken()).resolves.toBe(bff.currentCookieToken());
+	});
+
+	it("retries once when the token is rotated between issuance and the write", async () => {
+		const { callClientAPI } = await import("./core");
+
+		bff.rotateOnNextWrite();
+
+		await expect(
+			callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+		).resolves.toEqual({ ok: true });
+		expect(bff.writeTokens).toHaveLength(2);
+	});
+
+	it("shares one issued token across concurrent writes", async () => {
+		const { callClientAPI } = await import("./core");
+
+		await expect(
+			Promise.all([
+				callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+				callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+				callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+			]),
+		).resolves.toEqual([{ ok: true }, { ok: true }, { ok: true }]);
+		expect(bff.issuedTokens).toHaveLength(1);
+	});
+
+	it("does not fetch a token for read-only requests", async () => {
+		const { callClientAPI } = await import("./core");
+
+		await expect(callClientAPI("/v1/stats")).resolves.toEqual({ ok: true });
+		expect(bff.issuedTokens).toHaveLength(0);
+	});
+});

--- a/alt-frontend-sv/src/lib/api/client/core.ts
+++ b/alt-frontend-sv/src/lib/api/client/core.ts
@@ -1,15 +1,18 @@
-import {
-	assertOkResponse,
-	parseJsonBody,
-} from "$lib/api/handle-api-response";
-import { parseCsrfToken } from "$lib/schema/csrf";
 import { browser } from "$app/environment";
 import { base } from "$app/paths";
-
-let cachedCSRFToken: string | null = null;
-let csrfTokenExpiry = 0;
+import { assertOkResponse, parseJsonBody } from "$lib/api/handle-api-response";
+import { parseCsrfToken } from "$lib/schema/csrf";
 
 const FETCH_TIMEOUT_MS = 15_000;
+
+// auth-hub mints a new token on every /csrf call and the BFF mirrors it into
+// the browser-wide `csrf_token` cookie (src/lib/server/auth.ts), so only the
+// most recently issued token ever validates. Holding a token per tab would
+// therefore 403 every write from the older tab the moment a second tab loads,
+// which is why nothing is cached across requests here. Callers that overlap
+// share one issuance instead, so they cannot rotate the cookie out from under
+// each other.
+let inFlightCSRFToken: Promise<string | null> | null = null;
 
 // Exposed for callers that issue their own `fetch` (outside callClientAPI)
 // to state-changing endpoints, e.g. the admin/sovereign action hooks.
@@ -17,20 +20,23 @@ export async function getClientCSRFToken(): Promise<string | null> {
 	return fetchCSRFToken();
 }
 
-async function fetchCSRFToken(): Promise<string | null> {
-	if (cachedCSRFToken && Date.now() < csrfTokenExpiry) {
-		return cachedCSRFToken;
+function fetchCSRFToken(): Promise<string | null> {
+	if (!inFlightCSRFToken) {
+		inFlightCSRFToken = issueCSRFToken().finally(() => {
+			inFlightCSRFToken = null;
+		});
 	}
+	return inFlightCSRFToken;
+}
 
+async function issueCSRFToken(): Promise<string | null> {
 	try {
 		const response = await fetch(`${base}/api/auth/csrf`, {
 			credentials: "include",
 		});
 		if (!response.ok) return null;
 		const data: unknown = await response.json();
-		cachedCSRFToken = parseCsrfToken(data);
-		csrfTokenExpiry = Date.now() + 5 * 60 * 1000;
-		return cachedCSRFToken;
+		return parseCsrfToken(data);
 	} catch {
 		return null;
 	}
@@ -56,20 +62,27 @@ export async function callClientAPI<T>(
 		...((fetchOptions.headers as Record<string, string>) || {}),
 	};
 
-	if (needsCSRF) {
-		const csrfToken = await fetchCSRFToken();
-		if (csrfToken) {
-			headers["X-CSRF-Token"] = csrfToken;
-		}
-	}
-
-	try {
-		const response = await fetch(url, {
+	const sendRequest = (csrfToken: string | null): Promise<Response> =>
+		fetch(url, {
 			...fetchOptions,
-			headers,
+			headers: csrfToken ? { ...headers, "X-CSRF-Token": csrfToken } : headers,
 			credentials: "include",
 			signal: fetchOptions.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
+
+	try {
+		const csrfToken = needsCSRF ? await fetchCSRFToken() : null;
+		let response = await sendRequest(csrfToken);
+
+		// Another tab can re-issue the shared token between the fetch above and
+		// this request. The guard rejects with 403 before running any side
+		// effect, so replaying once with a freshly issued token is safe.
+		if (response.status === 403 && csrfToken) {
+			const retryToken = await fetchCSRFToken();
+			if (retryToken) {
+				response = await sendRequest(retryToken);
+			}
+		}
 
 		await assertOkResponse(response, { allowAccepted: true, url });
 		return parseJsonBody<T>(response, { url }, guard);

--- a/alt-frontend-sv/src/lib/api/client/opml.test.ts
+++ b/alt-frontend-sv/src/lib/api/client/opml.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$app/environment", () => ({ browser: true }));
+vi.mock("$app/paths", () => ({ base: "" }));
+
+const IMPORT_RESULT = {
+	total: 2,
+	imported: 2,
+	skipped: 0,
+	failed: 0,
+};
+
+function jsonResponse(body: unknown, status: number, statusText: string) {
+	return new Response(JSON.stringify(body), {
+		status,
+		statusText,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function opmlFile() {
+	return new File(['<opml version="2.0"></opml>'], "feeds.opml", {
+		type: "text/x-opml",
+	});
+}
+
+/**
+ * Stand-in for this BFF's /api/auth/csrf plus the guarded write routes the
+ * client hits. auth-hub mints a new HMAC token on every call and the BFF
+ * mirrors it into the browser-wide `csrf_token` cookie
+ * (src/lib/server/auth.ts), so only the most recently issued token ever
+ * validates — a module-private token cache therefore 403s as soon as any
+ * other client write has re-issued the shared token.
+ */
+function createFakeBff() {
+	let issued = 0;
+	let cookieToken: string | null = null;
+	let rotateBeforeNextWrite = false;
+	const issuedTokens: string[] = [];
+
+	function issueToken(): string {
+		issued += 1;
+		cookieToken = `csrf-token-${issued}`;
+		issuedTokens.push(cookieToken);
+		return cookieToken;
+	}
+
+	/**
+	 * Models another client write landing while a write is already in flight.
+	 * The importer's window is the whole multipart upload — the longest write
+	 * in the app — so this is the ordinary case, not a narrow race.
+	 */
+	function rotateDuringNextWrite() {
+		rotateBeforeNextWrite = true;
+	}
+
+	const fetchImpl = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : String(input);
+
+			if (url.endsWith("/api/auth/csrf")) {
+				return jsonResponse({ csrf_token: issueToken() }, 200, "OK");
+			}
+
+			const method = (init?.method ?? "GET").toUpperCase();
+			if (method === "GET") {
+				return jsonResponse({ ok: true }, 200, "OK");
+			}
+
+			if (rotateBeforeNextWrite) {
+				rotateBeforeNextWrite = false;
+				issueToken();
+			}
+
+			const headers = (init?.headers ?? {}) as Record<string, string>;
+			const provided = headers["X-CSRF-Token"] ?? null;
+			if (!provided || provided !== cookieToken) {
+				return jsonResponse({ error: "invalid csrf token" }, 403, "Forbidden");
+			}
+
+			if (url.endsWith("/api/v1/rss-feed-link/import/opml")) {
+				return jsonResponse(IMPORT_RESULT, 200, "OK");
+			}
+			return jsonResponse({ ok: true }, 200, "OK");
+		},
+	);
+
+	return { fetchImpl, issuedTokens, rotateDuringNextWrite };
+}
+
+describe("importOPMLClient CSRF handling", () => {
+	let bff: ReturnType<typeof createFakeBff>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		bff = createFakeBff();
+		vi.stubGlobal("fetch", bff.fetchImpl);
+	});
+
+	it("still imports after an unrelated write has re-issued the shared token", async () => {
+		const { importOPMLClient } = await import("./opml");
+		const { callClientAPI } = await import("./core");
+
+		await expect(importOPMLClient(opmlFile())).resolves.toEqual(IMPORT_RESULT);
+
+		// Any other state-changing action (mark-as-read here) rotates the
+		// browser-wide cookie out from under whatever the importer is holding.
+		await expect(
+			callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+		).resolves.toEqual({ ok: true });
+
+		await expect(importOPMLClient(opmlFile())).resolves.toEqual(IMPORT_RESULT);
+	});
+
+	it("replays the import once when a write rotates the token mid-upload", async () => {
+		const { importOPMLClient } = await import("./opml");
+
+		bff.rotateDuringNextWrite();
+
+		await expect(importOPMLClient(opmlFile())).resolves.toEqual(IMPORT_RESULT);
+	});
+
+	it("shares one issued token with a concurrent write", async () => {
+		const { importOPMLClient } = await import("./opml");
+		const { callClientAPI } = await import("./core");
+
+		await expect(
+			Promise.all([
+				importOPMLClient(opmlFile()),
+				callClientAPI("/v1/feeds/read", { method: "POST", body: "{}" }),
+			]),
+		).resolves.toEqual([IMPORT_RESULT, { ok: true }]);
+		expect(bff.issuedTokens).toHaveLength(1);
+	});
+});

--- a/alt-frontend-sv/src/lib/api/client/opml.ts
+++ b/alt-frontend-sv/src/lib/api/client/opml.ts
@@ -1,27 +1,7 @@
 import { browser } from "$app/environment";
 import { base } from "$app/paths";
+import { getClientCSRFToken } from "$lib/api/client/core";
 import type { OPMLImportResult } from "$lib/schema/opml";
-
-let cachedCSRFToken: string | null = null;
-let csrfTokenExpiry = 0;
-
-async function getCSRFToken(): Promise<string | null> {
-	if (cachedCSRFToken && Date.now() < csrfTokenExpiry) {
-		return cachedCSRFToken;
-	}
-	try {
-		const response = await fetch(`${base}/api/auth/csrf`, {
-			credentials: "include",
-		});
-		if (!response.ok) return null;
-		const data = await response.json();
-		cachedCSRFToken = data.csrf_token;
-		csrfTokenExpiry = Date.now() + 5 * 60 * 1000;
-		return cachedCSRFToken;
-	} catch {
-		return null;
-	}
-}
 
 /**
  * Export all feeds as OPML 2.0 XML.
@@ -52,23 +32,35 @@ export async function importOPMLClient(file: File): Promise<OPMLImportResult> {
 		throw new Error("This function can only be called from the client");
 	}
 
-	const csrfToken = await getCSRFToken();
+	// Issuance lives in core.ts alone: every /api/auth/csrf call re-mints the
+	// token and overwrites the browser-wide cookie, so a second cache here
+	// would hand out a token that any other client write has already invalidated.
+	const csrfToken = await getClientCSRFToken();
 
 	const formData = new FormData();
 	formData.append("file", file);
 
-	const headers: Record<string, string> = {};
-	if (csrfToken) {
-		headers["X-CSRF-Token"] = csrfToken;
-	}
-
 	const url = `${base}/api/v1/rss-feed-link/import/opml`;
-	const response = await fetch(url, {
-		method: "POST",
-		body: formData,
-		headers,
-		credentials: "include",
-	});
+	const sendRequest = (token: string | null): Promise<Response> =>
+		fetch(url, {
+			method: "POST",
+			body: formData,
+			headers: token ? { "X-CSRF-Token": token } : {},
+			credentials: "include",
+		});
+
+	let response = await sendRequest(csrfToken);
+
+	// Same replay callClientAPI does, and the importer needs it more: the
+	// upload is the longest-running write in the app, so any concurrent write
+	// has the whole transfer in which to rotate the shared cookie. The guard
+	// rejects with 403 before importing anything, so retrying once is safe.
+	if (response.status === 403 && csrfToken) {
+		const retryToken = await getClientCSRFToken();
+		if (retryToken) {
+			response = await sendRequest(retryToken);
+		}
+	}
 
 	if (!response.ok) {
 		const errorText = await response.text().catch(() => "");

--- a/alt-frontend-sv/src/lib/hooks/test-helpers/stream-updates-tab.svelte.ts
+++ b/alt-frontend-sv/src/lib/hooks/test-helpers/stream-updates-tab.svelte.ts
@@ -1,0 +1,28 @@
+import { flushSync } from "svelte";
+import { useStreamUpdates } from "../useStreamUpdates.svelte.ts";
+
+type StreamResult = ReturnType<typeof useStreamUpdates>;
+
+/**
+ * Mounts useStreamUpdates the way a Home page tab does — inside an
+ * $effect.root so the hook's own $effect runs. Lives in a .svelte.ts because
+ * runes are only compiled in those files; plain .test.ts cannot call them.
+ */
+export function mountStreamTab(lensId: string): {
+	stream: StreamResult;
+	cleanup: () => void;
+} {
+	let stream!: StreamResult;
+	const cleanup = $effect.root(() => {
+		stream = useStreamUpdates({
+			get enabled() {
+				return true;
+			},
+			get lensId() {
+				return lensId;
+			},
+		});
+		flushSync();
+	});
+	return { stream, cleanup };
+}

--- a/alt-frontend-sv/src/lib/hooks/useStreamUpdates.leader-election.test.ts
+++ b/alt-frontend-sv/src/lib/hooks/useStreamUpdates.leader-election.test.ts
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+/**
+ * Multi-tab leader election for the Knowledge Home stream.
+ *
+ * jsdom rather than the default node environment: the hook's $effect is only
+ * compiled (and BroadcastChannel only reachable) when the module is built for
+ * the browser, and the whole election lives inside that $effect.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock modules
+vi.mock("$app/paths", () => ({ base: "" }));
+vi.mock("@connectrpc/connect-web", () => ({
+	createConnectTransport: vi.fn(() => ({})),
+}));
+vi.mock("$lib/connect/transport-client", () => ({
+	createClientTransport: vi.fn(() => ({})),
+}));
+vi.mock("@connectrpc/connect", () => ({
+	createClient: vi.fn(),
+}));
+vi.mock("$lib/gen/alt/knowledge_home/v1/knowledge_home_pb", () => ({
+	KnowledgeHomeService: {},
+}));
+
+import { createClient } from "@connectrpc/connect";
+import { mountStreamTab } from "./test-helpers/stream-updates-tab.svelte.ts";
+
+// Mirrors the hook's own constants.
+const LEADER_CLAIM_TIMEOUT = 500;
+const LEADER_HEARTBEAT_TIMEOUT = 10000;
+
+/** A stream that stays open forever, like a real long-lived SSE connection. */
+function createHangingStream() {
+	return {
+		[Symbol.asyncIterator]() {
+			return {
+				next(): Promise<IteratorResult<Record<string, unknown>>> {
+					return new Promise(() => {});
+				},
+			};
+		},
+	};
+}
+
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Same channel name the hook derives from the lens — this is the wire. */
+function openPeerChannel(lensId: string): BroadcastChannel {
+	return new BroadcastChannel(`kh-stream:${lensId}`);
+}
+
+/**
+ * Resolves with the tabId of the next claim seen on the channel, so a test can
+ * craft peer ids that sort above or below the tab under test.
+ */
+function nextClaimTabId(peer: BroadcastChannel): Promise<string> {
+	return new Promise((resolve) => {
+		peer.onmessage = (ev: MessageEvent<{ type: string; tabId: string }>) => {
+			if (ev.data?.type === "claim") resolve(ev.data.tabId);
+		};
+	});
+}
+
+describe("useStreamUpdates leader election", () => {
+	let mockStreamFn: ReturnType<typeof vi.fn>;
+	let signals: AbortSignal[];
+
+	beforeEach(() => {
+		signals = [];
+		mockStreamFn = vi.fn((_req: unknown, opts: { signal: AbortSignal }) => {
+			signals.push(opts.signal);
+			return createHangingStream();
+		});
+		vi.mocked(createClient).mockReturnValue({
+			streamKnowledgeHomeUpdates: mockStreamFn,
+		} as never);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keeps one tab streaming when two tabs claim in the same timer batch", async () => {
+		const lensId = "lens-symmetric-claim";
+		vi.useFakeTimers();
+		let tabA: ReturnType<typeof mountStreamTab>;
+		let tabB: ReturnType<typeof mountStreamTab>;
+		try {
+			tabA = mountStreamTab(lensId);
+			tabB = mountStreamTab(lensId);
+			// Both claim timers were armed in the same tick. Draining them in one
+			// batch is the race: neither tab can observe the other's announce
+			// before deciding it is leader itself.
+			vi.advanceTimersByTime(LEADER_CLAIM_TIMEOUT + 100);
+		} finally {
+			vi.useRealTimers();
+		}
+		// Now let both announces cross the channel.
+		await wait(50);
+
+		const leaders = [tabA.stream.isLeader, tabB.stream.isLeader].filter(
+			Boolean,
+		);
+		expect(leaders).toHaveLength(1);
+		// Home keeps getting live updates only while some tab holds an open
+		// stream — a mutual demotion aborts every one of them.
+		expect(signals.some((signal) => !signal.aborted)).toBe(true);
+
+		tabA.cleanup();
+		tabB.cleanup();
+	});
+
+	it("keeps leadership when the announcing tab sorts above it", async () => {
+		const lensId = "lens-outranks-peer";
+		const peer = openPeerChannel(lensId);
+		const claimed = nextClaimTabId(peer);
+		const tab = mountStreamTab(lensId);
+		const tabId = await claimed;
+
+		await wait(LEADER_CLAIM_TIMEOUT + 200);
+		expect(tab.stream.isLeader).toBe(true);
+
+		// `${tabId}0` sorts after tabId, so the peer is the one that must yield.
+		peer.postMessage({ type: "leader_announce", tabId: `${tabId}0` });
+		await wait(50);
+
+		expect(tab.stream.isLeader).toBe(true);
+		expect(signals.some((signal) => !signal.aborted)).toBe(true);
+
+		peer.close();
+		tab.cleanup();
+	});
+
+	it("yields leadership when the announcing tab sorts below it", async () => {
+		const lensId = "lens-outranked-by-peer";
+		const peer = openPeerChannel(lensId);
+		const claimed = nextClaimTabId(peer);
+		const tab = mountStreamTab(lensId);
+		const tabId = await claimed;
+
+		await wait(LEADER_CLAIM_TIMEOUT + 200);
+		expect(tab.stream.isLeader).toBe(true);
+
+		// A prefix of tabId sorts before it.
+		peer.postMessage({
+			type: "leader_announce",
+			tabId: tabId.slice(0, -1),
+		});
+		await wait(50);
+
+		expect(tab.stream.isLeader).toBe(false);
+
+		peer.close();
+		tab.cleanup();
+	});
+
+	it("defers to an established leader's ack whatever the tab ids sort like", async () => {
+		const lensId = "lens-ack-wins";
+		const peer = openPeerChannel(lensId);
+		const claimed = nextClaimTabId(peer);
+		const tab = mountStreamTab(lensId);
+		const tabId = await claimed;
+
+		// An ack answers our claim, so the acking tab is already streaming even
+		// though its id sorts after ours. The tie-break must not apply here.
+		peer.postMessage({ type: "leader_ack", tabId: `${tabId}0` });
+		await wait(LEADER_CLAIM_TIMEOUT + 200);
+
+		expect(tab.stream.isLeader).toBe(false);
+		expect(mockStreamFn).not.toHaveBeenCalled();
+
+		peer.close();
+		tab.cleanup();
+	});
+
+	it("staggers the re-claim deadline of tabs demoted in the same batch", async () => {
+		const lensId = "lens-jitter";
+		const peer = openPeerChannel(lensId);
+		const tabA = mountStreamTab(lensId);
+		const tabB = mountStreamTab(lensId);
+		await wait(LEADER_CLAIM_TIMEOUT + 300);
+
+		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+		vi.spyOn(Math, "random")
+			.mockReturnValueOnce(0.25)
+			.mockReturnValueOnce(0.75);
+
+		// "0" sorts before any uuid, so both tabs demote in the same batch and
+		// both arm a re-claim deadline.
+		peer.postMessage({ type: "leader_announce", tabId: "0" });
+		await wait(50);
+
+		const deadlines = setTimeoutSpy.mock.calls
+			.map(([, delay]) => delay)
+			.filter(
+				(delay): delay is number =>
+					typeof delay === "number" && delay >= LEADER_HEARTBEAT_TIMEOUT,
+			);
+		expect(deadlines).toHaveLength(2);
+		expect(new Set(deadlines).size).toBe(2);
+
+		peer.close();
+		tabA.cleanup();
+		tabB.cleanup();
+	});
+});

--- a/alt-frontend-sv/src/lib/hooks/useStreamUpdates.svelte.ts
+++ b/alt-frontend-sv/src/lib/hooks/useStreamUpdates.svelte.ts
@@ -11,9 +11,9 @@
  * - Exponential backoff reconnection
  */
 import { createClient } from "@connectrpc/connect";
+import type { StreamHomeUpdate } from "$lib/connect/knowledge_home";
 import { createClientTransport } from "$lib/connect/transport-client";
 import { KnowledgeHomeService } from "$lib/gen/alt/knowledge_home/v1/knowledge_home_pb";
-import type { StreamHomeUpdate } from "$lib/connect/knowledge_home";
 
 const MAX_RETRIES = 10;
 const BASE_RETRY_DELAY = 1000;
@@ -22,6 +22,7 @@ const COALESCE_DELAY = 3000;
 const LEADER_CLAIM_TIMEOUT = 500;
 const LEADER_HEARTBEAT_INTERVAL = 5000;
 const LEADER_HEARTBEAT_TIMEOUT = 10000;
+const LEADER_TIMEOUT_JITTER = 2000;
 
 interface StreamUpdateOptions {
 	get enabled(): boolean;
@@ -277,8 +278,16 @@ export function useStreamUpdates(opts: StreamUpdateOptions) {
 
 				case "leader_ack":
 				case "leader_announce":
-					// Another tab is already leader — become follower
-					becomeFollower();
+					// Both messages assert "I am the leader". While we are not leading
+					// there is nothing to arbitrate — defer, as before. While we are,
+					// this is a split brain: two claim timers fired in the same batch,
+					// so each tab announced and acked the other's in-flight claim.
+					// Demoting on both sides would leave nobody holding the stream and
+					// the synchronised re-claim would repeat the tie, so break it on
+					// tabId — lowest wins.
+					if (!isLeader || msg.tabId < tabId) {
+						becomeFollower();
+					}
 					break;
 
 				case "leader_heartbeat":
@@ -370,11 +379,15 @@ export function useStreamUpdates(opts: StreamUpdateOptions) {
 		if (leaderTimeoutTimer) {
 			clearTimeout(leaderTimeoutTimer);
 		}
+		// Jitter the deadline: tabs demoted in the same batch would otherwise
+		// re-claim in the same batch too, replaying the same tie every round.
+		const delay =
+			LEADER_HEARTBEAT_TIMEOUT + Math.random() * LEADER_TIMEOUT_JITTER;
 		leaderTimeoutTimer = setTimeout(() => {
 			// Leader heartbeat timed out — re-claim
 			leaderTimeoutTimer = null;
 			claimLeadership();
-		}, LEADER_HEARTBEAT_TIMEOUT);
+		}, delay);
 	}
 
 	function closeChannel() {

--- a/alt-frontend-sv/src/lib/server/connect-path.test.ts
+++ b/alt-frontend-sv/src/lib/server/connect-path.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { isConnectMethodName, parseConnectPath } from "./connect-path";
+
+describe("isConnectMethodName", () => {
+	it.each([
+		"Watch",
+		"GetFeedStats",
+		"Get_v2",
+		"a",
+		"Stream2",
+	])("accepts the proto identifier %s", (value) => {
+		expect(isConnectMethodName(value)).toBe(true);
+	});
+
+	// The separators below are what SvelteKit hands us after decoding `%5C`,
+	// `%2F` and `%2E`, and what `fetch` would then resolve away.
+	it.each([
+		"",
+		"..",
+		".",
+		"Watch/Extra",
+		"Watch\\Extra",
+		"..\\..\\v1\\aggregate",
+		"../../v1/aggregate",
+		"Watch?admin=1",
+		"Watch#/v1/aggregate",
+		"Watch%2F..%2Fv1",
+		"/Watch",
+		"2Watch",
+		"Watch Extra",
+		"Watch\nGET /v1/aggregate",
+	])("refuses %j", (value) => {
+		expect(isConnectMethodName(value)).toBe(false);
+	});
+});
+
+describe("parseConnectPath", () => {
+	it("splits a well-formed Connect path", () => {
+		expect(
+			parseConnectPath("alt.knowledge_home.v1.KnowledgeHomeService/Get"),
+		).toEqual({
+			service: "alt.knowledge_home.v1.KnowledgeHomeService",
+			method: "Get",
+		});
+	});
+
+	// A dot-separated service name must not be mistaken for a traversal-bearing
+	// one: only the identifier shape decides, so `..` in either half is out.
+	it.each([
+		"alt.feeds.v2.FeedService",
+		"alt.feeds.v2.FeedService/",
+		"alt.feeds.v2.FeedService/Get\\..\\..\\v1\\dashboard",
+		"alt.feeds.v2.FeedService/Get/Extra",
+		"alt..v2.FeedService/Get",
+		"../alt.feeds.v2.FeedService/Get",
+		"/GetFeedStats",
+	])("refuses %j", (path) => {
+		expect(parseConnectPath(path)).toBeNull();
+	});
+});

--- a/alt-frontend-sv/src/lib/server/connect-path.ts
+++ b/alt-frontend-sv/src/lib/server/connect-path.ts
@@ -1,0 +1,66 @@
+/**
+ * Positive-form validation for the Connect-RPC paths our proxies forward.
+ *
+ * Both `/api/v2` proxies attach a privileged token to a path the caller chose,
+ * so the segment they append to an upstream origin decides which endpoint that
+ * token reaches. SvelteKit hands rest params to the route already
+ * percent-decoded, so `%5C` arrives as a literal `\` and `%2E%2E` as `..`; the
+ * WHATWG URL parser inside `fetch` then treats `\` as a path separator for
+ * http(s) and collapses dot segments. A negative guard — splitting on "/",
+ * scanning for "..", blacklisting characters — is therefore always one encoding
+ * behind: the value it inspects is not the value `fetch` will resolve.
+ *
+ * So we validate in the positive direction instead. A Connect path is exactly
+ * `<package>.<Service>/<Method>`, and both halves are proto identifiers, which
+ * cannot contain a separator, a dot segment, a percent sign or a query/fragment
+ * delimiter in the first place. Anything that fails the identifier shape is
+ * refused without asking why it failed.
+ */
+
+/**
+ * A single proto identifier: a leading letter, then letters, digits and
+ * underscores. Deliberately anchored — an unanchored test would match the
+ * identifier-looking prefix of `Watch\..\..\v1\aggregate`.
+ */
+const IDENTIFIER = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/**
+ * A fully-qualified Connect service name: dot-joined proto identifiers, e.g.
+ * `alt.knowledge_home.v1.KnowledgeHomeService`.
+ */
+const SERVICE_NAME = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)*$/;
+
+export interface ConnectPath {
+	readonly service: string;
+	readonly method: string;
+}
+
+/**
+ * True when `value` is a well-formed Connect method name (one proto identifier).
+ *
+ * Use this where the service prefix is fixed by the route and only the method
+ * comes from the caller.
+ */
+export function isConnectMethodName(value: string): boolean {
+	return IDENTIFIER.test(value);
+}
+
+/**
+ * Parse `<service>/<method>` into its two halves, or null when the input is not
+ * exactly that shape.
+ *
+ * Returning null rather than throwing keeps the caller's refusal path a plain
+ * 404: the proxy must not tell an unauthenticated prober which half it rejected.
+ */
+export function parseConnectPath(path: string): ConnectPath | null {
+	const separator = path.indexOf("/");
+	if (separator === -1) return null;
+
+	const service = path.slice(0, separator);
+	const method = path.slice(separator + 1);
+
+	if (!SERVICE_NAME.test(service)) return null;
+	if (!isConnectMethodName(method)) return null;
+
+	return { service, method };
+}

--- a/alt-frontend-sv/src/lib/server/tag-trail-api.test.ts
+++ b/alt-frontend-sv/src/lib/server/tag-trail-api.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$env/dynamic/private", () => ({
+	env: {
+		BACKEND_REST_URL: "http://backend.test",
+	},
+}));
+
+const AUTH_HUB_URL = "http://auth-hub:8888";
+const BACKEND_TOKEN = "backend-token-for-the-caller";
+
+// SvelteKit hands `params.id` to the handler already decodeURIComponent'd, so a
+// request for `..%2F..%2Fv1%2Fdashboard%2Foverview%3F` arrives here as literal
+// dot segments plus a `?` that swallows the rest of the template into a query
+// string. This is the raw value the handler sees, not the wire form.
+const TRAVERSAL_ID = "../../v1/dashboard/overview?";
+
+/**
+ * Stubs global fetch: answers auth-hub's /session with a token so the request
+ * to the backend carries one, and records every backend URL that was asked for.
+ */
+function stubFetch(body: unknown): { backendUrls: string[] } {
+	const backendUrls: string[] = [];
+
+	vi.stubGlobal(
+		"fetch",
+		vi.fn((input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : String(input);
+
+			if (url.startsWith(AUTH_HUB_URL)) {
+				return Promise.resolve(
+					new Response(null, {
+						status: 200,
+						headers: { "X-Alt-Backend-Token": BACKEND_TOKEN },
+					}),
+				);
+			}
+
+			backendUrls.push(url);
+			return Promise.resolve(
+				new Response(JSON.stringify(body), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			);
+		}),
+	);
+
+	return { backendUrls };
+}
+
+function requestEvent(id: string) {
+	return {
+		request: new Request(`http://localhost/api/articles/${id}/tags`, {
+			headers: { cookie: "ory_kratos_session=abc" },
+		}),
+		params: { id },
+	} as never;
+}
+
+describe("tag trail route params", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("keeps a traversal article id inside /v1/articles/<id>/tags", async () => {
+		const { backendUrls } = stubFetch({ article_id: TRAVERSAL_ID, tags: [] });
+
+		const { GET } = await import("../../routes/api/articles/[id]/tags/+server");
+		await GET(requestEvent(TRAVERSAL_ID));
+
+		expect(backendUrls).toHaveLength(1);
+		const requested = new URL(backendUrls[0] as string);
+		expect(requested.pathname.startsWith("/v1/articles/")).toBe(true);
+		expect(requested.pathname.endsWith("/tags")).toBe(true);
+		expect(requested.search).toBe("");
+	});
+
+	it("keeps a well-formed article id addressing the same endpoint", async () => {
+		const articleId = "550e8400-e29b-41d4-a716-446655440000";
+		const { backendUrls } = stubFetch({ article_id: articleId, tags: [] });
+
+		const { GET } = await import("../../routes/api/articles/[id]/tags/+server");
+		await GET(requestEvent(articleId));
+
+		const requested = new URL(backendUrls[0] as string);
+		expect(requested.pathname).toBe(`/v1/articles/${articleId}/tags`);
+		expect(requested.search).toBe("");
+	});
+
+	it("keeps a traversal feed id inside /v1/feeds/<id>/tags", async () => {
+		const { backendUrls } = stubFetch({ feed_id: TRAVERSAL_ID, tags: [] });
+
+		const { GET } = await import("../../routes/api/feeds/[id]/tags/+server");
+		await GET({
+			request: new Request(`http://localhost/api/feeds/${TRAVERSAL_ID}/tags`, {
+				headers: { cookie: "ory_kratos_session=abc" },
+			}),
+			params: { id: TRAVERSAL_ID },
+		} as never);
+
+		expect(backendUrls).toHaveLength(1);
+		const requested = new URL(backendUrls[0] as string);
+		expect(requested.pathname.startsWith("/v1/feeds/")).toBe(true);
+		expect(requested.pathname.endsWith("/tags")).toBe(true);
+		expect(requested.search).toBe("?limit=20");
+	});
+
+	it("keeps a well-formed feed id addressing the same endpoint", async () => {
+		const feedId = "9f2c1ab0-0000-4000-8000-00000000feed";
+		const { backendUrls } = stubFetch({ feed_id: feedId, tags: [] });
+
+		const { GET } = await import("../../routes/api/feeds/[id]/tags/+server");
+		await GET({
+			request: new Request(`http://localhost/api/feeds/${feedId}/tags`, {
+				headers: { cookie: "ory_kratos_session=abc" },
+			}),
+			params: { id: feedId },
+		} as never);
+
+		const requested = new URL(backendUrls[0] as string);
+		expect(requested.pathname).toBe(`/v1/feeds/${feedId}/tags`);
+		expect(requested.search).toBe("?limit=20");
+	});
+});

--- a/alt-frontend-sv/src/lib/server/tag-trail-api.ts
+++ b/alt-frontend-sv/src/lib/server/tag-trail-api.ts
@@ -78,8 +78,11 @@ export async function getArticleTags(
 	cookie: string | null,
 	articleId: string,
 ): Promise<ArticleTagsResponse> {
+	// params.id reaches here already decodeURIComponent'd by SvelteKit and with
+	// no format check, so re-encoding is what keeps a caller-supplied id from
+	// escaping this endpoint and taking the backend token somewhere else.
 	return callBackendAPI<ArticleTagsResponse>(
-		`/v1/articles/${articleId}/tags`,
+		`/v1/articles/${encodeURIComponent(articleId)}/tags`,
 		cookie,
 	);
 }
@@ -94,7 +97,7 @@ export async function getFeedTagsById(
 	limit = 20,
 ): Promise<FeedTagsResponse> {
 	return callBackendAPI<FeedTagsResponse>(
-		`/v1/feeds/${feedId}/tags?limit=${limit}`,
+		`/v1/feeds/${encodeURIComponent(feedId)}/tags?limit=${limit}`,
 		cookie,
 	);
 }

--- a/alt-frontend-sv/src/routes/api/v2/[...path]/+server.ts
+++ b/alt-frontend-sv/src/routes/api/v2/[...path]/+server.ts
@@ -8,6 +8,7 @@
 import type { RequestHandler } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
 import { PUBLIC_SERVICES } from "$lib/gen/allowlist";
+import { parseConnectPath } from "$lib/server/connect-path";
 
 const BACKEND_CONNECT_URL =
 	env.BACKEND_CONNECT_URL || "http://alt-backend:9101";
@@ -27,14 +28,18 @@ const BACKEND_CONNECT_URL =
  */
 const PROXYABLE_SERVICES = new Set<string>(PUBLIC_SERVICES);
 
+/**
+ * The allowlist only decides *which* service may be reached; it says nothing
+ * about the rest of the path. `parseConnectPath` supplies that half, in the
+ * positive direction — see its doc comment for why splitting on "/" and
+ * counting segments cannot: SvelteKit decodes `%5C` before we see it and the
+ * URL parser in `fetch` then reads that backslash as a separator, so
+ * `alt.feeds.v2.FeedService/Get\..\..\v1\dashboard` looks like two segments
+ * here and resolves to `/v1/dashboard` there.
+ */
 function isProxyableService(path: string): boolean {
-	const [service, method, ...rest] = path.split("/");
-	return (
-		rest.length === 0 &&
-		!!method &&
-		!!service &&
-		PROXYABLE_SERVICES.has(service)
-	);
+	const parsed = parseConnectPath(path);
+	return parsed !== null && PROXYABLE_SERVICES.has(parsed.service);
 }
 
 /**
@@ -51,7 +56,7 @@ export const fallback: RequestHandler = async ({ request, params, locals }) => {
 			JSON.stringify({
 				level: "warn",
 				source: "connect-proxy",
-				msg: "rejected non-proxyable Connect-RPC service",
+				msg: "rejected non-proxyable Connect-RPC path",
 				path,
 			}),
 		);

--- a/alt-frontend-sv/src/routes/api/v2/[...path]/path-traversal.test.ts
+++ b/alt-frontend-sv/src/routes/api/v2/[...path]/path-traversal.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fallback } from "./+server";
+
+// SvelteKit hands the rest param already percent-decoded, so `%5C` arrives as a
+// literal backslash and `%2E%2E` as a literal `..`. The WHATWG URL parser that
+// `fetch` runs then treats `\` as a path separator for http(s) and collapses
+// dot segments, so a method name carrying either escapes the service prefix and
+// reaches an arbitrary backend path — with the proxy's backend token attached.
+// Any negative-form guard (split, blacklist, substring scan) loses this race;
+// only a positive method-name format check closes it.
+function makeEvent(path: string, token: string | null = "backend-token") {
+	return {
+		request: new Request("http://localhost/api/v2/proxied", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "{}",
+		}),
+		params: { path },
+		locals: { backendToken: token },
+	} as unknown as Parameters<typeof fallback>[0];
+}
+
+describe("POST /api/v2/[...path] method-name validation", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("{}", { status: 200 })),
+		);
+	});
+
+	// Every entry names a service that IS on the generated allowlist, so the
+	// only thing standing between the caller and an arbitrary backend path is
+	// the method-name check.
+	it.each([
+		["encoded backslash traversal", "Get\\..\\..\\v1\\dashboard\\overview"],
+		["bare backslash traversal", "..\\..\\v1\\aggregate"],
+		["single backslash segment", "Get\\Other"],
+		["dot segment", ".."],
+		["query string smuggled into the method", "GetFeedStats?admin=1"],
+		["fragment smuggled into the method", "GetFeedStats#/v1/aggregate"],
+		["still-encoded slash", "GetFeedStats%2F..%2Fv1"],
+		["absolute path escape", "/v1/dashboard/overview"],
+	])("refuses %s", async (_label, method) => {
+		const res = await fallback(makeEvent(`alt.feeds.v2.FeedService/${method}`));
+
+		expect(res.status).toBe(404);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it("still proxies a well-formed Connect method", async () => {
+		const res = await fallback(
+			makeEvent("alt.feeds.v2.FeedService/GetFeedStats"),
+		);
+
+		expect(res.status).toBe(200);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe(
+			"http://alt-backend:9101/alt.feeds.v2.FeedService/GetFeedStats",
+		);
+	});
+});

--- a/alt-frontend-sv/src/routes/api/v2/alt.admin_monitor.v1.AdminMonitorService/[...path]/+server.ts
+++ b/alt-frontend-sv/src/routes/api/v2/alt.admin_monitor.v1.AdminMonitorService/[...path]/+server.ts
@@ -12,12 +12,37 @@
 
 import type { RequestHandler } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
+import { isConnectMethodName } from "$lib/server/connect-path";
 
 const BFF_URL = env.BFF_CONNECT_URL || "http://alt-butterfly-facade:9250";
 
 const SERVICE_PREFIX = "/alt.admin_monitor.v1.AdminMonitorService/";
 
 export const fallback: RequestHandler = async ({ request, params, locals }) => {
+	const method = params.path || "";
+
+	// The prefix above is the only thing scoping this proxy to the admin
+	// service, and a prefix is just a string until the method appended to it is
+	// known to be a single proto identifier. Without this check an authenticated
+	// non-admin can send `..%2F..%2Fv1%2Faggregate` and have `fetch` normalise
+	// its way onto any BFF endpoint with their token attached — the BFF's own
+	// role check is the only thing left, which makes this a guard bypass rather
+	// than mere defence in depth.
+	if (!isConnectMethodName(method)) {
+		console.warn(
+			JSON.stringify({
+				level: "warn",
+				source: "admin-monitor-proxy",
+				msg: "rejected malformed Connect method name",
+				method,
+			}),
+		);
+		return new Response(
+			JSON.stringify({ code: "not_found", message: "Unknown endpoint" }),
+			{ status: 404, headers: { "Content-Type": "application/json" } },
+		);
+	}
+
 	const token = locals.backendToken;
 	if (!token) {
 		return new Response(
@@ -29,7 +54,6 @@ export const fallback: RequestHandler = async ({ request, params, locals }) => {
 		);
 	}
 
-	const method = params.path || "";
 	const target = `${BFF_URL}${SERVICE_PREFIX}${method}`;
 
 	const headers = new Headers(request.headers);

--- a/alt-frontend-sv/src/routes/api/v2/alt.admin_monitor.v1.AdminMonitorService/[...path]/server.test.ts
+++ b/alt-frontend-sv/src/routes/api/v2/alt.admin_monitor.v1.AdminMonitorService/[...path]/server.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fallback } from "./+server";
+
+// This proxy concatenates the catch-all straight onto a fixed service prefix,
+// so the prefix is only as strong as the segment appended to it. SvelteKit
+// percent-decodes the rest param before we see it, and `fetch`'s URL parser
+// then collapses `..` and treats `\` as a separator — an authenticated
+// non-admin sending `..%2F..%2Fv1%2Faggregate` walks straight out of the
+// AdminMonitorService prefix onto any BFF endpoint with their token attached.
+function makeEvent(path: string, token: string | null = "backend-token") {
+	return {
+		request: new Request("http://localhost/api/v2/admin-monitor", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "{}",
+		}),
+		params: { path },
+		locals: { backendToken: token },
+	} as unknown as Parameters<typeof fallback>[0];
+}
+
+describe("POST /api/v2/alt.admin_monitor.v1.AdminMonitorService/[...path]", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("{}", { status: 200 })),
+		);
+	});
+
+	it.each([
+		["encoded slash traversal", "../../v1/aggregate"],
+		["encoded backslash traversal", "..\\..\\v1\\aggregate"],
+		["traversal after a valid-looking method", "Watch\\..\\..\\v1\\aggregate"],
+		["extra path segment", "Watch/Extra"],
+		["query string smuggled into the method", "Watch?admin=1"],
+		["fragment smuggled into the method", "Watch#/v1/aggregate"],
+		["still-encoded slash", "Watch%2F..%2Fv1"],
+		["empty method", ""],
+	])("refuses %s", async (_label, method) => {
+		const res = await fallback(makeEvent(method));
+
+		expect(res.status).toBe(404);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it("proxies a well-formed Connect method to the BFF", async () => {
+		const res = await fallback(makeEvent("Watch"));
+
+		expect(res.status).toBe(200);
+		expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe(
+			"http://alt-butterfly-facade:9250/alt.admin_monitor.v1.AdminMonitorService/Watch",
+		);
+	});
+
+	it("still requires a backend token", async () => {
+		const res = await fallback(makeEvent("Watch", null));
+
+		expect(res.status).toBe(401);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+});

--- a/altctl/internal/setup/secrets.go
+++ b/altctl/internal/setup/secrets.go
@@ -37,7 +37,13 @@ type SecretsResult struct {
 // internal/stack uses for the stack registry. A secret base.yaml declares
 // that has no entry here still gets generated, via defaultSecretMeta.
 var knownSecretMeta = map[string]secretMeta{
-	"backend_token_secret.txt":              {"Backend JWT token secret", true, 32, 0},
+	"backend_token_secret.txt": {"Backend JWT token secret", true, 32, 0},
+	// Separate from backend_token_secret so the HS256 signing key stays inside
+	// auth-hub: this one is the /internal shared bearer alt-data-hub puts in a
+	// plaintext X-Internal-Auth header, and auth-hub refuses to start when the
+	// two files hold the same value. Both are auto-generated independently, so
+	// a fresh `altctl init` can never produce the collision.
+	"auth_hub_internal_secret.txt":          {"auth-hub /internal shared bearer (X-Internal-Auth)", true, 32, 0},
 	"postgres_password.txt":                 {"PostgreSQL superuser password", true, 32, 0},
 	"db_password.txt":                       {"Application database password", true, 32, 0},
 	"pre_processor_sidecar_db_password.txt": {"Pre-processor sidecar DB password", true, 32, 0},

--- a/auth-hub/cmd/auth-hub/internal_auth_wiring_test.go
+++ b/auth-hub/cmd/auth-hub/internal_auth_wiring_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"auth-hub/config"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	jwtSigningKey     = "this-is-a-valid-backend-token-secret-32-chars-long"
+	internalAuthValue = "this-is-a-distinct-internal-auth-secret-32-chars"
+)
+
+func separatedSecretsConfig() *config.Config {
+	return &config.Config{
+		KratosURL:          "http://kratos:4433",
+		Port:               "8888",
+		CacheTTL:           5 * time.Minute,
+		CSRFSecret:         "this-is-a-valid-csrf-secret-that-is-at-least-32-chars",
+		BackendTokenSecret: jwtSigningKey,
+		InternalAuthSecret: internalAuthValue,
+	}
+}
+
+// serveInternal exercises the middleware main wires onto the /internal group.
+func serveInternal(t *testing.T, mw echo.MiddlewareFunc, header string) int {
+	t.Helper()
+
+	e := echo.New()
+	e.Use(mw)
+	e.GET("/internal/system-user", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/system-user", nil)
+	if header != "" {
+		req.Header.Set("X-Internal-Auth", header)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+// The JWT signing key must not open /internal. alt-backend puts whatever this
+// group accepts into a plaintext X-Internal-Auth header on every
+// GetSystemUser call, so accepting the signing key here is what pushed it out
+// of the process and into access logs and OTel span attributes.
+func TestWireInternalAuth_RejectsTheJWTSigningKey(t *testing.T) {
+	mw := wireInternalAuth(separatedSecretsConfig())
+
+	assert.Equal(t, http.StatusForbidden, serveInternal(t, mw, jwtSigningKey))
+}
+
+func TestWireInternalAuth_AcceptsTheInternalAuthSecret(t *testing.T) {
+	mw := wireInternalAuth(separatedSecretsConfig())
+
+	assert.Equal(t, http.StatusOK, serveInternal(t, mw, internalAuthValue))
+}
+
+// Defence in depth for the choke point: config.Validate already rejects an
+// identical pair, so reaching here with one means that invariant broke.
+func TestWireInternalAuth_PanicsWhenSecretsAreIdentical(t *testing.T) {
+	cfg := separatedSecretsConfig()
+	cfg.InternalAuthSecret = cfg.BackendTokenSecret
+
+	assert.Panics(t, func() {
+		wireInternalAuth(cfg)
+	})
+}

--- a/auth-hub/cmd/auth-hub/main.go
+++ b/auth-hub/cmd/auth-hub/main.go
@@ -30,16 +30,26 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// wireInternalAuth is the sole choke point for /internal auth wiring. It
-// panics on an empty secret instead of falling back to an unauthenticated
-// no-op: config.Validate() already requires a non-empty BackendTokenSecret,
-// so reaching this branch with an empty secret means that invariant broke,
-// not that internal auth should be silently disabled (CLAUDE.md Rule 8).
-func wireInternalAuth(secret string) echo.MiddlewareFunc {
-	if secret == "" {
-		panic("main: BACKEND_TOKEN_SECRET must be set before wiring internal auth")
+// wireInternalAuth is the sole choke point for /internal auth wiring. It takes
+// the whole config rather than a bare string so the caller cannot hand it the
+// wrong secret: the group is keyed on InternalAuthSecret, never on the HS256
+// key that signs backend JWTs. alt-backend puts whatever this group accepts
+// into a plaintext X-Internal-Auth header on every GetSystemUser call, which
+// spreads it to nginx access logs and OTel span attributes — a place the
+// signing key must never reach.
+//
+// Both guards panic instead of degrading. config.Validate() already requires a
+// non-empty InternalAuthSecret distinct from BackendTokenSecret, so reaching
+// either branch means that invariant broke, not that internal auth should be
+// silently disabled or silently keyed on the signing key (CLAUDE.md Rule 8).
+func wireInternalAuth(cfg *config.Config) echo.MiddlewareFunc {
+	if cfg.InternalAuthSecret == "" {
+		panic("main: INTERNAL_AUTH_SECRET must be set before wiring internal auth")
 	}
-	return appmiddleware.InternalAuth(secret)
+	if cfg.InternalAuthSecret == cfg.BackendTokenSecret {
+		panic("main: INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET")
+	}
+	return appmiddleware.InternalAuth(cfg.InternalAuthSecret)
 }
 
 func main() {
@@ -179,12 +189,17 @@ func main() {
 	e.POST("/csrf", csrfHandler.Handle, csrfRL.Middleware())
 	e.GET("/health", healthHandler.Handle)
 
-	// Internal routes (protected by shared secret)
+	// Internal routes (protected by a shared bearer that is deliberately not
+	// the JWT signing key — see wireInternalAuth)
 	internalGroup := e.Group("/internal",
 		internalRL.Middleware(),
 	)
-	internalGroup.Use(wireInternalAuth(cfg.BackendTokenSecret))
+	internalGroup.Use(wireInternalAuth(cfg))
 	internalGroup.GET("/system-user", internalHandler.HandleSystemUser)
+	// Names the secret this group is keyed on, never its value: an operator
+	// reading the log can tell the two secrets apart without a way to learn
+	// either (auth-hub Rule 3).
+	slog.InfoContext(ctx, "internal_auth_enabled", "secret_source", "INTERNAL_AUTH_SECRET")
 
 	// Start server with errgroup for graceful shutdown
 	address := fmt.Sprintf(":%s", cfg.Port)

--- a/auth-hub/cmd/auth-hub/main_test.go
+++ b/auth-hub/cmd/auth-hub/main_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"auth-hub/config"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,12 +17,12 @@ import (
 // signal to skip auth (CLAUDE.md Rule 8).
 func TestWireInternalAuth_PanicsOnEmptySecret(t *testing.T) {
 	assert.Panics(t, func() {
-		wireInternalAuth("")
+		wireInternalAuth(&config.Config{})
 	})
 }
 
 func TestWireInternalAuth_FailsClosedWithoutHeader(t *testing.T) {
-	mw := wireInternalAuth("this-is-a-valid-backend-token-secret-32-chars-long")
+	mw := wireInternalAuth(separatedSecretsConfig())
 
 	e := echo.New()
 	e.Use(mw)
@@ -36,8 +38,8 @@ func TestWireInternalAuth_FailsClosedWithoutHeader(t *testing.T) {
 }
 
 func TestWireInternalAuth_AllowsValidSecret(t *testing.T) {
-	secret := "this-is-a-valid-backend-token-secret-32-chars-long"
-	mw := wireInternalAuth(secret)
+	cfg := separatedSecretsConfig()
+	mw := wireInternalAuth(cfg)
 
 	e := echo.New()
 	e.Use(mw)
@@ -46,7 +48,7 @@ func TestWireInternalAuth_AllowsValidSecret(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/internal/system-user", nil)
-	req.Header.Set("X-Internal-Auth", secret)
+	req.Header.Set("X-Internal-Auth", cfg.InternalAuthSecret)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 

--- a/auth-hub/config/config.go
+++ b/auth-hub/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	BackendTokenIssuer   string        // JWT issuer claim
 	BackendTokenAudience string        // JWT audience claim
 	BackendTokenTTL      time.Duration // JWT token TTL
+	InternalAuthSecret   string        // Shared bearer the /internal group compares X-Internal-Auth against
 	ValidateRateLimit    float64       // Validate endpoint: requests per second (default: 100/60 ≈ 1.67)
 	SessionRateLimit     float64       // Session endpoint: requests per second (default: 30/60 = 0.5)
 	CSRFRateLimit        float64       // CSRF endpoint: requests per second (default: 100)
@@ -36,9 +37,10 @@ func Load() (*Config, error) {
 		BackendTokenIssuer:   getEnv("BACKEND_TOKEN_ISSUER", "auth-hub"),
 		BackendTokenAudience: getEnv("BACKEND_TOKEN_AUDIENCE", "alt-backend"),
 		BackendTokenTTL:      5 * time.Minute, // Default 5 minutes
-		ValidateRateLimit:    100.0 / 60.0,    // Default: ~1.67 req/s (100 req/min)
-		SessionRateLimit:     30.0 / 60.0,     // Default: 0.5 req/s (30 req/min)
-		CSRFRateLimit:        100.0,           // Default: 100 req/s
+		InternalAuthSecret:   getEnv("INTERNAL_AUTH_SECRET", ""),
+		ValidateRateLimit:    100.0 / 60.0, // Default: ~1.67 req/s (100 req/min)
+		SessionRateLimit:     30.0 / 60.0,  // Default: 0.5 req/s (30 req/min)
+		CSRFRateLimit:        100.0,        // Default: 100 req/s
 	}
 
 	// Parse CACHE_TTL if provided
@@ -121,6 +123,24 @@ func (c *Config) Validate() error {
 	}
 	if len(c.BackendTokenSecret) < 32 {
 		return fmt.Errorf("BACKEND_TOKEN_SECRET must be at least 32 characters")
+	}
+
+	// INTERNAL_AUTH_SECRET is the shared bearer the /internal group compares
+	// X-Internal-Auth against. It is a separate secret from the HS256 signing
+	// key on purpose: alt-backend sends this value in a plaintext header on
+	// every GetSystemUser call, so it lands in nginx access logs and OTel span
+	// attributes. The signing key must never reach that wire, and reusing one
+	// value for both jobs is what put it there. No default and no fallback to
+	// BACKEND_TOKEN_SECRET — an unset value exits non-zero (CLAUDE.md rule 9).
+	if c.InternalAuthSecret == "" {
+		return fmt.Errorf("INTERNAL_AUTH_SECRET is required")
+	}
+	if len(c.InternalAuthSecret) < 32 {
+		return fmt.Errorf("INTERNAL_AUTH_SECRET must be at least 32 characters")
+	}
+	if c.InternalAuthSecret == c.BackendTokenSecret {
+		return fmt.Errorf("INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET: " +
+			"the JWT signing key would travel in plaintext X-Internal-Auth headers")
 	}
 
 	return nil

--- a/auth-hub/config/config_test.go
+++ b/auth-hub/config/config_test.go
@@ -25,6 +25,7 @@ func TestLoad(t *testing.T) {
 				os.Unsetenv("PORT")
 				os.Unsetenv("CACHE_TTL")
 				os.Unsetenv("CSRF_SECRET")
+				os.Unsetenv("INTERNAL_AUTH_SECRET")
 			},
 			cleanupEnv:  func() {},
 			expected:    nil,
@@ -39,6 +40,7 @@ func TestLoad(t *testing.T) {
 				os.Setenv("CACHE_TTL", "10m")
 				os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 				os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+				os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 			},
 			cleanupEnv: func() {
 				os.Unsetenv("KRATOS_URL")
@@ -46,6 +48,7 @@ func TestLoad(t *testing.T) {
 				os.Unsetenv("CACHE_TTL")
 				os.Unsetenv("CSRF_SECRET")
 				os.Unsetenv("BACKEND_TOKEN_SECRET")
+				os.Unsetenv("INTERNAL_AUTH_SECRET")
 			},
 			expected: &Config{
 				KratosURL:  "http://custom-kratos:4444",
@@ -73,6 +76,7 @@ func TestLoad(t *testing.T) {
 				os.Setenv("KRATOS_URL", "http://localhost:4433")
 				os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 				os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+				os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 				os.Unsetenv("PORT")
 				os.Unsetenv("CACHE_TTL")
 			},
@@ -80,6 +84,7 @@ func TestLoad(t *testing.T) {
 				os.Unsetenv("KRATOS_URL")
 				os.Unsetenv("CSRF_SECRET")
 				os.Unsetenv("BACKEND_TOKEN_SECRET")
+				os.Unsetenv("INTERNAL_AUTH_SECRET")
 			},
 			expected: &Config{
 				KratosURL:  "http://localhost:4433",
@@ -121,9 +126,11 @@ func TestLoad(t *testing.T) {
 func TestLoad_ValidateRateLimit_Default(t *testing.T) {
 	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 	defer func() {
 		os.Unsetenv("CSRF_SECRET")
 		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
 		os.Unsetenv("VALIDATE_RATE_LIMIT")
 	}()
 
@@ -135,10 +142,12 @@ func TestLoad_ValidateRateLimit_Default(t *testing.T) {
 func TestLoad_ValidateRateLimit_EnvOverride(t *testing.T) {
 	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 	os.Setenv("VALIDATE_RATE_LIMIT", "50.0")
 	defer func() {
 		os.Unsetenv("CSRF_SECRET")
 		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
 		os.Unsetenv("VALIDATE_RATE_LIMIT")
 	}()
 
@@ -150,10 +159,12 @@ func TestLoad_ValidateRateLimit_EnvOverride(t *testing.T) {
 func TestLoad_ValidateRateLimit_Invalid(t *testing.T) {
 	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 	os.Setenv("VALIDATE_RATE_LIMIT", "not-a-number")
 	defer func() {
 		os.Unsetenv("CSRF_SECRET")
 		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
 		os.Unsetenv("VALIDATE_RATE_LIMIT")
 	}()
 
@@ -165,9 +176,11 @@ func TestLoad_ValidateRateLimit_Invalid(t *testing.T) {
 func TestLoad_CSRFRateLimit_Default(t *testing.T) {
 	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 	defer func() {
 		os.Unsetenv("CSRF_SECRET")
 		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
 		os.Unsetenv("CSRF_RATE_LIMIT")
 	}()
 
@@ -179,10 +192,12 @@ func TestLoad_CSRFRateLimit_Default(t *testing.T) {
 func TestLoad_CSRFRateLimit_EnvOverride(t *testing.T) {
 	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 	os.Setenv("CSRF_RATE_LIMIT", "50.0")
 	defer func() {
 		os.Unsetenv("CSRF_SECRET")
 		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
 		os.Unsetenv("CSRF_RATE_LIMIT")
 	}()
 
@@ -194,10 +209,12 @@ func TestLoad_CSRFRateLimit_EnvOverride(t *testing.T) {
 func TestLoad_CSRFRateLimit_Invalid(t *testing.T) {
 	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
 	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
 	os.Setenv("CSRF_RATE_LIMIT", "not-a-number")
 	defer func() {
 		os.Unsetenv("CSRF_SECRET")
 		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
 		os.Unsetenv("CSRF_RATE_LIMIT")
 	}()
 
@@ -221,6 +238,7 @@ func TestConfig_Validate(t *testing.T) {
 				CacheTTL:           5 * time.Minute,
 				CSRFSecret:         "this-is-a-valid-csrf-secret-that-is-at-least-32-chars",
 				BackendTokenSecret: "this-is-a-valid-backend-token-secret-32-chars-long",
+				InternalAuthSecret: "this-is-a-distinct-internal-auth-secret-32-chars",
 			},
 			wantErr: false,
 		},
@@ -294,6 +312,7 @@ func TestConfig_Validate(t *testing.T) {
 				CacheTTL:           5 * time.Minute,
 				CSRFSecret:         "this-is-a-valid-csrf-secret-that-is-at-least-32-chars",
 				BackendTokenSecret: "this-is-a-valid-backend-token-secret-32-chars-long",
+				InternalAuthSecret: "this-is-a-distinct-internal-auth-secret-32-chars",
 			},
 			wantErr: false,
 		},

--- a/auth-hub/config/internal_auth_secret_test.go
+++ b/auth-hub/config/internal_auth_secret_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseValidConfig is a config that passes Validate once the /internal shared
+// bearer is separated from the JWT signing key.
+func baseValidConfig() *Config {
+	return &Config{
+		KratosURL:          "http://kratos:4433",
+		Port:               "8888",
+		CacheTTL:           5 * time.Minute,
+		CSRFSecret:         "this-is-a-valid-csrf-secret-that-is-at-least-32-chars",
+		BackendTokenSecret: "this-is-a-valid-backend-token-secret-32-chars-long",
+		InternalAuthSecret: "this-is-a-distinct-internal-auth-secret-32-chars",
+	}
+}
+
+// The HS256 key that signs backend JWTs must never leave the process, but the
+// /internal shared bearer travels in a plaintext X-Internal-Auth header on
+// every alt-backend GetSystemUser call — and from there into access logs and
+// OTel span attributes. Sharing one value between the two jobs put the signing
+// key on that wire, so they are now two separate required secrets.
+func TestConfig_Validate_InternalAuthSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*Config)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "distinct internal auth secret is valid",
+			mutate:  func(*Config) {},
+			wantErr: false,
+		},
+		{
+			name:        "missing internal auth secret",
+			mutate:      func(c *Config) { c.InternalAuthSecret = "" },
+			wantErr:     true,
+			errContains: "INTERNAL_AUTH_SECRET is required",
+		},
+		{
+			name:        "internal auth secret too short",
+			mutate:      func(c *Config) { c.InternalAuthSecret = "short-secret" },
+			wantErr:     true,
+			errContains: "INTERNAL_AUTH_SECRET must be at least 32 characters",
+		},
+		{
+			name:        "internal auth secret reuses the JWT signing key",
+			mutate:      func(c *Config) { c.InternalAuthSecret = c.BackendTokenSecret },
+			wantErr:     true,
+			errContains: "INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseValidConfig()
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// Rule 9: an unset INTERNAL_AUTH_SECRET exits non-zero instead of falling back
+// to BACKEND_TOKEN_SECRET (which is what the single-secret wiring effectively
+// did) or to any built-in default.
+func TestLoad_InternalAuthSecret_HasNoDefault(t *testing.T) {
+	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
+	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Unsetenv("INTERNAL_AUTH_SECRET")
+	defer func() {
+		os.Unsetenv("CSRF_SECRET")
+		os.Unsetenv("BACKEND_TOKEN_SECRET")
+	}()
+
+	_, err := Load()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "INTERNAL_AUTH_SECRET is required")
+}
+
+func TestLoad_InternalAuthSecret_RejectsReuseOfSigningKey(t *testing.T) {
+	const shared = "this-is-a-valid-backend-token-secret-32-chars-long"
+	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
+	os.Setenv("BACKEND_TOKEN_SECRET", shared)
+	os.Setenv("INTERNAL_AUTH_SECRET", shared)
+	defer func() {
+		os.Unsetenv("CSRF_SECRET")
+		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
+	}()
+
+	_, err := Load()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "INTERNAL_AUTH_SECRET must not equal BACKEND_TOKEN_SECRET")
+}
+
+func TestLoad_InternalAuthSecret_FromEnv(t *testing.T) {
+	os.Setenv("CSRF_SECRET", "this-is-a-valid-csrf-secret-that-is-at-least-32-chars")
+	os.Setenv("BACKEND_TOKEN_SECRET", "this-is-a-valid-backend-token-secret-32-chars-long")
+	os.Setenv("INTERNAL_AUTH_SECRET", "this-is-a-distinct-internal-auth-secret-32-chars")
+	defer func() {
+		os.Unsetenv("CSRF_SECRET")
+		os.Unsetenv("BACKEND_TOKEN_SECRET")
+		os.Unsetenv("INTERNAL_AUTH_SECRET")
+	}()
+
+	cfg, err := Load()
+
+	require.NoError(t, err)
+	assert.Equal(t, "this-is-a-distinct-internal-auth-secret-32-chars", cfg.InternalAuthSecret)
+	assert.NotEqual(t, cfg.BackendTokenSecret, cfg.InternalAuthSecret)
+}

--- a/compose/ai.yaml
+++ b/compose/ai.yaml
@@ -288,7 +288,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-    tty: true
     labels:
       - rask.group=pre-processor
     logging:

--- a/compose/auth.yaml
+++ b/compose/auth.yaml
@@ -140,6 +140,12 @@ services:
       - BACKEND_TOKEN_ISSUER=auth-hub
       - BACKEND_TOKEN_AUDIENCE=alt-backend
       - BACKEND_TOKEN_TTL=30m
+      # The /internal group's shared bearer. Required, no default, and rejected
+      # at startup when it equals BACKEND_TOKEN_SECRET: alt-data-hub sends this
+      # value in a plaintext X-Internal-Auth header on every GetSystemUser call,
+      # so it reaches access logs and OTel span attributes — which is why the
+      # HS256 signing key above no longer doubles as it.
+      - INTERNAL_AUTH_SECRET_FILE=/run/secrets/auth_hub_internal_secret
       - MTLS_LISTEN=${MTLS_LISTEN:-true}
       - MTLS_PORT=9443
       - MTLS_CERT_FILE=/certs/svc-cert.pem
@@ -153,6 +159,7 @@ services:
     secrets:
       - csrf_secret
       - backend_token_secret
+      - auth_hub_internal_secret
     volumes:
       - auth_hub_certs:/certs:ro
       - pki_trust_bundle:/trust:ro

--- a/compose/base.yaml
+++ b/compose/base.yaml
@@ -7,6 +7,15 @@ name: alt
 secrets:
   backend_token_secret:
     file: ../secrets/backend_token_secret.txt
+  # The shared bearer auth-hub's /internal group compares X-Internal-Auth
+  # against. Deliberately a different value from backend_token_secret: that one
+  # is the HS256 key auth-hub signs browser tokens with, and it used to do both
+  # jobs — which put the signing key in a plaintext header on every
+  # alt-data-hub GetSystemUser call, and from there into nginx access logs and
+  # OTel span attributes. auth-hub refuses to start when the two match.
+  # Unrelated to internal_auth_token below, which is auth-token-manager's.
+  auth_hub_internal_secret:
+    file: ../secrets/auth_hub_internal_secret.txt
   postgres_password:
     file: ../secrets/postgres_password.txt
   db_password:

--- a/compose/compose.staging.yaml
+++ b/compose/compose.staging.yaml
@@ -1260,6 +1260,9 @@ services:
       - BACKEND_TOKEN_ISSUER=alt-staging-auth-hub
       - BACKEND_TOKEN_AUDIENCE=alt-backend
       - AUTH_HUB_URL=http://auth-hub/
+      # Must match auth-hub's INTERNAL_AUTH_SECRET below, and must differ from
+      # alt_backend_token_secret — see the comment on the auth-hub service.
+      - INTERNAL_AUTH_SECRET=staging-fixture-internal-auth-secret-not-a-real-key
       - SOVEREIGN_URL=http://knowledge-sovereign
       # A disabled mq-hub client no-ops every publish while the article RPCs
       # still answer 200 (ADR-000928), so the enabled value is carried into
@@ -1408,6 +1411,14 @@ services:
       # is shared with alt-backend so the JWT auth-hub issues is
       # verifiable by anyone already trusting alt_backend_token_secret.
       - BACKEND_TOKEN_SECRET_FILE=/run/secrets/alt_backend_token_secret
+      # The /internal group's shared bearer, and deliberately NOT the HS256
+      # secret above: alt-data-hub sends this value in a plaintext
+      # X-Internal-Auth header, so a signing key doing both jobs ends up in
+      # access logs and OTel span attributes. auth-hub exits non-zero when the
+      # two match. Inline rather than a fixture file for the same reason
+      # VAPID_PUBLIC_KEY is: this is a throwaway staging value that the suite
+      # also needs to send, and one literal keeps the two in step.
+      - INTERNAL_AUTH_SECRET=staging-fixture-internal-auth-secret-not-a-real-key
       - CSRF_SECRET_FILE=/run/secrets/auth_hub_csrf_secret
       - MTLS_LISTEN=false
       - LOG_LEVEL=info

--- a/compose/core.yaml
+++ b/compose/core.yaml
@@ -658,6 +658,12 @@ services:
       # every token auth-hub has already minted.
       BACKEND_TOKEN_AUDIENCE: alt-backend
       AUTH_HUB_URL: http://auth-hub:8888
+      # The bearer this binary puts in X-Internal-Auth when it asks auth-hub
+      # for the system user. Separate from backend_token_secret on purpose:
+      # that header is plaintext and is copied into nginx access logs and OTel
+      # span attributes, so the JWT signing key must not be what opens
+      # auth-hub's /internal group. auth-hub exits non-zero if the two match.
+      INTERNAL_AUTH_SECRET_FILE: /run/secrets/auth_hub_internal_secret
       # SOVEREIGN_URL has no default; unset means the sovereign client no-ops
       # every append while the caller still records success.
       SOVEREIGN_URL: http://knowledge-sovereign:9500
@@ -682,6 +688,7 @@ services:
     secrets:
       - postgres_password
       - backend_token_secret
+      - auth_hub_internal_secret
     deploy:
       # See alt-harvester: mem_limit and deploy.resources.limits cannot both
       # be set unless they agree, so memory lives in the limits block.

--- a/compose/core.yaml
+++ b/compose/core.yaml
@@ -30,7 +30,11 @@ x-alt-go-common: &alt-go-common
   restart: always
   networks:
     - alt-network
-  tty: true
+  # Deliberately no `tty: true`. A TTY puts stdout and stderr on one pty, so
+  # Docker's log endpoint returns a raw headerless stream and every frame
+  # reaches rask-log-forwarder as Console -> Stdout. That makes
+  # `WHERE stream='stderr'` permanently empty for this service, panics
+  # included, and leaves ANSI colour codes in the text stored in ClickHouse.
   ulimits:
     nofile:
       soft: 65536
@@ -98,7 +102,6 @@ services:
       resources:
         reservations:
           memory: 256M
-    tty: true
     labels:
       - rask.group=alt-frontend
     logging:
@@ -128,7 +131,12 @@ services:
     environment:
       - PORT=4173
       - ORIGIN=${ORIGIN:-http://localhost:4173}
-      - BODY_SIZE_LIMIT=Infinity
+      # The nginx cutover took `client_max_body_size 32m` with it, and that
+      # directive was the authoritative limit precisely because this value was
+      # Infinity. plecto's manifest declares no body limit, so adapter-node is
+      # now the only thing standing between a POST under /api/ and this
+      # container's 512m — state the cap here rather than leave it implied.
+      - BODY_SIZE_LIMIT=32M
       - KRATOS_INTERNAL_URL=${KRATOS_INTERNAL_URL:-http://kratos:4433}
       - KRATOS_PUBLIC_URL=${KRATOS_PUBLIC_URL:-http://localhost/ory}
       - PUBLIC_API_BASE_URL=${PUBLIC_API_BASE_URL:-http://localhost:9000}
@@ -157,7 +165,6 @@ services:
       resources:
         reservations:
           memory: 256M
-    tty: true
     healthcheck:
       test: ["CMD-SHELL", "bun -e \"const n=require('net');const s=n.createConnection(4173,'127.0.0.1',()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1))\""]
       interval: 10s
@@ -339,9 +346,17 @@ services:
       # pushes, so the signing key stays out of it — see alt-notifier below.
       - vapid_public_key
     deploy:
+      # memory used to sit under reservations alone, which is a scheduling
+      # hint and not a cap: a leak in the user-facing API would have run until
+      # the host's OOM killer picked a victim, and that victim is as likely to
+      # be alt-db or news-creator-backend as this container. The limit sits
+      # above the reservation so the steady-state working set is still
+      # guaranteed. No mem_limit here — see alt-harvester for why the two
+      # cannot coexist.
       resources:
         limits:
           cpus: '4.0'
+          memory: 3G
         reservations:
           memory: 2G
           cpus: '2.0'
@@ -359,7 +374,6 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
-    tty: true
     labels:
       - rask.group=alt-backend
     logging:

--- a/compose/workers.yaml
+++ b/compose/workers.yaml
@@ -48,7 +48,6 @@ services:
     restart: always
     networks:
       - alt-network
-    tty: true
     labels:
       - rask.group=pre-processor-sidecar
     logging:
@@ -133,7 +132,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-    tty: true
     labels:
       - rask.group=search-indexer
     logging:
@@ -213,7 +211,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-    tty: true
     restart: unless-stopped
     labels:
       - rask.group=tag-generator

--- a/docker/postgres/postgresql-rag.conf
+++ b/docker/postgres/postgresql-rag.conf
@@ -13,7 +13,12 @@ shared_buffers = 128MB
 # ログ設定
 log_connections = on
 log_disconnections = on
-log_statement = 'all'
+# rag-db は記事本文とそのチャンクを持つ。'all' はそれをリテラルごとコンテナログに
+# 落とし、rask forwarder 群が /var/lib/docker/containers から読める。db / kratos-db
+# 側 (postgresql.conf) と同じ判断で、スキーマ変更の追跡だけ残す。遅いクエリの
+# 可視性は次行の閾値で担保する（閾値超過分は文面が出るので完全な遮断ではない）。
+log_statement = 'ddl'
+log_min_duration_statement = 200
 
 # Idle-in-transaction timeout. The index upsert now embeds BEFORE opening
 # its transaction, so no code path holds a transaction across network I/O

--- a/docker/postgres/postgresql-recap.conf
+++ b/docker/postgres/postgresql-recap.conf
@@ -14,7 +14,12 @@ shared_buffers = 128MB
 # ログ設定
 log_connections = on
 log_disconnections = on
-log_statement = 'all'
+# recap-db は recap 本文と記事テキストを持つ。'all' はそれをリテラルごとコンテナログに
+# 落とし、rask forwarder 群が /var/lib/docker/containers から読める。db / kratos-db
+# 側 (postgresql.conf) と同じ判断で、スキーマ変更の追跡だけ残す。遅いクエリの
+# 可視性は次行の閾値で担保する（閾値超過分は文面が出るので完全な遮断ではない）。
+log_statement = 'ddl'
+log_min_duration_statement = 200
 
 # アイドルトランザクションタイムアウト（30秒）
 # トランザクションがアイドル状態のまま30秒経過すると自動終了

--- a/docker/postgres/postgresql.conf
+++ b/docker/postgres/postgresql.conf
@@ -16,7 +16,12 @@ pg_stat_statements.track = 'all'
 # ログ設定
 log_connections = on
 log_disconnections = on
-log_statement = 'all'
+# このファイルは db と kratos-db の両方に config_file としてマウントされる。
+# 'all' は Kratos の identity traits（メールアドレス）や記事本文をリテラルごと
+# コンテナログに落とし、rask forwarder 群が /var/lib/docker/containers から読める。
+# スキーマ変更の追跡だけ残し、遅いクエリの可視性は下の 200ms 閾値で担保する
+# （閾値超過分は文面が出るので、これは削減であって完全な遮断ではない）。
+log_statement = 'ddl'
 log_min_duration_statement = 200
 
 # アイドルトランザクションタイムアウト（5分）

--- a/docs/services/auth-hub.md
+++ b/docs/services/auth-hub.md
@@ -97,12 +97,11 @@ flowchart LR
 ### /session (Session Info + Backend Token)
 - セッション検証 + バックエンドトークン (JWT) を一括発行
 - `X-Alt-Backend-Token` レスポンスヘッダーに JWT を含む
-- `X-Alt-Shared-Secret` レスポンスヘッダー (レガシー互換、`AUTH_SHARED_SECRET` 設定時のみ)
 - BFF (alt-butterfly-facade) がバックエンドへのリクエスト時に使用
 
 ### /internal/system-user
 - 内部サービス間通信用エンドポイント
-- `AUTH_SHARED_SECRET` が設定されている場合、`X-Internal-Auth` ヘッダーによる認証が必要
+- `INTERNAL_AUTH_SECRET` (必須) を `X-Internal-Auth` ヘッダーで提示する。未設定なら auth-hub は起動時に exit 1 するので、認証が無効な状態は存在しない
 - Kratos Admin API から最初の identity ID を取得して返却
 - レスポンス: `{"user_id": "<kratos-identity-id>"}`
 
@@ -130,8 +129,8 @@ flowchart LR
 | `PORT` | 8888 | サービスポート |
 | `CACHE_TTL` | 5m | セッションキャッシュ TTL |
 | `CSRF_SECRET` | (required) | CSRF シークレット (最低 32 文字, `_FILE` サフィックス対応) |
-| `AUTH_SHARED_SECRET` | (optional) | 内部 API 認証用共有シークレット (`_FILE` サフィックス対応) |
 | `BACKEND_TOKEN_SECRET` | (required) | JWT 署名シークレット (最低 32 文字, `_FILE` サフィックス対応) |
+| `INTERNAL_AUTH_SECRET` | (required) | `/internal` 共有ベアラ (最低 32 文字, `BACKEND_TOKEN_SECRET` と別値必須, `_FILE` サフィックス対応) |
 | `BACKEND_TOKEN_ISSUER` | auth-hub | JWT issuer claim |
 | `BACKEND_TOKEN_AUDIENCE` | alt-backend | JWT audience claim |
 | `BACKEND_TOKEN_TTL` | 5m | JWT 有効期限 |
@@ -142,6 +141,12 @@ flowchart LR
 | `DEPLOYMENT_ENV` | development | デプロイ環境 (OTel リソース) |
 
 > **Note:** すべてのシークレット変数は `_FILE` サフィックスでファイルパス指定が可能 (Docker secrets 対応)。例: `CSRF_SECRET_FILE=/run/secrets/csrf_secret`
+>
+> `INTERNAL_AUTH_SECRET` には専用の docker secret `auth_hub_internal_secret` を用意してある
+> (`INTERNAL_AUTH_SECRET_FILE=/run/secrets/auth_hub_internal_secret`)。
+> `BACKEND_TOKEN_SECRET` と同じ値を入れると起動時に exit 1 する — `/internal` ベアラは
+> 平文の `X-Internal-Auth` ヘッダで流れ、アクセスログと OTel span attribute に残るため、
+> JWT 署名鍵をそこに出さないことが分離の目的。呼び出し側 (alt-data-hub) にも同じ値を渡す。
 
 ## Rate Limiting
 

--- a/e2e/fixtures/staging-secrets/README.md
+++ b/e2e/fixtures/staging-secrets/README.md
@@ -14,10 +14,16 @@ against it.
 | File | Used by | Role |
 |------|---------|------|
 | `meili_master_key.txt` | `search-indexer` profile | Meilisearch admin key |
-| `alt_backend_token_secret.txt` | `alt-backend`, `auth-hub` profiles | HS256 secret. In the `alt-backend` profile it validates the pre-minted JWT at `e2e/fixtures/alt-backend/test-jwt.txt`; in the `auth-hub` profile it is the signing key for the `X-Alt-Backend-Token` JWT that `/validate` issues and the shared secret that the `/internal/system-user` `X-Internal-Auth` middleware compares against (constant-time). |
+| `alt_backend_token_secret.txt` | `alt-backend`, `auth-hub` profiles | HS256 secret. In the `alt-backend` profile it validates the pre-minted JWT at `e2e/fixtures/alt-backend/test-jwt.txt`; in the `auth-hub` profile it is the signing key for the `X-Alt-Backend-Token` JWT that `/validate` issues, and only that — `/internal/system-user` keys on `INTERNAL_AUTH_SECRET` instead, and auth-hub refuses to start when the two are equal. |
 | `auth_hub_csrf_secret.txt` | `auth-hub` profile | HMAC-SHA256 secret used by auth-hub's CSRF token generator. Must be ≥ 32 bytes. |
 | `auth_hub_kratos_cookie_secret.txt` | `auth-hub` profile | Kratos `secrets.cookie[0]` — HMAC key over `ory_kratos_session` cookies in staging. |
 | `auth_hub_kratos_cipher_secret.txt` | `auth-hub` profile | Kratos `secrets.cipher[0]` — exactly 32 bytes (xchacha20-poly1305 requirement). |
+
+The `/internal/system-user` shared bearer has no file here: `INTERNAL_AUTH_SECRET`
+is set inline on both the `auth-hub` and `alt-data-hub` services in
+`compose.staging.yaml`, and `e2e/playwright/auth-hub/run.sh` defaults to the same
+literal. Those three must be changed together — auth-hub answers 403 to every
+`/internal` call the moment they drift.
 
 Other staging services inline their test passwords as plain env vars
 (e.g. `knowledge-sovereign-db` uses `POSTGRES_PASSWORD`) because the

--- a/e2e/playwright/alt-backend/tests/augur-rag.spec.ts
+++ b/e2e/playwright/alt-backend/tests/augur-rag.spec.ts
@@ -43,44 +43,13 @@ test.describe("GET /v1/rag/context", () => {
 });
 
 /**
- * ATTENTION — this endpoint pair is **not authenticated**.
- *
- * `RegisterAugurRoutes(e, v1, container)` registers
- * `g.GET("/rag/context", …)` on the bare `/v1` group and
- * `e.POST("/sse/v1/rag/answer", …)` on the root Echo instance. Neither carries
- * `authMiddleware.RequireAuth()`, unlike every other `/v1` group in
- * routes.go — so both reach the RAG orchestrator for any caller, with no JWT,
- * no tenant scoping, and no admin check.
- *
- * The Hurl suite sent a JWT on both calls and never probed the negative, so
- * this was invisible. The tests below pin the *current* behaviour rather than
- * the desired one, deliberately: changing who may call a live endpoint is a
- * product decision, not a test-suite decision. When the routes are moved under
- * RequireAuth, these two tests fail — which is the point. Delete them then and
- * add the two lines to the PROTECTED_ROUTES table in tests/auth.spec.ts.
+ * Both endpoints are authenticated, so both anonymous probes that used to sit
+ * here have moved into tests/auth.spec.ts's JWT boundary, where every other
+ * `/v1` group's 401 lives. They pinned the gap this file found — the pair was
+ * the only user-facing surface registered without `RequireAuth()` — and said
+ * to move them the day that changed; augur_handler.go now puts `/rag` behind
+ * a guarded group and hangs RequireAuth off the SSE route directly.
  */
-test.describe("augur authentication gap (pinned, not endorsed)", () => {
-	test("GET /v1/rag/context answers without a JWT", async ({ restAnon }) => {
-		const response = await restAnon.get("/v1/rag/context?q=ai");
-		expect(
-			response.status(),
-			"if this is now 401, the augur routes were put behind RequireAuth — " +
-				"move them into tests/auth.spec.ts's PROTECTED_ROUTES and delete this test",
-		).not.toBe(401);
-	});
-
-	test("POST /sse/v1/rag/answer answers without a JWT", async ({ restAnon, csrf }) => {
-		const response = await restAnon.post("/sse/v1/rag/answer", {
-			headers: { "Content-Type": "application/json", "X-CSRF-Token": csrf },
-			data: { messages: [{ role: "user", content: "hello" }], stream: false },
-		});
-		expect(
-			response.status(),
-			"if this is now 401, the augur routes were put behind RequireAuth — " +
-				"move them into tests/auth.spec.ts's PROTECTED_ROUTES and delete this test",
-		).not.toBe(401);
-	});
-});
 
 test.describe("POST /sse/v1/rag/answer", () => {
 	test("a non-streaming answer returns 200 with an empty answer", async ({ rest, csrf }) => {

--- a/e2e/playwright/alt-backend/tests/auth.spec.ts
+++ b/e2e/playwright/alt-backend/tests/auth.spec.ts
@@ -28,9 +28,10 @@ const PROTECTED_ROUTES = [
 	{ group: "images (proxy)", path: `/v1/images/proxy/invalidsig/${encodeURIComponent("http://stub.invalid/x.png")}` },
 	{ group: "admin (dashboard)", path: "/v1/dashboard/metrics" },
 	{ group: "admin (scraping-domains)", path: "/v1/admin/scraping-domains" },
-	// The augur group is deliberately absent from this table — it is not
-	// authenticated at all. See tests/augur-rag.spec.ts, which pins that gap
-	// explicitly rather than letting its absence here read as an oversight.
+	{ group: "augur (rag context)", path: "/v1/rag/context?q=ai" },
+	// The augur pair's other half, `/sse/v1/rag/answer`, cannot join this table:
+	// it is POST-only, so a GET is answered 405 by Echo's router before any
+	// route middleware runs. It has its own test below.
 ] as const;
 
 test.describe("JWT auth boundary", () => {
@@ -39,6 +40,23 @@ test.describe("JWT auth boundary", () => {
 			await expectStatus(await restAnon.get(route.path), 401);
 		});
 	}
+
+	test("augur (sse answer): no token → 401", async ({ restAnon, csrf }) => {
+		// The half of the augur pair that is mounted on the Echo root rather than
+		// on the /v1 group — augur_handler.go keeps the `/sse/` prefix because the
+		// BodyLimit, Timeout and Gzip skippers in routes.go all match on it — so
+		// it takes RequireAuth as per-route middleware and is the one route here
+		// whose guard is not inherited from a Group.
+		//
+		// The CSRF token is sent even though this is an auth test: CSRFMiddleware
+		// is a global `e.Use` and therefore runs first, so without one the answer
+		// is 403 and says nothing about JWT.
+		const response = await restAnon.post("/sse/v1/rag/answer", {
+			headers: { "Content-Type": "application/json", "X-CSRF-Token": csrf },
+			data: { messages: [{ role: "user", content: "hello" }], stream: false },
+		});
+		await expectStatus(response, 401);
+	});
 
 	test("malformed token → 401", async ({ restAnon }) => {
 		const response = await restAnon.get("/v1/feeds/fetch/list", {

--- a/e2e/playwright/auth-hub/run.sh
+++ b/e2e/playwright/auth-hub/run.sh
@@ -26,10 +26,16 @@
 #     because the /internal limiter is 10 req/min burst 3. Nothing is shared
 #     between tests now, and each test carries its own synthetic client
 #     address, so the suite runs `fullyParallel`.
-#   * `--secret` redaction for the session cookie and the shared secret. The
-#     secret arrives here as a *path*, is read inside the test container, and
+#   * `--secret` redaction for the session cookie and the HS256 signing key.
+#     That key arrives here as a *path*, is read inside the test container, and
 #     never reaches a compose slice, `docker inspect`, or a CI env dump;
 #     `suite.sh`'s `redact_secrets` scrubs the log dump on failure.
+#     INTERNAL_AUTH_SECRET below is the one exception: it is exported as a
+#     value, so it does reach the container env and a CI env dump, and
+#     `redact_secrets` (JWS and PEM forms only) will not scrub it. That is
+#     acceptable only because the literal is already committed in plaintext in
+#     compose.staging.yaml — a path would buy nothing. Never give a real secret
+#     this treatment.
 #
 # Environment overrides beyond the shared ones (see _lib/suite.sh):
 #   BASE_URL           auth-hub REST URL as seen from the test container
@@ -60,15 +66,21 @@ suite_endpoint MTLS_URL          "https://auth-hub:9443"
 # Secrets and fixtures arrive as paths. The repo is bind-mounted into the test
 # container at the same absolute path, so these resolve unchanged inside it.
 #
-# alt_backend_token_secret does double duty, exactly as it does in the service:
-# compose mounts it as BACKEND_TOKEN_SECRET_FILE (the HS256 signing key) and
-# main.go passes the same value to wireInternalAuth (the X-Internal-Auth shared
-# secret). The suite needs it for both — to verify the JWT signature the way
-# alt-backend will, and to authenticate against /internal.
+# alt_backend_token_secret is the HS256 signing key and only that; the suite
+# needs it to verify the JWT signature the way alt-backend will. It no longer
+# opens /internal — main.go keys that group on INTERNAL_AUTH_SECRET, and
+# auth-hub refuses to start when the two are the same value.
 suite_endpoint BACKEND_TOKEN_SECRET_FILE \
   "$ROOT/e2e/fixtures/staging-secrets/alt_backend_token_secret.txt"
 suite_endpoint IDENTITY_EMAIL_FILE    "$ROOT/e2e/fixtures/auth-hub/test-identity-email.txt"
 suite_endpoint IDENTITY_PASSWORD_FILE "$ROOT/e2e/fixtures/auth-hub/test-identity-password.txt"
+
+# The /internal shared bearer — the one secret that arrives as a value rather
+# than a path, because compose.staging.yaml sets it inline on both auth-hub and
+# alt-data-hub. The default here has to be that same literal, or every
+# /internal call in the suite gets 403 instead of 200.
+suite_endpoint INTERNAL_AUTH_SECRET \
+  "staging-fixture-internal-auth-secret-not-a-real-key"
 
 # Mirrors of the three BACKEND_TOKEN_* values compose.staging.yaml configures
 # auth-hub with. They live here rather than as constants in the suite so that

--- a/e2e/playwright/auth-hub/src/env.ts
+++ b/e2e/playwright/auth-hub/src/env.ts
@@ -38,18 +38,33 @@ export const env = {
 	mtlsURL: requiredEnv("MTLS_URL"),
 
 	/**
-	 * The HS256 secret auth-hub signs backend JWTs with, and the shared secret
-	 * the /internal middleware compares `X-Internal-Auth` against.
+	 * The HS256 secret auth-hub signs backend JWTs with — and nothing else.
 	 *
-	 * One value, two jobs: compose.staging.yaml mounts
-	 * `alt_backend_token_secret` as both `BACKEND_TOKEN_SECRET_FILE` (used by
-	 * `infrastructure/token/jwt.go`) and — via `wireInternalAuth(cfg.
-	 * BackendTokenSecret)` in main.go — as the internal shared secret.
+	 * It used to do two jobs: `main.go` keyed the /internal group on this same
+	 * value. It no longer does (`wireInternalAuth(cfg)` reads
+	 * `INTERNAL_AUTH_SECRET`), because the /internal bearer crosses the network
+	 * in a plaintext header and lands in nginx access logs and OTel span
+	 * attributes, which is no place for a signing key. auth-hub now refuses to
+	 * start when the two are equal, so sending this one to /internal is a 403.
+	 * See `internalAuthSecret` below.
 	 *
 	 * Arrives as a path rather than a value so it never lands in `docker
 	 * inspect` output, a rendered compose slice, or a CI environment dump.
 	 */
 	backendTokenSecret: requiredSecretFile("BACKEND_TOKEN_SECRET_FILE"),
+
+	/**
+	 * The shared bearer auth-hub's /internal group compares `X-Internal-Auth`
+	 * against (`middleware/internal_auth.go`, keyed on `INTERNAL_AUTH_SECRET`).
+	 *
+	 * A plain value rather than a path, unlike every other secret here, because
+	 * compose.staging.yaml sets it inline — it is a throwaway staging literal
+	 * that both auth-hub and alt-data-hub carry, and one literal is what keeps
+	 * the three in step. Reading it from the environment rather than hard-coding
+	 * it means a changed compose slice fails as a named 403 here instead of
+	 * passing against a secret nothing uses.
+	 */
+	internalAuthSecret: requiredEnv("INTERNAL_AUTH_SECRET"),
 
 	/**
 	 * The Kratos identity fixtures the Hurl suite used verbatim.

--- a/e2e/playwright/auth-hub/tests/internal.spec.ts
+++ b/e2e/playwright/auth-hub/tests/internal.spec.ts
@@ -36,7 +36,7 @@ import { echoErrorSchema, systemUserSchema } from "../src/schemas.js";
 
 /** A wrong secret of the same length as the real one — the timing-safe case. */
 function lengthMatchedWrongSecret(): string {
-	return "x".repeat(env.backendTokenSecret.length);
+	return "x".repeat(env.internalAuthSecret.length);
 }
 
 test.describe("internal system-user", () => {
@@ -46,7 +46,7 @@ test.describe("internal system-user", () => {
 	}) => {
 		const body = await expectJsonStatus(
 			await hub.get("/internal/system-user", {
-				headers: { "X-Internal-Auth": env.backendTokenSecret },
+				headers: { "X-Internal-Auth": env.internalAuthSecret },
 			}),
 			200,
 			// `strict()`: this is a service-to-service response guarded only by a
@@ -70,7 +70,7 @@ test.describe("internal system-user", () => {
 		// Two calls, not more: the /internal limiter is burst 3 (main.go:174) and
 		// runs before the auth middleware, so this test's private bucket has room
 		// for exactly three.
-		const headers = { "X-Internal-Auth": env.backendTokenSecret };
+		const headers = { "X-Internal-Auth": env.internalAuthSecret };
 		const first = await expectJsonStatus(
 			await hub.get("/internal/system-user", { headers }),
 			200,
@@ -160,7 +160,7 @@ test.describe("internal auth boundary", () => {
 		// correct shared secret — a 401 or 403 would mean the group middleware
 		// ran in an order this test does not model.
 		const response = await hub.post("/internal/system-user", {
-			headers: { "X-Internal-Auth": env.backendTokenSecret },
+			headers: { "X-Internal-Auth": env.internalAuthSecret },
 		});
 		await expectStatusIn(response, [404, 405]);
 	});
@@ -174,7 +174,7 @@ test.describe("internal auth boundary", () => {
 		// probe could just be a middleware ordering artefact.
 		await expectStatus(
 			await hub.get("/internal/identities", {
-				headers: { "X-Internal-Auth": env.backendTokenSecret },
+				headers: { "X-Internal-Auth": env.internalAuthSecret },
 			}),
 			404,
 		);

--- a/for-development/start-dev.sh
+++ b/for-development/start-dev.sh
@@ -22,11 +22,18 @@ if [ ! -d "secrets" ]; then
     # Note: generate-secrets.sh writes to current directory (./secrets) which is PROJECT_ROOT now.
 fi
 
-# Ensure kratos.yml exists from template
-if [ ! -f "kratos/kratos.yml" ]; then
+# Regenerate kratos.yml from the template on every run. kratos.yml is a derived,
+# gitignored file, but it used to be created once and never refreshed — so a
+# template change (password policy, HIBP, session lifespan) silently never
+# reached any host that had already started the stack. The dev seds below are
+# idempotent and re-applied straight after, so regenerating costs nothing.
+if [ -f "kratos/kratos.yml" ]; then
+    cp kratos/kratos.yml kratos/kratos.yml.bak
+    echo "Regenerating kratos.yml from template (previous copy kept as kratos.yml.bak)..."
+else
     echo "Creating kratos.yml from template..."
-    cp kratos/kratos_template.yml kratos/kratos.yml
 fi
+cp kratos/kratos_template.yml kratos/kratos.yml
 
 # Ensure kratos.yml has correct base_url for dev
 if [ -f "kratos/kratos.yml" ]; then

--- a/knowledge-sovereign/app/driver/sovereign_db/read_infra.go
+++ b/knowledge-sovereign/app/driver/sovereign_db/read_infra.go
@@ -328,16 +328,69 @@ func (r *Repository) AdvanceProjectionCheckpointIfUnchanged(
 	return tag.RowsAffected() == 1, nil
 }
 
-// GetProjectionLag returns how many events the farthest-behind projector
-// checkpoint trails the knowledge_events tip (max(event_seq) - min(checkpoint)).
+// projectionLagQuery measures the lag as a duration, because that is what the
+// field it fills means: GetProjectionLagResponse.lag_seconds, which alt-backend
+// multiplies by time.Second and publishes as alt_home_projector_lag_seconds,
+// alerted on at > 600 (ticket) and > 1800 (page).
+//
+// The duration is the age of the oldest event no live projector has folded yet
+// — the frontier is the minimum checkpoint, and the first event past it is the
+// one that has been waiting longest. A caught-up projection has no such event
+// and so has no lag; the COALESCE turns that into 0 rather than a NULL the
+// float64 scan destination could not take. GREATEST clamps a future-dated event
+// to 0, since alt-backend reads a negative lag as its "unavailable" sentinel.
+//
+// The frontier is bound to the roster rather than taken over the whole
+// checkpoint table. Retiring a projection drops its read models but leaves its
+// checkpoint row behind (migration 00028 for the Knowledge Loop, whose
+// `knowledge-loop-projector` and `surface_planner_v2` rows the loop runbook
+// still documents), and a frozen row is the permanent minimum: the reported lag
+// would climb forever while every running projector stayed current. LEFT JOIN,
+// not inner: a projector that has never run has no row at all, and that is the
+// worst lag there is, not an absence to skip.
+//
+// The frontier probe is an ordered LIMIT 1 over idx_knowledge_events_seq rather
+// than an aggregate, for the reason spelled out on
+// knowledgeEventLastOccurrenceAgesQuery — a MergeAppend across the partitions
+// stopped after the first row, instead of a scan that evicts the read path's
+// shared_buffers pages on every sample.
+const projectionLagQuery = `
+WITH frontier AS (
+	SELECT COALESCE(MIN(COALESCE(c.last_event_seq, 0)), 0) AS seq
+	FROM unnest($1::text[]) AS p(projector_name)
+	LEFT JOIN knowledge_projection_checkpoints c USING (projector_name)
+)
+SELECT COALESCE((
+	SELECT GREATEST(EXTRACT(EPOCH FROM (now() - ke.occurred_at)), 0)
+	FROM knowledge_events ke
+	WHERE ke.event_seq > (SELECT seq FROM frontier)
+	ORDER BY ke.event_seq
+	LIMIT 1
+), 0)::float8`
+
+// liveProjectorNames is the checkpoint roster the lag gauge measures: the
+// projectors this process actually runs. It is derived from the rebuild
+// allowlist because those targets already carry the checkpoint key of each
+// in-process projector, so a projector can never be added to one list and
+// forgotten in the other.
+func liveProjectorNames() []string {
+	targets := RebuildTargets()
+	names := make([]string, 0, len(targets))
+	for _, t := range targets {
+		names = append(names, t.ProjectorName())
+	}
+	return names
+}
+
+// GetProjectionLag returns how many SECONDS the farthest-behind live projector
+// is behind the event log — the age of the oldest event it has not folded yet,
+// 0 when it is caught up. Seconds, not events: the value is forwarded verbatim
+// as lag_seconds and alerted on in seconds, and the two units do not correlate
+// (a healthy projector 700 events behind would page, an hour-dead one 100
+// events behind would stay silent).
 func (r *Repository) GetProjectionLag(ctx context.Context) (float64, error) {
-	query := `SELECT GREATEST(
-		(SELECT COALESCE(MAX(event_seq), 0) FROM knowledge_events) -
-		(SELECT COALESCE(MIN(last_event_seq), 0) FROM knowledge_projection_checkpoints),
-		0
-	)::float8`
 	var lag float64
-	if err := r.pool.QueryRow(ctx, query).Scan(&lag); err != nil {
+	if err := r.pool.QueryRow(ctx, projectionLagQuery, liveProjectorNames()).Scan(&lag); err != nil {
 		return 0, fmt.Errorf("GetProjectionLag: %w", err)
 	}
 	return lag, nil

--- a/knowledge-sovereign/app/driver/sovereign_db/read_infra_lag_test.go
+++ b/knowledge-sovereign/app/driver/sovereign_db/read_infra_lag_test.go
@@ -1,0 +1,112 @@
+package sovereign_db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetProjectionLag feeds a field the wire declares as seconds
+// (GetProjectionLagResponse.lag_seconds, double), which alt-backend converts
+// straight into a time.Duration of seconds and alerts on at
+// alt_home_projector_lag_seconds > 600 / > 1800. So the query has to return a
+// duration, not a count of events: max(event_seq) - min(checkpoint) is an event
+// backlog, and the two units do not even correlate — a healthy projector 700
+// events behind pages, an hour-dead one 100 events behind stays silent.
+//
+// The duration that means "the projection is behind" is how long the oldest
+// event nobody has folded yet has been waiting, so the query must reach
+// knowledge_events.occurred_at and subtract it from now().
+func TestGetProjectionLag_ReturnsSecondsNotAnEventCount(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	_, err := repo.GetProjectionLag(context.Background())
+	require.NoError(t, err)
+	require.Len(t, mock.queryRowCalls, 1)
+
+	sql := mock.queryRowCalls[0].SQL
+	assert.Contains(t, sql, "EXTRACT(EPOCH",
+		"lag_seconds must be a wall-clock duration; a bare sequence subtraction reports events in a field alerted on as seconds")
+	assert.Contains(t, sql, "occurred_at",
+		"the duration is measured from the oldest unprojected event's occurred_at")
+	assert.NotContains(t, sql, "MAX(event_seq)",
+		"max(event_seq) - min(checkpoint) is the event-count form this field must never carry again")
+}
+
+// The MIN over the checkpoint table is taken across every row it finds, and
+// retired projectors keep their rows: migration 00028 dropped the Knowledge Loop
+// read models but not the `knowledge-loop-projector` / `surface_planner_v2`
+// checkpoints the loop runbook documents. A frozen row like that is the
+// permanent minimum, so the reported lag grows forever no matter how current the
+// projectors that are actually running are.
+//
+// Scoping the MIN to the in-process projector roster is what keeps the gauge
+// describing live projectors. Binding the roster (rather than filtering on a
+// name pattern) also means retiring a projector is a one-line registry edit.
+func TestGetProjectionLag_MeasuresOnlyTheProjectorsThatAreRunning(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	_, err := repo.GetProjectionLag(context.Background())
+	require.NoError(t, err)
+	require.Len(t, mock.queryRowCalls, 1)
+
+	call := mock.queryRowCalls[0]
+	require.Len(t, call.Args, 1, "the live projector roster must be bound, or the MIN spans retired checkpoints")
+	names, ok := call.Args[0].([]string)
+	require.True(t, ok, "the roster is bound as a text[]")
+
+	want := []string{}
+	for _, target := range RebuildTargets() {
+		want = append(want, target.ProjectorName())
+	}
+	assert.ElementsMatch(t, want, names,
+		"the roster must be the in-process projectors, so a retired projector's frozen checkpoint cannot pin the minimum")
+
+	assert.Contains(t, call.SQL, "LEFT JOIN knowledge_projection_checkpoints",
+		"a projector that has never run has no row at all; an inner join would drop it from the MIN and hide the worst lag there is")
+}
+
+// The scanned value is the answer, in seconds, verbatim: the RPC forwards it to
+// alt-backend, which multiplies by time.Second. Anything applied on top here
+// would be a second unit conversion nobody downstream knows about.
+func TestGetProjectionLag_ForwardsTheScannedSecondsVerbatim(t *testing.T) {
+	mock := &mockPgx{}
+	mock.queryRowFunc = func(_ context.Context, _ string, _ ...interface{}) pgx.Row {
+		return &mockRow{scanFunc: func(dest ...interface{}) error {
+			require.Len(t, dest, 1)
+			seconds, ok := dest[0].(*float64)
+			require.True(t, ok, "lag is scanned as float8 seconds")
+			*seconds = 742.5
+			return nil
+		}}
+	}
+	repo := &Repository{pool: mock}
+
+	lag, err := repo.GetProjectionLag(context.Background())
+	require.NoError(t, err)
+	assert.InDelta(t, 742.5, lag, 0.0001)
+}
+
+// A caught-up projection has no unprojected event to measure, and the answer
+// then is 0 seconds rather than NULL — the scan destination is a plain float64,
+// so a NULL would fail the whole health read instead of reporting "no lag".
+func TestGetProjectionLag_CaughtUpProjectionIsZeroNotNull(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	_, err := repo.GetProjectionLag(context.Background())
+	require.NoError(t, err)
+	require.Len(t, mock.queryRowCalls, 1)
+
+	sql := mock.queryRowCalls[0].SQL
+	assert.True(t, strings.Contains(sql, "COALESCE"),
+		"the no-unprojected-event case must resolve to 0, not NULL, or a healthy projection breaks the scan")
+	assert.Contains(t, sql, "GREATEST",
+		"a future-dated event must not report negative lag; alt-backend reads negatives as its unavailable sentinel")
+}

--- a/knowledge-sovereign/app/driver/sovereign_db/repository.go
+++ b/knowledge-sovereign/app/driver/sovereign_db/repository.go
@@ -313,28 +313,57 @@ func (r *Repository) ClearSupersedeState(ctx context.Context, payload json.RawMe
 // A naive unconditional `col = col + delta` double-counts on an at-least-once
 // resend or a full reprojection replay of the same event.
 //
-// Guard: `digest.UpdatedAt` is always the source event's OccurredAt (never
-// wall-clock — see projectArticleCreated et al.), which is stable and
-// (for a single user's own event stream) strictly increasing per distinct
-// event. The WHERE clause on the UPDATE only applies the delta when the
-// incoming event is strictly newer than the last one already folded in;
-// replaying the identical event (same OccurredAt) becomes a no-op instead
-// of a second addition.
+// Guard: the fold's own knowledge_events.event_seq, carried as
+// `last_event_seq`. The WHERE clause on the UPDATE only applies the delta
+// when the incoming event sits strictly above the highest event_seq already
+// folded into the row, so replaying an event the row has already seen is a
+// no-op instead of a second addition.
+//
+// It deliberately is *not* guarded on updated_at. updated_at is the source
+// event's OccurredAt, and OccurredAt is stamped with time.Now() by whichever
+// producer emitted the event before the append RPC — six-plus independent
+// producers, six-plus independent clocks — while the projector folds in
+// event_seq order. When the two orders disagree for the same user and day,
+// a wall-clock guard throws away the whole DO UPDATE of the older-looking
+// event, counter deltas included, and TodayBar stays permanently short.
+// event_seq is monotonic in exactly the order the fold runs, so it is the
+// only discriminator that means "already folded" rather than "another
+// machine's clock is ahead". Same role last_event_seq plays in
+// knowledge_projection_checkpoints.
 func (r *Repository) UpsertTodayDigest(ctx context.Context, payload json.RawMessage) error {
 	var digest struct {
-		UserID                uuid.UUID `json:"user_id"`
-		DigestDate            string    `json:"digest_date"`
-		NewArticles           int       `json:"new_articles"`
-		SummarizedArticles    int       `json:"summarized_articles"`
-		UnsummarizedArticles  int       `json:"unsummarized_articles"`
-		TopTags               []string  `json:"top_tags"`
-		PulseRefs             []string  `json:"pulse_refs"`
-		UpdatedAt             time.Time `json:"updated_at"`
-		WeeklyRecapAvailable  bool      `json:"weekly_recap_available"`
-		EveningPulseAvailable bool      `json:"evening_pulse_available"`
+		UserID               uuid.UUID `json:"user_id"`
+		DigestDate           string    `json:"digest_date"`
+		NewArticles          int       `json:"new_articles"`
+		SummarizedArticles   int       `json:"summarized_articles"`
+		UnsummarizedArticles int       `json:"unsummarized_articles"`
+		TopTags              []string  `json:"top_tags"`
+		PulseRefs            []string  `json:"pulse_refs"`
+		UpdatedAt            time.Time `json:"updated_at"`
+		// LastEventSeq is a pointer so a payload that omits the key
+		// entirely (nil) can be told apart from one that sends an
+		// explicit 0 — the two need different diagnostics, see below.
+		LastEventSeq          *int64 `json:"last_event_seq"`
+		WeeklyRecapAvailable  bool   `json:"weekly_recap_available"`
+		EveningPulseAvailable bool   `json:"evening_pulse_available"`
 	}
 	if err := json.Unmarshal(payload, &digest); err != nil {
 		return fmt.Errorf("UpsertTodayDigest: unmarshal: %w", err)
+	}
+
+	// last_event_seq must be present and identify a real event. A payload
+	// that omits the key comes from a producer built against the older
+	// schema; silently falling back to the wall-clock guard would restore
+	// the very defect this column exists to close, with nothing anywhere
+	// to say so (Alt Rule 8: no silent fallback for an unwired write path).
+	// knowledge_events.event_seq is BIGSERIAL, hence always >= 1: a zero is
+	// the Go/JSON zero value leaking through, and it would tie or lose
+	// against every stored value and strand the row forever.
+	if digest.LastEventSeq == nil {
+		return fmt.Errorf("UpsertTodayDigest: last_event_seq is required")
+	}
+	if *digest.LastEventSeq <= 0 {
+		return fmt.Errorf("UpsertTodayDigest: last_event_seq must be a positive event_seq, got %d", *digest.LastEventSeq)
 	}
 
 	topTags := digest.TopTags
@@ -355,21 +384,32 @@ func (r *Repository) UpsertTodayDigest(ctx context.Context, payload json.RawMess
 		return fmt.Errorf("UpsertTodayDigest: marshal pulse_refs: %w", err)
 	}
 
+	// $5 (the unsummarized_articles delta) is the one signed counter:
+	// SummaryVersionCreated contributes -1. The floor has to sit on the
+	// INSERT operand too, not only in the ON CONFLICT branch — a midnight
+	// batch summarizing yesterday's articles makes that -1 the first digest
+	// write of the new day, and the plain INSERT path would store it as-is
+	// (the column has no CHECK and GetTodayDigest returns it verbatim).
+	// The conflict branch then has to read the delta back from the bare
+	// parameter rather than EXCLUDED: EXCLUDED is the row *after* the VALUES
+	// expressions are evaluated, so it carries the floored 0 and the
+	// decrement of an existing row would silently become a no-op.
 	query := `INSERT INTO today_digest_view
 		(user_id, digest_date, new_articles, summarized_articles,
 		 unsummarized_articles, top_tags_json, pulse_refs_json, updated_at,
-		 weekly_recap_available, evening_pulse_available)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		 weekly_recap_available, evening_pulse_available, last_event_seq)
+		VALUES ($1, $2, $3, $4, GREATEST(0, $5), $6, $7, $8, $9, $10, $11)
 		ON CONFLICT (user_id, digest_date) DO UPDATE SET
 		 new_articles = today_digest_view.new_articles + EXCLUDED.new_articles,
 		 summarized_articles = today_digest_view.summarized_articles + EXCLUDED.summarized_articles,
-		 unsummarized_articles = GREATEST(0, today_digest_view.unsummarized_articles + EXCLUDED.unsummarized_articles),
+		 unsummarized_articles = GREATEST(0, today_digest_view.unsummarized_articles + $5),
 		 top_tags_json = COALESCE(NULLIF(EXCLUDED.top_tags_json, '[]'::jsonb), today_digest_view.top_tags_json),
 		 pulse_refs_json = COALESCE(NULLIF(EXCLUDED.pulse_refs_json, '[]'::jsonb), today_digest_view.pulse_refs_json),
 		 updated_at = EXCLUDED.updated_at,
 		 weekly_recap_available = EXCLUDED.weekly_recap_available OR today_digest_view.weekly_recap_available,
-		 evening_pulse_available = EXCLUDED.evening_pulse_available OR today_digest_view.evening_pulse_available
-		WHERE EXCLUDED.updated_at > today_digest_view.updated_at`
+		 evening_pulse_available = EXCLUDED.evening_pulse_available OR today_digest_view.evening_pulse_available,
+		 last_event_seq = EXCLUDED.last_event_seq
+		WHERE EXCLUDED.last_event_seq > today_digest_view.last_event_seq`
 
 	_, err = r.pool.Exec(ctx, query,
 		digest.UserID, digest.DigestDate,
@@ -377,6 +417,7 @@ func (r *Repository) UpsertTodayDigest(ctx context.Context, payload json.RawMess
 		digest.UnsummarizedArticles, string(topTagsJSON), string(pulseRefsJSON),
 		digest.UpdatedAt,
 		digest.WeeklyRecapAvailable, digest.EveningPulseAvailable,
+		*digest.LastEventSeq,
 	)
 	if err != nil {
 		return fmt.Errorf("UpsertTodayDigest: %w", err)

--- a/knowledge-sovereign/app/driver/sovereign_db/repository_test.go
+++ b/knowledge-sovereign/app/driver/sovereign_db/repository_test.go
@@ -297,7 +297,8 @@ func TestUpsertTodayDigest_PreservesPulseRefsFromPayload(t *testing.T) {
 		"pulse_refs": ["cluster:42", "cluster:99"],
 		"updated_at": "2026-05-04T03:00:00Z",
 		"weekly_recap_available": true,
-		"evening_pulse_available": true
+		"evening_pulse_available": true,
+		"last_event_seq": 1201
 	}`)
 
 	require.NoError(t, repo.UpsertTodayDigest(context.Background(), payload))
@@ -331,7 +332,8 @@ func TestUpsertTodayDigest_UsesMergeSafeSQL(t *testing.T) {
 		"digest_date": "2026-05-04",
 		"top_tags": ["go"],
 		"pulse_refs": ["cluster:1"],
-		"updated_at": "2026-05-04T03:00:00Z"
+		"updated_at": "2026-05-04T03:00:00Z",
+		"last_event_seq": 1202
 	}`)
 	require.NoError(t, repo.UpsertTodayDigest(context.Background(), payload))
 	require.Len(t, mock.execCalls, 1)
@@ -361,10 +363,13 @@ func TestUpsertTodayDigest_UsesMergeSafeSQL(t *testing.T) {
 // new_articles/summarized_articles/unsummarized_articles are additive
 // deltas contributed per source event — an unconditional col = col + delta
 // double-counts on an at-least-once RPC resend or a full reprojection
-// replay of the same event. The fix guards the UPDATE with
-// EXCLUDED.updated_at > today_digest_view.updated_at: since updated_at is
-// always the source event's OccurredAt (never wall-clock), replaying the
-// identical event becomes a no-op.
+// replay of the same event. The UPDATE is therefore guarded on the fold's
+// own knowledge_events.event_seq: an event whose seq the row has already
+// absorbed is a no-op.
+//
+// The discriminator used to be EXCLUDED.updated_at, which is the event's
+// occurred_at and thus a producer wall clock; TestUpsertTodayDigest_
+// ReplayGuardOrdersByEventSeqNotWallClock covers why that lost increments.
 func TestUpsertTodayDigest_ReplayGuardPreventsDoubleCounting(t *testing.T) {
 	mock := &mockPgx{}
 	repo := &Repository{pool: mock}
@@ -373,13 +378,14 @@ func TestUpsertTodayDigest_ReplayGuardPreventsDoubleCounting(t *testing.T) {
 		"user_id": "11111111-1111-4111-8111-111111111111",
 		"digest_date": "2026-05-04",
 		"new_articles": 1,
-		"updated_at": "2026-05-04T03:00:00Z"
+		"updated_at": "2026-05-04T03:00:00Z",
+		"last_event_seq": 1203
 	}`)
 	require.NoError(t, repo.UpsertTodayDigest(context.Background(), payload))
 	require.Len(t, mock.execCalls, 1)
 	sql := mock.execCalls[0].SQL
 
-	assert.Contains(t, sql, "WHERE EXCLUDED.updated_at > today_digest_view.updated_at",
+	assert.Contains(t, sql, "WHERE EXCLUDED.last_event_seq > today_digest_view.last_event_seq",
 		"additive counters must be guarded by a strictly-newer-event check")
 }
 

--- a/knowledge-sovereign/app/driver/sovereign_db/repository_today_digest_test.go
+++ b/knowledge-sovereign/app/driver/sovereign_db/repository_today_digest_test.go
@@ -1,0 +1,144 @@
+package sovereign_db
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpsertTodayDigest_RequiresLastEventSeq pins the producer-wiring contract
+// for the replay guard. The guard can only mean "already folded" if it is
+// keyed on the log's own order; a payload that omits last_event_seq comes from
+// a producer that does not know about the field and must be told loudly rather
+// than silently fall back to a wall-clock comparison (Alt Rule 8: no silent
+// fallback for an unwired write path — same shape as score_op on
+// UpsertKnowledgeHomeItem).
+func TestUpsertTodayDigest_RequiresLastEventSeq(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	payload := json.RawMessage(`{
+		"user_id": "11111111-1111-4111-8111-111111111111",
+		"digest_date": "2026-05-04",
+		"new_articles": 1,
+		"updated_at": "2026-05-04T03:00:00Z"
+	}`)
+
+	err := repo.UpsertTodayDigest(context.Background(), payload)
+	require.Error(t, err, "a digest write with no last_event_seq must fail loudly, not fall back to the wall clock")
+	assert.Contains(t, err.Error(), "last_event_seq")
+	assert.Empty(t, mock.execCalls, "nothing may reach the database once the payload is rejected")
+}
+
+// TestUpsertTodayDigest_RejectsNonPositiveLastEventSeq guards the other half of
+// the same contract. knowledge_events.event_seq is BIGSERIAL, so it is always
+// >= 1; a zero (the Go/JSON zero value, and the column default carried by rows
+// written before the column existed) would tie or lose against every stored
+// value and quietly strand the row forever.
+func TestUpsertTodayDigest_RejectsNonPositiveLastEventSeq(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	payload := json.RawMessage(`{
+		"user_id": "11111111-1111-4111-8111-111111111111",
+		"digest_date": "2026-05-04",
+		"new_articles": 1,
+		"updated_at": "2026-05-04T03:00:00Z",
+		"last_event_seq": 0
+	}`)
+
+	err := repo.UpsertTodayDigest(context.Background(), payload)
+	require.Error(t, err, "event_seq 0 never identifies a real event and must be rejected")
+	assert.Contains(t, err.Error(), "last_event_seq")
+	assert.Empty(t, mock.execCalls)
+}
+
+// TestUpsertTodayDigest_ReplayGuardOrdersByEventSeqNotWallClock is the
+// structural guard for finding 056.
+//
+// updated_at is the source event's occurred_at, and occurred_at is stamped
+// with time.Now() by whichever producer emitted the event before the append
+// RPC — six-plus independent producers, six-plus independent clocks. The fold
+// order is event_seq. When the two disagree for the same user and day, an
+// `EXCLUDED.updated_at > today_digest_view.updated_at` guard throws away the
+// whole DO UPDATE of the older-looking event — its counter deltas included —
+// and TodayBar stays permanently one short. event_seq is monotonic in exactly
+// the order the projector folds, so it is the only discriminator that
+// distinguishes "already folded" from "another machine's clock is ahead".
+func TestUpsertTodayDigest_ReplayGuardOrdersByEventSeqNotWallClock(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	require.NoError(t, repo.UpsertTodayDigest(context.Background(), json.RawMessage(`{
+		"user_id": "11111111-1111-4111-8111-111111111111",
+		"digest_date": "2026-05-04",
+		"new_articles": 1,
+		"updated_at": "2026-05-04T03:00:00Z",
+		"last_event_seq": 4711
+	}`)))
+	require.Len(t, mock.execCalls, 1)
+	sql := mock.execCalls[0].SQL
+
+	assert.Contains(t, sql, "WHERE EXCLUDED.last_event_seq > today_digest_view.last_event_seq",
+		"the additive counters must be gated on the log's own order, not on a producer's clock")
+	assert.NotContains(t, sql, "EXCLUDED.updated_at > today_digest_view.updated_at",
+		"a wall-clock guard silently drops the increments of any event whose producer clock lags")
+	assert.Contains(t, sql, "last_event_seq = EXCLUDED.last_event_seq",
+		"the high-water mark must advance, otherwise every later event re-passes the guard")
+
+	require.Len(t, mock.execCalls[0].Args, 11, "last_event_seq must be bound as the 11th parameter")
+	assert.EqualValues(t, 4711, mock.execCalls[0].Args[10],
+		"last_event_seq must reach the statement as the payload's event_seq")
+}
+
+// TestUpsertTodayDigest_FirstWriteOfDayFloorsNegativeUnsummarized is the
+// structural guard for finding 057.
+//
+// unsummarized_articles is a signed delta: SummaryVersionCreated contributes
+// -1. GREATEST(0, ...) used to live only in the ON CONFLICT branch, so a
+// midnight batch summarising yesterday's articles — where the -1 is the first
+// digest write of the new day — took the plain INSERT path and stored -1.
+// The column has no CHECK and GetTodayDigest returns it verbatim, so that day
+// reads one short for good.
+//
+// The floor therefore belongs on the INSERT operand, and the ON CONFLICT
+// branch must then read the delta from the bare parameter rather than
+// EXCLUDED: EXCLUDED is the row *after* the VALUES expressions are evaluated,
+// so it would carry the floored 0 and the decrement would silently become a
+// no-op.
+func TestUpsertTodayDigest_FirstWriteOfDayFloorsNegativeUnsummarized(t *testing.T) {
+	mock := &mockPgx{}
+	repo := &Repository{pool: mock}
+
+	require.NoError(t, repo.UpsertTodayDigest(context.Background(), json.RawMessage(`{
+		"user_id": "11111111-1111-4111-8111-111111111111",
+		"digest_date": "2026-05-05",
+		"summarized_articles": 1,
+		"unsummarized_articles": -1,
+		"updated_at": "2026-05-05T00:03:00Z",
+		"last_event_seq": 90210
+	}`)))
+	require.Len(t, mock.execCalls, 1)
+	call := mock.execCalls[0]
+
+	assert.Contains(t, call.SQL, "GREATEST(0, $5)",
+		"the INSERT operand must be floored, or the first write of the day stores a negative count")
+
+	assert.Contains(t, call.SQL, "unsummarized_articles = GREATEST(0, today_digest_view.unsummarized_articles + $5)",
+		"the conflict branch must add the signed delta from the bare parameter")
+	assert.NotContains(t, call.SQL, "today_digest_view.unsummarized_articles + EXCLUDED.unsummarized_articles",
+		"EXCLUDED carries the floored VALUES expression, so a -1 decrement would become +0")
+
+	require.GreaterOrEqual(t, len(call.Args), 5)
+	assert.EqualValues(t, -1, call.Args[4],
+		"the signed delta must still be bound raw — flooring in Go would break the decrement of an existing row")
+
+	// The other two counters are only ever 0 or +1, so they stay unfloored;
+	// pin that so nobody "fixes" them into a floor that hides a real bug.
+	assert.False(t, strings.Contains(call.SQL, "GREATEST(0, $3)") || strings.Contains(call.SQL, "GREATEST(0, $4)"),
+		"new_articles/summarized_articles are never negative and must not be floored")
+}

--- a/knowledge-sovereign/app/usecase/knowledge_home_projector/projector.go
+++ b/knowledge-sovereign/app/usecase/knowledge_home_projector/projector.go
@@ -392,6 +392,15 @@ type digestWrite struct {
 	UnsummarizedArticles int       `json:"unsummarized_articles"`
 	TopTags              []string  `json:"top_tags"`
 	UpdatedAt            time.Time `json:"updated_at"`
+	// LastEventSeq is the folding event's own knowledge_events.event_seq.
+	// The counters above are additive deltas, so sovereign_db's merge-safe
+	// UPSERT needs a monotonic discriminator to tell "already folded" from
+	// "another producer's clock is ahead" and applies the DO UPDATE only
+	// above the row's stored high-water mark. UpdatedAt cannot serve: it is
+	// the event's OccurredAt, stamped by whichever producer emitted it. The
+	// driver rejects a payload that omits this rather than falling back, so
+	// every digestWrite literal must set it.
+	LastEventSeq int64 `json:"last_event_seq"`
 }
 
 type recallReasonWire struct {
@@ -504,12 +513,23 @@ func (p *Projector) upsertHomeItem(ctx context.Context, item homeItemWrite) erro
 	return nil
 }
 
+// upsertDigest's error is fatal to the fold, unlike the recall-candidate and
+// clear-supersede side effects below. today_digest_view's counters are
+// additive deltas keyed on the folding event's event_seq: an event the
+// checkpoint walks past contributes its increment exactly never again, and a
+// RebuildProjection cannot recover it either — the rebuild truncates and
+// replays the same log into the same failure. Logging at WARN and returning
+// nil here is also precisely what hid the producer/consumer skew that stopped
+// today_digest_view being written at all (Alt Rule 8).
 func (p *Projector) upsertDigest(ctx context.Context, digest digestWrite) error {
 	raw, err := json.Marshal(digest)
 	if err != nil {
 		return fmt.Errorf("marshal today_digest_view payload: %w", err)
 	}
-	return p.repo.UpsertTodayDigest(ctx, raw)
+	if err := p.repo.UpsertTodayDigest(ctx, raw); err != nil {
+		return fmt.Errorf("upsert today_digest_view: %w", err)
+	}
+	return nil
 }
 
 func (p *Projector) upsertRecallCandidate(ctx context.Context, candidate recallCandidateWrite) error {
@@ -588,12 +608,9 @@ func (p *Projector) foldArticleCreated(ctx context.Context, evt sovereign_db.Kno
 		NewArticles:          1,
 		UnsummarizedArticles: 1,
 		UpdatedAt:            occurredAt,
+		LastEventSeq:         evt.EventSeq,
 	}
-	if err := p.upsertDigest(ctx, digest); err != nil {
-		p.logger.WarnContext(ctx, "knowledge_home_projector: today_digest upsert failed for ArticleCreated",
-			slog.String("event_id", evt.EventID.String()), slog.Any("error", err))
-	}
-	return nil
+	return p.upsertDigest(ctx, digest)
 }
 
 // isHTTPURL allowlists {http, https}. Mirrors the FE-side safeArticleHref
@@ -700,12 +717,9 @@ func (p *Projector) foldSummaryVersionCreated(ctx context.Context, evt sovereign
 		SummarizedArticles:   summarizedArticles,
 		UnsummarizedArticles: unsummarizedDelta,
 		UpdatedAt:            occurredAt,
+		LastEventSeq:         evt.EventSeq,
 	}
-	if err := p.upsertDigest(ctx, digest); err != nil {
-		p.logger.WarnContext(ctx, "knowledge_home_projector: today_digest upsert failed for SummaryVersionCreated",
-			slog.String("event_id", evt.EventID.String()), slog.Any("error", err))
-	}
-	return nil
+	return p.upsertDigest(ctx, digest)
 }
 
 // foldTagSetVersionCreated: design change (F-01) — tags travel on the event
@@ -745,15 +759,13 @@ func (p *Projector) foldTagSetVersionCreated(ctx context.Context, evt sovereign_
 	// touching the row would still bump its updated_at.
 	if len(payload.Tags) > 0 {
 		digest := digestWrite{
-			UserID:     userID,
-			DigestDate: occurredAt.Format(time.DateOnly),
-			TopTags:    payload.Tags,
-			UpdatedAt:  occurredAt,
+			UserID:       userID,
+			DigestDate:   occurredAt.Format(time.DateOnly),
+			TopTags:      payload.Tags,
+			UpdatedAt:    occurredAt,
+			LastEventSeq: evt.EventSeq,
 		}
-		if err := p.upsertDigest(ctx, digest); err != nil {
-			p.logger.WarnContext(ctx, "knowledge_home_projector: today_digest upsert failed for TagSetVersionCreated",
-				slog.String("event_id", evt.EventID.String()), slog.Any("error", err))
-		}
+		return p.upsertDigest(ctx, digest)
 	}
 	return nil
 }
@@ -982,10 +994,11 @@ func (p *Projector) foldReasonMerged(ctx context.Context, evt sovereign_db.Knowl
 // recall_candidate_view is a disposable projection (immutable-design-guard),
 // so a TRUNCATE + full reproject replay must reach the same snoozed/dismissed
 // state alt-backend's write-through usecases already applied directly. Unlike
-// the today_digest/recall_candidate side effects on other events (which are
-// secondary and non-fatal), the write here IS the event's entire purpose, so
-// a repository failure is a hard-fail: it stops the batch rather than
-// silently advancing the checkpoint past a lost snooze/dismiss.
+// the recall_candidate side effect on HomeItemOpened (which a later open
+// re-derives, and which is therefore non-fatal), the write here IS the
+// event's entire purpose, so a repository failure is a hard-fail: it stops
+// the batch rather than silently advancing the checkpoint past a lost
+// snooze/dismiss.
 
 func (p *Projector) foldRecallSnoozed(ctx context.Context, evt sovereign_db.KnowledgeEvent) error {
 	var payload recallSnoozedPayload

--- a/knowledge-sovereign/app/usecase/knowledge_home_projector/projector_test.go
+++ b/knowledge-sovereign/app/usecase/knowledge_home_projector/projector_test.go
@@ -80,6 +80,11 @@ type capturedDigest struct {
 	UnsummarizedArticles int       `json:"unsummarized_articles"`
 	TopTags              []string  `json:"top_tags"`
 	UpdatedAt            time.Time `json:"updated_at"`
+	// LastEventSeq is a pointer for the same reason the driver's unmarshal
+	// target is: a payload that omits the key must be distinguishable from
+	// one that sends an explicit 0, because the driver rejects both and the
+	// fake has to reject them the same way.
+	LastEventSeq *int64 `json:"last_event_seq"`
 }
 
 type capturedRecallCandidate struct {
@@ -346,12 +351,25 @@ func (f *fakeRepo) ClearSupersedeState(_ context.Context, payload json.RawMessag
 }
 
 func (f *fakeRepo) UpsertTodayDigest(_ context.Context, payload json.RawMessage) error {
-	if f.todayDigestErr != nil {
-		return f.todayDigestErr
-	}
 	var w capturedDigest
 	if err := json.Unmarshal(payload, &w); err != nil {
 		return fmt.Errorf("fakeRepo.UpsertTodayDigest: %w", err)
+	}
+	// Mirror sovereign_db.UpsertTodayDigest's producer-wiring guard: the
+	// merge-safe UPSERT gates its additive counters on last_event_seq, so a
+	// payload that omits the key — or sends the 0 that a BIGSERIAL never
+	// issues — is refused before anything reaches the row rather than
+	// silently falling back to the wall clock. A fake that accepted what the
+	// driver refuses is how a fold that writes no last_event_seq stayed green
+	// here while today_digest_view stopped being written in production.
+	if w.LastEventSeq == nil {
+		return fmt.Errorf("fakeRepo.UpsertTodayDigest: last_event_seq is required")
+	}
+	if *w.LastEventSeq <= 0 {
+		return fmt.Errorf("fakeRepo.UpsertTodayDigest: last_event_seq must be a positive event_seq, got %d", *w.LastEventSeq)
+	}
+	if f.todayDigestErr != nil {
+		return f.todayDigestErr
 	}
 	f.digests[w.UserID.String()] = w
 	return nil
@@ -517,7 +535,18 @@ func TestProjector_ArticleCreated_ScoreIsIndependentOfIngestTimeStaleness(t *tes
 		"score must not depend on published_at's age at ingest time — that is a read-time ranking concern")
 }
 
-func TestProjector_ArticleCreated_TodayDigestFailureIsNonFatal(t *testing.T) {
+// TestProjector_ArticleCreated_TodayDigestFailureStallsTheCheckpoint used to
+// pin the opposite: the fold logged the digest failure at WARN and returned
+// nil, so the checkpoint advanced past the event. That is fine for a side
+// effect that can be recomputed, and today_digest_view cannot be — the write
+// is an *additive delta*, so an event folded past is a counter increment that
+// no later event and no reprojection will ever contribute again (a rebuild
+// truncates and replays the same log, hitting the same failure). Swallowing
+// it also made a producer/consumer schema skew — exactly the one that shipped
+// when the driver started requiring last_event_seq — indistinguishable from a
+// healthy run, which is what Alt Rule 8 forbids. A digest failure therefore
+// stops the batch and leaves the event in the log to be retried.
+func TestProjector_ArticleCreated_TodayDigestFailureStallsTheCheckpoint(t *testing.T) {
 	tenant := uuid.New()
 	user := userPtr()
 	articleID := uuid.New()
@@ -536,12 +565,14 @@ func TestProjector_ArticleCreated_TodayDigestFailureIsNonFatal(t *testing.T) {
 	p := NewProjector(repo, nil, Config{})
 
 	err := p.RunBatch(context.Background())
-	require.NoError(t, err, "a today_digest upsert failure must not fail the batch (non-fatal side effect)")
+	require.Error(t, err, "a lost today_digest delta must fail the batch, not be logged and forgotten")
+	assert.Contains(t, err.Error(), "today_digest_view unavailable")
 
 	itemKey := fmt.Sprintf("article:%s", articleID)
 	_, ok := repo.homeItems[itemKey]
-	assert.True(t, ok, "the home item upsert must still succeed even when today_digest fails")
-	assert.Equal(t, int64(1), repo.checkpoint, "checkpoint still advances past a non-fatal side-effect failure")
+	assert.True(t, ok, "the home item upsert already succeeded and stays — the fold is idempotent on retry")
+	assert.Equal(t, int64(0), repo.checkpoint,
+		"the checkpoint must not move past an event whose counter delta was never applied")
 }
 
 // ── ArticleUrlBackfilled ──

--- a/knowledge-sovereign/app/usecase/knowledge_home_projector/projector_today_digest_seq_test.go
+++ b/knowledge-sovereign/app/usecase/knowledge_home_projector/projector_today_digest_seq_test.go
@@ -1,0 +1,93 @@
+package knowledge_home_projector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"knowledge-sovereign/driver/sovereign_db"
+)
+
+// TestProjector_DigestWritesCarryTheirEventSeq is the producer half of
+// today_digest_view's replay guard.
+//
+// sovereign_db.UpsertTodayDigest gates the additive counters on
+// last_event_seq — the folding event's own knowledge_events.event_seq, the
+// only discriminator that means "already folded" rather than "another
+// producer's clock is ahead" — and refuses a payload that does not carry it.
+// The three folds below are the only production writers of that payload, so a
+// digestWrite without last_event_seq does not degrade today_digest_view, it
+// stops it from being written at all, for every user, until a producer change
+// lands. Consumer and producer therefore have to move in the same commit.
+func TestProjector_DigestWritesCarryTheirEventSeq(t *testing.T) {
+	articleID := uuid.New()
+
+	tests := []struct {
+		name      string
+		eventType string
+		seq       int64
+		payload   map[string]any
+	}{
+		{
+			name:      "ArticleCreated contributes the new/unsummarized deltas",
+			eventType: "ArticleCreated",
+			seq:       4711,
+			payload: map[string]any{
+				"article_id": articleID.String(),
+				"title":      "Rust async runtimes compared",
+				"url":        "https://example.com/rust-async",
+			},
+		},
+		{
+			name:      "SummaryVersionCreated moves an article from unsummarized to summarized",
+			eventType: "SummaryVersionCreated",
+			seq:       90210,
+			payload: map[string]any{
+				"article_id":   articleID.String(),
+				"summary_text": "Tokio and async-std differ mainly in scheduler design.",
+			},
+		},
+		{
+			name:      "TagSetVersionCreated contributes top_tags",
+			eventType: "TagSetVersionCreated",
+			seq:       1337,
+			payload: map[string]any{
+				"article_id": articleID.String(),
+				"tags":       []string{"rust", "async"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenant := uuid.New()
+			user := userPtr()
+			occurredAt := time.Date(2026, 7, 14, 9, 0, 0, 0, time.UTC)
+
+			events := []sovereign_db.KnowledgeEvent{
+				homeEvent(tt.seq, tt.eventType, articleID.String(), occurredAt, tenant, user, mustJSON(t, tt.payload)),
+			}
+			repo := newFakeRepo(events)
+			// Start the checkpoint right below the event so the batch is
+			// contiguous — the distinctive seq values above are there to
+			// prove the fold forwards the event's own sequence rather than
+			// some batch-local counter.
+			repo.checkpoint = tt.seq - 1
+			p := NewProjector(repo, nil, Config{})
+			require.NoError(t, p.RunBatch(context.Background()))
+
+			digest, ok := repo.digests[user.String()]
+			require.True(t, ok, "%s must write today_digest_view", tt.eventType)
+			require.NotNil(t, digest.LastEventSeq,
+				"the marshalled digest payload must carry last_event_seq — the driver rejects it outright otherwise")
+			assert.Equal(t, tt.seq, *digest.LastEventSeq,
+				"last_event_seq must be the folding event's own event_seq, the same value the checkpoint advances on")
+			assert.Equal(t, tt.seq, repo.checkpoint,
+				"the checkpoint may only pass the event once its digest delta actually landed")
+		})
+	}
+}

--- a/knowledge-sovereign/migrations/00031_add_today_digest_last_event_seq.sql
+++ b/knowledge-sovereign/migrations/00031_add_today_digest_last_event_seq.sql
@@ -1,0 +1,25 @@
+-- today_digest_view's additive counters need a replay guard, and until now
+-- that guard was `EXCLUDED.updated_at > today_digest_view.updated_at`.
+-- updated_at is the source event's occurred_at, which every producer stamps
+-- with its own wall clock before the append RPC, while knowledge_home_projector
+-- folds in event_seq order. Two events for the same user and day whose clocks
+-- disagree therefore arrive with occurred_at going backwards, and the
+-- older-looking one had its whole DO UPDATE — counter deltas included —
+-- discarded, leaving TodayBar permanently one short.
+--
+-- event_seq is the log's own monotonic order and is exactly what the fold
+-- iterates, so it is the only discriminator that means "already folded into
+-- this row" instead of "some other machine's clock is ahead". This is the
+-- same role last_event_seq already plays in knowledge_projection_checkpoints.
+--
+-- DEFAULT 0 sits below every real event_seq (knowledge_events.event_seq is
+-- BIGSERIAL, hence >= 1), so rows written before this migration lose the
+-- guard against the next event rather than being stranded above it.
+-- today_digest_view is a disposable projection: RebuildProjection truncates
+-- it and replays the log, refilling the column exactly.
+
+ALTER TABLE today_digest_view
+  ADD COLUMN IF NOT EXISTS last_event_seq BIGINT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN today_digest_view.last_event_seq
+  IS 'Highest knowledge_events.event_seq folded into this row; replay guard for the additive counters';

--- a/knowledge-sovereign/migrations/atlas.sum
+++ b/knowledge-sovereign/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:JbaNApHxlIO+J6oqai1vYpADTeYyDT41buCzelnE+pc=
+h1:wBa7/0XoG9qyZQrTCGLl754JflJN1ly4Zh9kQwvJ0RI=
 00001_initial_schema.sql h1:CSFJx5Q5Jv44C4sqoKpzvdh6t8Unwog8bZw9/VBd3NQ=
 00002_add_link_column.sql h1:A2QxniA5wEK9bo0UnqTNKX5TgvkR/zugtdCKs8O07DE=
 00003_fix_user_events_dedupe_constraint.sql h1:5EpJwNHbInepPLqTMNG3YL/FPTqvpkpqazjt6rK0PkQ=
@@ -29,3 +29,4 @@ h1:JbaNApHxlIO+J6oqai1vYpADTeYyDT41buCzelnE+pc=
 00028_drop_knowledge_loop_projections.sql h1:YaOmNXyr8T+x3xXDQaqJ0GqEynpwGYrGVLnhQ47ozbs=
 00029_create_knowledge_trail_act_outcomes.sql h1:fNaAr7v65hM5KgD2oXNgcsWN54UZaiN3N3GuuePTJTI=
 00030_add_event_type_occurred_index_for_liveness_gauge.sql h1:aGy7wz7n9LqGyOBUj2E0c7vWwU/kImAkfEYeMOAXwJ8=
+00031_add_today_digest_last_event_seq.sql h1:yG+J583BUlb3kmWrjNA3SyWpIhHEUL+4waosFAHx3CQ=

--- a/kratos/kratos_template.yml
+++ b/kratos/kratos_template.yml
@@ -40,10 +40,26 @@ selfservice:
     password:
       enabled: true
       config:
-        haveibeenpwned_enabled: false
+        # session.lifespan が 720h でロックアウトも無いので、当たった 1 本が
+        # そのまま 30 日分のセッションになる。ここは Ory 既定より緩めない。
+        haveibeenpwned_enabled: true
+        # 0 = 漏洩リストに 1 件でも載っていれば拒否（Ory 既定かつ最も厳しい値）
         max_breaches: 0
-        min_password_length: 6
-        identifier_similarity_check_enabled: false
+        # HIBP 到達不能時は fail-closed。true（Ory 既定）だと
+        # validator.go の該当分岐が素の `return nil` で、ロガーも
+        # `io.Discard` 固定のため、照合が飛ばされたことがどこにも残らない。
+        # 漏洩パスワードが素通りしたか否かを事後に判定できない状態は
+        # CLAUDE.md rule 8 / 9 の無言フォールバックそのものなので取らない。
+        #
+        # 代償: api.pwnedpasswords.com へ到達できない間は登録と
+        # パスワード変更が失敗する。Kratos の resilient client は
+        # retryMax 4 / connect timeout 1s なので、失敗が確定するまで
+        # 15〜20 秒かかる。DB 障害と誤診しないこと。
+        # → egress 断は「登録できない」として顕在化する。
+        ignore_network_errors: false
+        # NIST SP 800-63B の SHALL は 8 文字。12 はその上を取った Alt 側の判断
+        min_password_length: 12
+        identifier_similarity_check_enabled: true
 
     totp:
       config:

--- a/mq-hub/app/domain/stream.go
+++ b/mq-hub/app/domain/stream.go
@@ -18,14 +18,25 @@ const (
 	StreamKeyTags StreamKey = "alt:events:tags"
 	// StreamKeyIndex is the stream for index commands.
 	StreamKeyIndex StreamKey = "alt:events:index"
+	// StreamKeyArticlesDLQ is the dead-letter stream shadowing
+	// StreamKeyArticles. pre-processor, search-indexer and tag-generator all
+	// consume alt:events:articles under their own consumer group and all
+	// derive the same DLQ key, so this single entry covers all three.
+	//
+	// mq-hub never publishes here -- the consumers XADD into it directly when
+	// a message exceeds their MaxDeliveries -- but it must still be listed:
+	// nothing consumes a DLQ, so the only things that ever shorten it are the
+	// producer's own XADD cap and the trim pass below.
+	StreamKeyArticlesDLQ StreamKey = "alt:events:articles:dlq"
 )
 
 // validStreamKeys contains all valid stream keys.
 var validStreamKeys = map[StreamKey]bool{
-	StreamKeyArticles:  true,
-	StreamKeySummaries: true,
-	StreamKeyTags:      true,
-	StreamKeyIndex:     true,
+	StreamKeyArticles:    true,
+	StreamKeySummaries:   true,
+	StreamKeyTags:        true,
+	StreamKeyIndex:       true,
+	StreamKeyArticlesDLQ: true,
 }
 
 // IsValid returns true if the stream key is a known valid key.
@@ -43,6 +54,7 @@ func AllStreamKeys() []StreamKey {
 		StreamKeySummaries,
 		StreamKeyTags,
 		StreamKeyIndex,
+		StreamKeyArticlesDLQ,
 	}
 }
 

--- a/mq-hub/app/usecase/trim_streams_dlq_test.go
+++ b/mq-hub/app/usecase/trim_streams_dlq_test.go
@@ -1,0 +1,35 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mq-hub/domain"
+)
+
+// TestTrimStreamsUsecase_CoversDLQStreams reproduces the mq-hub half of the
+// finding: the maintenance pass walked the four live streams only, so the DLQ
+// the consumers XADD into had no ceiling from either side. XTRIM is the only
+// control that still works once redis-streams is at maxmemory under
+// noeviction (XADD is denyoom there), so a stream left out of this pass is a
+// stream nothing can shrink back.
+//
+// pre-processor, search-indexer and tag-generator all consume
+// alt:events:articles under their own group and all derive the same DLQ key,
+// so the one entry below covers all three. It is spelled out as a literal on
+// purpose: what has to match is the key those services actually write to, not
+// whatever the constant happens to be named here.
+func TestTrimStreamsUsecase_CoversDLQStreams(t *testing.T) {
+	const articlesDLQ = domain.StreamKey("alt:events:articles:dlq")
+
+	trimmer := &stubTrimmer{deleted: map[domain.StreamKey]int64{}}
+
+	_, err := NewTrimStreamsUsecase(trimmer, 50000).Execute(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, trimmer.calls, articlesDLQ,
+		"the DLQ is XADDed by three consumers and read by nobody; if this pass skips it, nothing bounds it")
+}

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -49,8 +49,12 @@ server {
     listen 80;
     server_name localhost;
 
-    # Explicit upload ceiling. Frontend BODY_SIZE_LIMIT=Infinity (compose/core.yaml)
-    # would otherwise accept arbitrary bodies; nginx is the authoritative edge limit.
+    # Explicit upload ceiling, kept in step with the frontend's own
+    # BODY_SIZE_LIMIT=32M (compose/core.yaml). Defence in depth rather than the
+    # sole cap: both layers now declare it, so raising one without the other
+    # just moves the rejection, it does not open the edge.
+    # compose/dev.yaml and compose/frontend-dev.yaml still run Infinity, so dev
+    # deliberately relies on this directive alone.
     client_max_body_size 32m;
 
     # Security headers

--- a/pre-processor-sidecar/app/repository/api_usage_repository.go
+++ b/pre-processor-sidecar/app/repository/api_usage_repository.go
@@ -15,6 +15,12 @@ import (
 	"pre-processor-sidecar/models"
 )
 
+// ErrNoUsageRecordToday reports that api_usage_tracking simply has no row for the
+// current date yet — the ordinary first-call-of-the-day condition, not a failure.
+// Callers seed a zero-valued counter on it and then write that counter back over
+// the day's row, so it must stay distinguishable from a query that failed.
+var ErrNoUsageRecordToday = errors.New("no api usage record found for today")
+
 // PostgreSQLAPIUsageRepository implements APIUsageRepository using PostgreSQL.
 type PostgreSQLAPIUsageRepository struct {
 	pool   PgxIface
@@ -47,7 +53,7 @@ func (r *PostgreSQLAPIUsageRepository) GetTodaysUsage(ctx context.Context) (*mod
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("no api usage record found for today: %w", err)
+			return nil, fmt.Errorf("%w: %w", ErrNoUsageRecordToday, err)
 		}
 		return nil, fmt.Errorf("failed to get today's api usage: %w", err)
 	}

--- a/pre-processor-sidecar/app/repository/api_usage_repository_test.go
+++ b/pre-processor-sidecar/app/repository/api_usage_repository_test.go
@@ -5,6 +5,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"regexp"
 	"testing"
@@ -73,8 +74,25 @@ func TestGetTodaysUsage_NotFound(t *testing.T) {
 	mock.ExpectQuery(selectTodaysUsageQuery).WillReturnError(pgx.ErrNoRows)
 
 	usage, err := repo.GetTodaysUsage(context.Background())
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoUsageRecordToday)
 	assert.Nil(t, usage)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A query that failed is not a day that has no row yet. Callers seed a fresh
+// zero-valued counter on ErrNoUsageRecordToday and then overwrite the row with
+// it, so collapsing the two would let one connection reset wipe the day's
+// persisted Zone 1 count.
+func TestGetTodaysUsage_QueryFailureIsNotMissingRow(t *testing.T) {
+	repo, mock := newTestAPIUsageRepo(t)
+
+	queryErr := errors.New("read tcp 10.0.0.5:5432: connection reset by peer")
+	mock.ExpectQuery(selectTodaysUsageQuery).WillReturnError(queryErr)
+
+	usage, err := repo.GetTodaysUsage(context.Background())
+	assert.Nil(t, usage)
+	assert.ErrorIs(t, err, queryErr)
+	assert.NotErrorIs(t, err, ErrNoUsageRecordToday)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pre-processor-sidecar/app/service/inoreader_service.go
+++ b/pre-processor-sidecar/app/service/inoreader_service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"pre-processor-sidecar/models"
+	"pre-processor-sidecar/repository"
 	"pre-processor-sidecar/utils"
 )
 
@@ -72,12 +74,17 @@ func (s *InoreaderService) zone1Snapshot() (usage, limit int) {
 	return s.rateLimitInfo.Zone1Usage, s.rateLimitInfo.Zone1Limit
 }
 
-// incrementZone1UsageLocally bumps the local fallback counter used when
-// UpdateAPIUsageFromHeaders fails, returning the new value for logging.
-func (s *InoreaderService) incrementZone1UsageLocally() int {
+// incrementUsageLocally bumps the in-process counter for the zone the endpoint
+// belongs to and returns the new Zone-1 value, which is what CheckAPIRateLimit
+// gates on.
+func (s *InoreaderService) incrementUsageLocally(zone1 bool) int {
 	s.rateLimitMu.Lock()
 	defer s.rateLimitMu.Unlock()
-	s.rateLimitInfo.Zone1Usage++
+	if zone1 {
+		s.rateLimitInfo.Zone1Usage++
+	} else {
+		s.rateLimitInfo.Zone2Usage++
+	}
 	return s.rateLimitInfo.Zone1Usage
 }
 
@@ -105,6 +112,15 @@ func NewInoreaderService(inoreaderClient InoreaderClientInterface, apiUsageRepo 
 	// TDD Phase 3 - REFACTOR: Initialize Monitoring
 	monitoringConfig := utils.DefaultMonitoringConfig()
 	monitor := utils.NewMonitor(monitoringConfig, logger)
+
+	// Announce the tracking wiring instead of discovering it call by call: without
+	// the repository the Zone 1 budget is only counted in-process and a restart
+	// hands the fetch loop a fresh 100 requests.
+	if apiUsageRepo == nil {
+		logger.Warn("api_usage_tracking_disabled",
+			"reason", "no APIUsageRepository wired",
+			"effect", "Zone 1 quota counted in-process only, reset on restart")
+	}
 
 	return &InoreaderService{
 		inoreaderClient:       inoreaderClient,
@@ -196,12 +212,11 @@ func (s *InoreaderService) FetchSubscriptions(ctx context.Context) ([]*models.Su
 			return fmt.Errorf("failed to parse subscriptions: %w", parseErr)
 		}
 
-		// CRITICAL FIX: Update API usage tracking after each API call
-		if updateErr := s.UpdateAPIUsageFromHeaders(ctx, "/subscription/list"); updateErr != nil {
-			s.logger.Warn("Failed to update API usage from headers", "error", updateErr)
-			// Increment local counter as fallback
-			newUsage := s.incrementZone1UsageLocally()
-			s.logger.Debug("Incremented local API usage counter", "zone1_usage", newUsage)
+		// Charge the call against the 100 req/day Zone 1 budget. The in-process
+		// counter has already advanced when this returns an error, so the guard
+		// keeps working even if the write to api_usage_tracking failed.
+		if usageErr := s.recordAPIUsage(ctx, "/subscription/list"); usageErr != nil {
+			s.logger.Warn("Failed to persist API usage tracking", "error", usageErr)
 		}
 
 		usage, _ := s.zone1Snapshot()
@@ -281,13 +296,10 @@ func (s *InoreaderService) FetchStreamContents(ctx context.Context, streamID, co
 		// Resolve subscription UUIDs for articles
 		articles = s.resolveSubscriptionUUIDs(articles)
 
-		// CRITICAL FIX: Update API usage tracking after each API call
+		// Charge the call against the 100 req/day Zone 1 budget (see FetchSubscriptions).
 		endpoint := "/stream/contents/" + streamID
-		if updateErr := s.UpdateAPIUsageFromHeaders(ctx, endpoint); updateErr != nil {
-			s.logger.Warn("Failed to update API usage from headers", "error", updateErr, "stream_id", streamID)
-			// Increment local counter as fallback
-			newUsage := s.incrementZone1UsageLocally()
-			s.logger.Debug("Incremented local API usage counter", "zone1_usage", newUsage)
+		if usageErr := s.recordAPIUsage(ctx, endpoint); usageErr != nil {
+			s.logger.Warn("Failed to persist API usage tracking", "error", usageErr, "stream_id", streamID)
 		}
 
 		usage, _ := s.zone1Snapshot()
@@ -360,13 +372,10 @@ func (s *InoreaderService) FetchUnreadStreamContents(ctx context.Context, stream
 	// Resolve subscription UUIDs for articles
 	articles = s.resolveSubscriptionUUIDs(articles)
 
-	// CRITICAL FIX: Update API usage tracking after each API call
+	// Charge the call against the 100 req/day Zone 1 budget (see FetchSubscriptions).
 	endpoint := "/stream/contents/" + streamID + "?xt=user/-/state/com.google/read"
-	if err := s.UpdateAPIUsageFromHeaders(ctx, endpoint); err != nil {
-		s.logger.Warn("Failed to update API usage from headers", "error", err, "stream_id", streamID)
-		// Increment local counter as fallback
-		newUsage := s.incrementZone1UsageLocally()
-		s.logger.Debug("Incremented local API usage counter", "zone1_usage", newUsage)
+	if usageErr := s.recordAPIUsage(ctx, endpoint); usageErr != nil {
+		s.logger.Warn("Failed to persist API usage tracking", "error", usageErr, "stream_id", streamID)
 	}
 
 	usage, _ := s.zone1Snapshot()
@@ -411,28 +420,42 @@ func (s *InoreaderService) resolveSubscriptionUUIDs(articles []*models.Article) 
 	return articles
 }
 
-// UpdateAPIUsageFromHeaders updates API usage tracking from response headers
-// DEPRECATED: This method should not make additional API calls just for headers
-// Instead, headers should be captured during the actual API calls
-func (s *InoreaderService) UpdateAPIUsageFromHeaders(ctx context.Context, endpoint string) error {
-	s.logger.Warn("UpdateAPIUsageFromHeaders called - this should be replaced with header capture during API calls",
-		"endpoint", endpoint)
+// recordAPIUsage charges one Inoreader call against the daily quota.
+//
+// The in-process counter that CheckAPIRateLimit gates on is advanced first and
+// unconditionally: a Postgres hiccup must never be indistinguishable from an
+// unlimited budget. Persistence to api_usage_tracking follows, so the 100 req/day
+// Zone 1 limit survives a sidecar restart instead of starting over at zero.
+//
+// Inoreader's X-Reader-Zone1-* response headers would be the authoritative source,
+// but the client layer returns only the decoded body and drops them; until it
+// forwards them, the counter is derived from the calls we make.
+func (s *InoreaderService) recordAPIUsage(ctx context.Context, endpoint string) error {
+	newUsage := s.incrementUsageLocally(s.isReadOnlyEndpoint(endpoint))
 
-	// Return success to avoid breaking existing code, but log the issue
-	s.logger.Debug("API usage repository not configured or headers not available, skipping usage tracking")
-	return nil
-}
-
-// processAPIUsageHeaders processes API response headers for usage tracking
-func (s *InoreaderService) processAPIUsageHeaders(ctx context.Context, headers map[string]string, endpoint string) error {
 	if s.apiUsageRepo == nil {
-		s.logger.Debug("API usage repository not configured, skipping usage tracking")
-		return nil
+		return fmt.Errorf("api usage repository not wired: %s counted in-process only (zone1_usage=%d)", endpoint, newUsage)
 	}
 
-	// Get or create today's usage record
+	return s.processAPIUsageHeaders(ctx, nil, endpoint)
+}
+
+// processAPIUsageHeaders persists one API call — and any rate limit headers that
+// came back with it — to today's api_usage_tracking row. recordAPIUsage is the
+// gatekeeper for a nil repository; reaching here without one is a wiring bug.
+func (s *InoreaderService) processAPIUsageHeaders(ctx context.Context, headers map[string]string, endpoint string) error {
+	// Get or create today's usage record. Only "there is no row for today yet" may
+	// seed a fresh counter: UpdateUsageRecord below rewrites the row's counters
+	// wholesale, so treating a transient read failure as a new day would overwrite
+	// a day already at 61/100 with 1 — invisible until the next restart inherits
+	// the 1 and spends the real Inoreader budget a second time.
 	usage, err := s.apiUsageRepo.GetTodaysUsage(ctx)
 	if err != nil {
+		if !errors.Is(err, repository.ErrNoUsageRecordToday) {
+			s.logger.Error("Failed to read today's API usage record", "error", err)
+			return fmt.Errorf("failed to read today's API usage record: %w", err)
+		}
+
 		// Create new usage record for today
 		usage = models.NewAPIUsageTracking()
 		if err := s.apiUsageRepo.CreateUsageRecord(ctx, usage); err != nil {
@@ -443,17 +466,21 @@ func (s *InoreaderService) processAPIUsageHeaders(ctx context.Context, headers m
 	}
 
 	// Check if usage should be reset (new day)
-	if usage.ShouldResetUsage() {
+	resetForNewDay := usage.ShouldResetUsage()
+	if resetForNewDay {
 		usage.ResetUsage()
 		s.logger.Info("Reset API usage counters for new day")
 	}
 
-	// Parse and update rate limit headers
-	headerMap := make(map[string]interface{})
-	for key, value := range headers {
-		headerMap[key] = value
+	// Parse and update rate limit headers. Skipped when the caller had none, or an
+	// empty map would wipe the headers the last header-bearing response stored.
+	if len(headers) > 0 {
+		headerMap := make(map[string]interface{}, len(headers))
+		for key, value := range headers {
+			headerMap[key] = value
+		}
+		usage.UpdateRateLimitHeaders(headerMap)
 	}
-	usage.UpdateRateLimitHeaders(headerMap)
 
 	// Increment appropriate usage counter based on endpoint
 	if s.isReadOnlyEndpoint(endpoint) {
@@ -464,8 +491,8 @@ func (s *InoreaderService) processAPIUsageHeaders(ctx context.Context, headers m
 		s.logger.Debug("Incremented Zone 2 API usage", "endpoint", endpoint, "new_count", usage.Zone2Requests)
 	}
 
-	// Update rate limit info from headers
-	s.updateRateLimitInfoFromHeaders(headers, usage)
+	// Update rate limit info from the persisted counters and any headers
+	s.updateRateLimitInfoFromHeaders(headers, usage, resetForNewDay)
 
 	// Save updated usage record
 	if err := s.apiUsageRepo.UpdateUsageRecord(ctx, usage); err != nil {
@@ -484,10 +511,24 @@ func (s *InoreaderService) processAPIUsageHeaders(ctx context.Context, headers m
 	return nil
 }
 
-// updateRateLimitInfoFromHeaders updates internal rate limit info from API response headers
-func (s *InoreaderService) updateRateLimitInfoFromHeaders(headers map[string]string, usage *models.APIUsageTracking) {
+// updateRateLimitInfoFromHeaders refreshes the in-process rate limit view from the
+// persisted daily counters and, when the response carried them, Inoreader's own
+// X-Reader-Zone* headers.
+func (s *InoreaderService) updateRateLimitInfoFromHeaders(headers map[string]string, usage *models.APIUsageTracking, resetForNewDay bool) {
 	s.rateLimitMu.Lock()
 	defer s.rateLimitMu.Unlock()
+
+	// api_usage_tracking outlives the process, so it — not the counter this process
+	// happens to have accumulated — is the real budget. Adopt it whenever it is
+	// ahead (restart mid-day, a run that died after the write). Follow it downwards
+	// only across a day rollover, or a freshly reset row would leave the guard
+	// latched at yesterday's count.
+	if resetForNewDay || usage.Zone1Requests > s.rateLimitInfo.Zone1Usage {
+		s.rateLimitInfo.Zone1Usage = usage.Zone1Requests
+	}
+	if resetForNewDay || usage.Zone2Requests > s.rateLimitInfo.Zone2Usage {
+		s.rateLimitInfo.Zone2Usage = usage.Zone2Requests
+	}
 
 	// Parse Inoreader-specific rate limit headers
 	if zone1Usage, ok := headers["X-Reader-Zone1-Usage"]; ok {

--- a/pre-processor-sidecar/app/service/inoreader_service_quota_test.go
+++ b/pre-processor-sidecar/app/service/inoreader_service_quota_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"pre-processor-sidecar/mocks"
+	"pre-processor-sidecar/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// todaysUsageAt builds a persisted api_usage_tracking row for the current day so
+// ShouldResetUsage() stays false and the test exercises the increment path.
+func todaysUsageAt(zone1 int) *models.APIUsageTracking {
+	usage := models.NewAPIUsageTracking()
+	usage.Zone1Requests = zone1
+	return usage
+}
+
+// A successful Inoreader call must land in api_usage_tracking. Without that write
+// the 100-req/day Zone 1 budget is only ever guessed at by the 16m scheduler.
+func TestFetchSubscriptions_PersistsZone1UsageToRepository(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mocks.NewMockInoreaderClient(ctrl)
+	client.EXPECT().
+		FetchSubscriptionList(gomock.Any(), gomock.Any()).
+		Return(map[string]interface{}{}, nil)
+	client.EXPECT().
+		ParseSubscriptionsResponse(gomock.Any()).
+		Return([]*models.Subscription{}, nil)
+
+	usageRepo := mocks.NewMockAPIUsageRepository(ctrl)
+	usageRepo.EXPECT().
+		GetTodaysUsage(gomock.Any()).
+		Return(todaysUsageAt(41), nil)
+
+	var persisted *models.APIUsageTracking
+	usageRepo.EXPECT().
+		UpdateUsageRecord(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, usage *models.APIUsageTracking) error {
+			persisted = usage
+			return nil
+		})
+
+	svc := NewInoreaderService(client, usageRepo, stubTokenProvider{}, slog.Default())
+
+	_, err := svc.FetchSubscriptions(context.Background())
+	require.NoError(t, err)
+
+	require.NotNil(t, persisted, "every Inoreader call must be written to api_usage_tracking")
+	assert.Equal(t, 42, persisted.Zone1Requests,
+		"the read-only /subscription/list call must advance the Zone 1 counter")
+}
+
+// The persisted daily counter — not the process-local zero value — is what the
+// quota guard has to gate on, so a sidecar that starts at 89/100 gets exactly one
+// call before CheckAPIRateLimit refuses the rest of the day.
+func TestFetchSubscriptions_BlocksOnceZone1BudgetIsExhausted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mocks.NewMockInoreaderClient(ctrl)
+	client.EXPECT().
+		FetchSubscriptionList(gomock.Any(), gomock.Any()).
+		Return(map[string]interface{}{}, nil).
+		Times(1)
+	client.EXPECT().
+		ParseSubscriptionsResponse(gomock.Any()).
+		Return([]*models.Subscription{}, nil).
+		Times(1)
+
+	usageRepo := mocks.NewMockAPIUsageRepository(ctrl)
+	usageRepo.EXPECT().
+		GetTodaysUsage(gomock.Any()).
+		Return(todaysUsageAt(89), nil).
+		Times(1)
+	usageRepo.EXPECT().
+		UpdateUsageRecord(gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(1)
+
+	svc := NewInoreaderService(client, usageRepo, stubTokenProvider{}, slog.Default())
+	ctx := context.Background()
+
+	_, err := svc.FetchSubscriptions(ctx)
+	require.NoError(t, err, "the 90th request is still inside the safety buffer")
+
+	allowed, remaining := svc.CheckAPIRateLimit()
+	assert.False(t, allowed, "90/100 with a 10 request safety buffer must stop further calls")
+	assert.Equal(t, 0, remaining)
+
+	_, err = svc.FetchSubscriptions(ctx)
+	require.Error(t, err, "the exhausted Zone 1 budget must reject the next call")
+	assert.ErrorContains(t, err, "API rate limit exceeded")
+}
+
+// An unwired usage repository must not hand the fetch loop an unlimited budget:
+// the in-process counter still advances so the guard keeps working, degraded.
+func TestFetchSubscriptions_UnwiredUsageRepositoryStillAdvancesGuard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mocks.NewMockInoreaderClient(ctrl)
+	client.EXPECT().
+		FetchSubscriptionList(gomock.Any(), gomock.Any()).
+		Return(map[string]interface{}{}, nil)
+	client.EXPECT().
+		ParseSubscriptionsResponse(gomock.Any()).
+		Return([]*models.Subscription{}, nil)
+
+	svc := NewInoreaderService(client, nil, stubTokenProvider{}, slog.Default())
+
+	_, err := svc.FetchSubscriptions(context.Background())
+	require.NoError(t, err)
+
+	_, remaining := svc.CheckAPIRateLimit()
+	assert.Equal(t, 89, remaining, "one call must be subtracted from the 90 request safe budget")
+}

--- a/pre-processor-sidecar/app/service/inoreader_service_usage_read_test.go
+++ b/pre-processor-sidecar/app/service/inoreader_service_usage_read_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"pre-processor-sidecar/mocks"
+	"pre-processor-sidecar/models"
+	"pre-processor-sidecar/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// A transient api_usage_tracking read failure must never be mistaken for "no row
+// for today". UpdateUsageRecord overwrites the day's counters wholesale, so a
+// single connection reset would rewrite a day sitting at 61/100 down to 1 — and
+// the in-process counter hides it until the next restart re-inherits the 1 and
+// burns through the real 100 req/day Inoreader budget.
+func TestFetchSubscriptions_TransientUsageReadErrorLeavesPersistedCounterAlone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mocks.NewMockInoreaderClient(ctrl)
+	client.EXPECT().
+		FetchSubscriptionList(gomock.Any(), gomock.Any()).
+		Return(map[string]interface{}{}, nil)
+	client.EXPECT().
+		ParseSubscriptionsResponse(gomock.Any()).
+		Return([]*models.Subscription{}, nil)
+
+	usageRepo := mocks.NewMockAPIUsageRepository(ctrl)
+	usageRepo.EXPECT().
+		GetTodaysUsage(gomock.Any()).
+		Return(nil, errors.New("read tcp 10.0.0.5:5432: connection reset by peer"))
+	// No CreateUsageRecord / UpdateUsageRecord expectation on purpose: writing
+	// today's row from a read we never got is the corruption under test, and
+	// gomock fails the test if either is called.
+
+	svc := NewInoreaderService(client, usageRepo, stubTokenProvider{}, slog.Default())
+
+	_, err := svc.FetchSubscriptions(context.Background())
+	require.NoError(t, err, "a usage tracking write failure must not fail the fetch itself")
+
+	// The guard still advances in-process, so an unreachable Postgres cannot read
+	// as an unlimited budget.
+	_, remaining := svc.CheckAPIRateLimit()
+	assert.Equal(t, 89, remaining, "one call must be subtracted from the 90 request safe budget")
+}
+
+// The first call of the day genuinely has no row yet. That case — and only that
+// case — may seed a fresh counter.
+func TestFetchSubscriptions_MissingTodaysRowSeedsFreshCounter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mocks.NewMockInoreaderClient(ctrl)
+	client.EXPECT().
+		FetchSubscriptionList(gomock.Any(), gomock.Any()).
+		Return(map[string]interface{}{}, nil)
+	client.EXPECT().
+		ParseSubscriptionsResponse(gomock.Any()).
+		Return([]*models.Subscription{}, nil)
+
+	usageRepo := mocks.NewMockAPIUsageRepository(ctrl)
+	usageRepo.EXPECT().
+		GetTodaysUsage(gomock.Any()).
+		Return(nil, repository.ErrNoUsageRecordToday)
+	usageRepo.EXPECT().
+		CreateUsageRecord(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	var persisted *models.APIUsageTracking
+	usageRepo.EXPECT().
+		UpdateUsageRecord(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, usage *models.APIUsageTracking) error {
+			persisted = usage
+			return nil
+		})
+
+	svc := NewInoreaderService(client, usageRepo, stubTokenProvider{}, slog.Default())
+
+	_, err := svc.FetchSubscriptions(context.Background())
+	require.NoError(t, err)
+
+	require.NotNil(t, persisted, "the day's first call must still be written to api_usage_tracking")
+	assert.Equal(t, 1, persisted.Zone1Requests)
+}

--- a/pre-processor/app/consumer/dlq.go
+++ b/pre-processor/app/consumer/dlq.go
@@ -38,8 +38,16 @@ func (c *Consumer) sendToDLQ(ctx context.Context, message redis.XMessage, delive
 		values[k] = v
 	}
 
+	// The DLQ is capped here or nowhere: mq-hub's periodic XTRIM pass only
+	// walks the four live streams in domain.AllStreamKeys(), and no service
+	// consumes a DLQ, so its only bound is the one its producer attaches.
+	// Unlike mq-hub's live-stream publishes this deliberately omits Mode
+	// "ACKED": the DLQ has no consumer group, so restricting trimming to
+	// fully-acked entries would trim nothing and leave the cap decorative.
 	if err := c.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: c.config.DLQStreamKey,
+		MaxLen: c.config.effectiveDLQMaxLen(),
+		Approx: true,
 		Values: values,
 	}).Err(); err != nil {
 		c.logger.Error("failed to write DLQ entry", "message_id", message.ID, "error", err)
@@ -60,28 +68,36 @@ func (c *Consumer) sendToDLQ(ctx context.Context, message redis.XMessage, delive
 
 // deliveryCounts looks up the current delivery counter for each given
 // message (already updated by the XAUTOCLAIM claim that preceded this
-// call).
+// call). It queries per message ID -- Start/End pinned to that exact ID --
+// rather than a single Start:"-",End:"+" sweep bounded by a Count derived
+// from len(messages): when this consumer's PEL holds more pending entries
+// than that Count, the ascending-ID-ordered sweep returns only the earliest
+// entries and silently omits any message in this batch whose ID sorts later,
+// making its delivery count read as zero regardless of its real value. That
+// falsely keeps shouldSendToDLQ from ever firing for it, so every sweep
+// re-runs the poison message's handler. See mq-hub/CLAUDE.md rule 5.
 func (c *Consumer) deliveryCounts(ctx context.Context, messages []redis.XMessage) map[string]int64 {
 	counts := make(map[string]int64, len(messages))
-	if len(messages) == 0 {
-		return counts
-	}
 
-	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
-		Stream:   c.config.StreamKey,
-		Group:    c.config.GroupName,
-		Consumer: c.config.ConsumerName,
-		Start:    "-",
-		End:      "+",
-		Count:    int64(len(messages)) * 2,
-	}).Result()
-	if err != nil {
-		c.logger.Error("failed to look up delivery counts for reclaimed messages", "error", err)
-		return counts
-	}
-
-	for _, p := range pending {
-		counts[p.ID] = p.RetryCount
+	for _, message := range messages {
+		pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream:   c.config.StreamKey,
+			Group:    c.config.GroupName,
+			Consumer: c.config.ConsumerName,
+			Start:    message.ID,
+			End:      message.ID,
+			Count:    1,
+		}).Result()
+		if err != nil {
+			c.logger.Error("failed to look up delivery count for reclaimed message",
+				"message_id", message.ID,
+				"error", err,
+			)
+			continue
+		}
+		for _, p := range pending {
+			counts[p.ID] = p.RetryCount
+		}
 	}
 	return counts
 }

--- a/pre-processor/app/consumer/dlq_maxlen_test.go
+++ b/pre-processor/app/consumer/dlq_maxlen_test.go
@@ -1,0 +1,120 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestReclaimPending_BoundsDLQStreamLength reproduces the finding: the DLQ
+// XADD carried no MAXLEN, and nothing else trims that stream -- mq-hub's
+// periodic XTRIM pass only walks domain.AllStreamKeys(), which lists the four
+// live streams and no DLQ, and no service consumes a DLQ. redis-streams runs
+// maxmemory 1gb under noeviction where XADD is denyoom, so an unbounded DLQ
+// full of whole original payloads eventually rejects every producer's publish
+// -- and publish-time trimming cannot then shrink anything back, because it
+// only runs as part of a successful XADD (compose/mq.yaml records that
+// self-locking condition).
+func TestReclaimPending_BoundsDLQStreamLength(t *testing.T) {
+	srv := miniredis.RunT(t)
+
+	ctx := context.Background()
+	seedClient := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+	defer func() { _ = seedClient.Close() }()
+
+	if err := seedClient.XGroupCreateMkStream(ctx, reclaimTestStream, reclaimTestGroup, "0").Err(); err != nil {
+		t.Fatalf("seed XGroupCreateMkStream: %v", err)
+	}
+
+	const poisonCount = 10
+	for i := 0; i < poisonCount; i++ {
+		if err := seedClient.XAdd(ctx, &redis.XAddArgs{
+			Stream: reclaimTestStream,
+			Values: map[string]interface{}{
+				"event_id": fmt.Sprintf("poison-%d", i),
+				"payload":  `{"article_id":"abc"}`,
+			},
+		}).Err(); err != nil {
+			t.Fatalf("seed poison XAdd %d: %v", i, err)
+		}
+	}
+
+	// Deliver to a ghost consumer that never ACKs, so every entry is already
+	// at one delivery when the reclaim sweep claims it.
+	if _, err := seedClient.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    reclaimTestGroup,
+		Consumer: "ghost-consumer",
+		Streams:  []string{reclaimTestStream, ">"},
+		Count:    poisonCount,
+	}).Result(); err != nil {
+		t.Fatalf("seed XReadGroup: %v", err)
+	}
+
+	claimIdleTime := 10 * time.Millisecond
+	const dlqMaxLen = 3
+
+	cfg := Config{
+		RedisURL:      fmt.Sprintf("redis://%s", srv.Addr()),
+		GroupName:     reclaimTestGroup,
+		ConsumerName:  "consumer-a",
+		StreamKey:     reclaimTestStream,
+		BatchSize:     poisonCount,
+		BlockTimeout:  time.Second,
+		ClaimIdleTime: claimIdleTime,
+		DLQStreamKey:  "alt:events:articles:dlq",
+		MaxDeliveries: 1,
+		DLQMaxLen:     dlqMaxLen,
+		Enabled:       true,
+	}
+
+	handler := &recordingHandler{err: fmt.Errorf("poison message: always fails")}
+
+	c, err := NewConsumer(cfg, handler, newQuietLogger())
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	defer c.Stop()
+
+	srv.SetTime(time.Now().Add(claimIdleTime + time.Second))
+
+	if err := c.reclaimPending(ctx); err != nil {
+		t.Fatalf("reclaimPending: %v", err)
+	}
+
+	// miniredis trims exactly and ignores the "~" modifier; real Redis keeps
+	// at least the cap. Either way the point is that a cap is attached at all,
+	// so the DLQ cannot grow without bound.
+	dlqLen, err := seedClient.XLen(ctx, cfg.DLQStreamKey).Result()
+	if err != nil {
+		t.Fatalf("XLen DLQ: %v", err)
+	}
+	if dlqLen == 0 {
+		t.Fatalf("DLQ stream is empty: the %d poison messages were never routed", poisonCount)
+	}
+	if dlqLen > dlqMaxLen {
+		t.Fatalf("DLQ stream length = %d after routing %d poison messages, want <= %d (the XADD carries no MAXLEN, so nothing bounds this stream)", dlqLen, poisonCount, dlqMaxLen)
+	}
+}
+
+// TestDLQMaxLen_UnsetConfigStillBounded pins the fallback: bootstrap/wire.go
+// builds Config as a struct literal, so a field it does not know about stays
+// zero. A zero cap must resolve to the package default rather than to
+// "unbounded" -- an unbounded DLQ is the failure mode this whole cap exists to
+// prevent, so it must never be reachable by forgetting to set a field.
+func TestDLQMaxLen_UnsetConfigStillBounded(t *testing.T) {
+	t.Parallel()
+
+	if got := (Config{}).effectiveDLQMaxLen(); got != defaultDLQMaxLen {
+		t.Fatalf("Config{}.effectiveDLQMaxLen() = %d, want %d", got, defaultDLQMaxLen)
+	}
+	if got := (Config{DLQMaxLen: 42}).effectiveDLQMaxLen(); got != 42 {
+		t.Fatalf("Config{DLQMaxLen: 42}.effectiveDLQMaxLen() = %d, want 42", got)
+	}
+	if cfg := DefaultConfig(); cfg.DLQMaxLen <= 0 {
+		t.Fatalf("DefaultConfig().DLQMaxLen = %d, want a positive cap", cfg.DLQMaxLen)
+	}
+}

--- a/pre-processor/app/consumer/redis_consumer.go
+++ b/pre-processor/app/consumer/redis_consumer.go
@@ -37,6 +37,31 @@ type Config struct {
 	// MaxDeliveries is the maximum number of times a single message may be
 	// delivered before it is moved to the DLQ. Zero disables DLQ routing.
 	MaxDeliveries int64
+	// DLQMaxLen caps the DLQ stream's length at XADD time. Zero or negative
+	// falls back to defaultDLQMaxLen -- see effectiveDLQMaxLen.
+	DLQMaxLen int64
+}
+
+// defaultDLQMaxLen bounds the DLQ stream when no cap is configured. Nothing
+// else trims it: mq-hub's periodic XTRIM pass only walks the four live streams
+// in domain.AllStreamKeys(), and no service consumes a DLQ. redis-streams runs
+// maxmemory 1gb under noeviction where XADD is denyoom, so an unbounded DLQ
+// carrying whole original payloads eventually rejects every producer's publish
+// (compose/mq.yaml records that self-locking condition). The value matches
+// mq-hub's STREAM_MAX_LEN so the DLQ can never outgrow the live stream it
+// shadows.
+const defaultDLQMaxLen int64 = 10000
+
+// effectiveDLQMaxLen resolves the cap actually handed to XADD. An unset cap
+// resolves to the bounded default rather than to "unbounded": bootstrap/wire.go
+// builds Config as a struct literal, and an unbounded DLQ is precisely the
+// failure mode this cap exists to prevent, so forgetting a field must not be
+// able to reach it.
+func (c Config) effectiveDLQMaxLen() int64 {
+	if c.DLQMaxLen <= 0 {
+		return defaultDLQMaxLen
+	}
+	return c.DLQMaxLen
 }
 
 // DefaultConfig returns a default consumer configuration.
@@ -52,6 +77,7 @@ func DefaultConfig() Config {
 		Enabled:       false,
 		DLQStreamKey:  "alt:events:articles:dlq",
 		MaxDeliveries: 5,
+		DLQMaxLen:     defaultDLQMaxLen,
 	}
 }
 
@@ -133,6 +159,7 @@ func (c *Consumer) Start(ctx context.Context) error {
 		"consumer", c.config.ConsumerName,
 		"dlq_stream", c.config.DLQStreamKey,
 		"max_deliveries", c.config.MaxDeliveries,
+		"dlq_max_len", c.config.effectiveDLQMaxLen(),
 	)
 
 	go c.consumeLoop(ctx)

--- a/pre-processor/app/consumer/redis_consumer_deliverycounts_test.go
+++ b/pre-processor/app/consumer/redis_consumer_deliverycounts_test.go
@@ -1,0 +1,153 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// handledMessageIDs returns the stream IDs the handler was actually invoked
+// with, under the handler's own lock.
+func handledMessageIDs(h *recordingHandler) []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ids := make([]string, 0, len(h.events))
+	for _, event := range h.events {
+		ids = append(ids, event.MessageID)
+	}
+	return ids
+}
+
+// TestReclaimPending_DLQsPoisonMessageDeepInThePEL reproduces the finding:
+// deliveryCounts looked the whole batch up with a single XPendingExt sweep
+// bounded by Start:"-", End:"+" and Count: len(messages)*2. That window only
+// ever covers the oldest few entries of this consumer's PEL, so once the PEL
+// is deeper than the window, a message from a later XAUTOCLAIM page is absent
+// from the result and its delivery count reads as zero. shouldSendToDLQ then
+// never fires for it and every sweep re-runs the poison message's handler --
+// a DB round-trip per sweep, forever. See mq-hub/CLAUDE.md rule 5 ("DLQ
+// conditions never fire").
+func TestReclaimPending_DLQsPoisonMessageDeepInThePEL(t *testing.T) {
+	srv := miniredis.RunT(t)
+
+	ctx := context.Background()
+	seedClient := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+	defer func() { _ = seedClient.Close() }()
+
+	const consumerName = "consumer-a"
+
+	if err := seedClient.XGroupCreateMkStream(ctx, reclaimTestStream, reclaimTestGroup, "0").Err(); err != nil {
+		t.Fatalf("seed XGroupCreateMkStream: %v", err)
+	}
+
+	// Fill this consumer's PEL with more low-ID entries than the old
+	// Count: len(messages)*2 window could ever return, so the poison message
+	// seeded after them lands on the third XAUTOCLAIM page.
+	const noiseCount = 21
+	for i := 0; i < noiseCount; i++ {
+		if err := seedClient.XAdd(ctx, &redis.XAddArgs{
+			Stream: reclaimTestStream,
+			Values: map[string]interface{}{"event_id": fmt.Sprintf("noise-%d", i)},
+		}).Err(); err != nil {
+			t.Fatalf("seed noise XAdd %d: %v", i, err)
+		}
+	}
+
+	targetID, err := seedClient.XAdd(ctx, &redis.XAddArgs{
+		Stream: reclaimTestStream,
+		Values: map[string]interface{}{"event_id": "poison"},
+	}).Result()
+	if err != nil {
+		t.Fatalf("seed poison XAdd: %v", err)
+	}
+
+	if _, err := seedClient.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    reclaimTestGroup,
+		Consumer: consumerName,
+		Streams:  []string{reclaimTestStream, ">"},
+		Count:    noiseCount + 1,
+	}).Result(); err != nil {
+		t.Fatalf("seed XReadGroup: %v", err)
+	}
+
+	// Drive only the poison message's delivery counter well past
+	// MaxDeliveries; the noise entries stay at one delivery so they keep
+	// occupying the front of the PEL instead of draining out of it.
+	const extraClaims = 5
+	for i := 0; i < extraClaims; i++ {
+		if _, err := seedClient.XClaim(ctx, &redis.XClaimArgs{
+			Stream:   reclaimTestStream,
+			Group:    reclaimTestGroup,
+			Consumer: consumerName,
+			MinIdle:  0,
+			Messages: []string{targetID},
+		}).Result(); err != nil {
+			t.Fatalf("pump poison XClaim %d: %v", i, err)
+		}
+	}
+
+	claimIdleTime := 10 * time.Millisecond
+
+	cfg := Config{
+		RedisURL:      fmt.Sprintf("redis://%s", srv.Addr()),
+		GroupName:     reclaimTestGroup,
+		ConsumerName:  consumerName,
+		StreamKey:     reclaimTestStream,
+		BatchSize:     10,
+		BlockTimeout:  time.Second,
+		ClaimIdleTime: claimIdleTime,
+		DLQStreamKey:  "alt:events:articles:dlq",
+		MaxDeliveries: 3,
+		Enabled:       true,
+	}
+
+	handler := &recordingHandler{err: fmt.Errorf("poison message: always fails")}
+
+	c, err := NewConsumer(cfg, handler, newQuietLogger())
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	defer c.Stop()
+
+	srv.SetTime(time.Now().Add(claimIdleTime + time.Second))
+
+	if err := c.reclaimPending(ctx); err != nil {
+		t.Fatalf("reclaimPending: %v", err)
+	}
+
+	dlqEntries, err := seedClient.XRange(ctx, cfg.DLQStreamKey, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("XRange DLQ: %v", err)
+	}
+	if len(dlqEntries) != 1 {
+		t.Fatalf("DLQ stream has %d entries, want 1 (the poison message sits on the third XAUTOCLAIM page, past the truncated XPENDING window)", len(dlqEntries))
+	}
+	if dlqEntries[0].Values["dlq_original_id"] != targetID {
+		t.Fatalf("DLQ entry dlq_original_id = %v, want %q", dlqEntries[0].Values["dlq_original_id"], targetID)
+	}
+
+	for _, id := range handledMessageIDs(handler) {
+		if id == targetID {
+			t.Fatalf("handler was re-invoked for the poison message %q; a message past MaxDeliveries must be DLQ'd, not retried", targetID)
+		}
+	}
+
+	stillPending, err := seedClient.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream: reclaimTestStream,
+		Group:  reclaimTestGroup,
+		Start:  targetID,
+		End:    targetID,
+		Count:  1,
+	}).Result()
+	if err != nil {
+		t.Fatalf("XPendingExt: %v", err)
+	}
+	if len(stillPending) != 0 {
+		t.Fatalf("poison message %q is still in the PEL after DLQ routing", targetID)
+	}
+}

--- a/pre-processor/app/driver/backend_api/article_backfill_exists_test.go
+++ b/pre-processor/app/driver/backend_api/article_backfill_exists_test.go
@@ -1,0 +1,154 @@
+package backend_api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"pre-processor/domain"
+	datahubv1 "pre-processor/gen/proto/services/datahub/v1"
+	"pre-processor/gen/proto/services/datahub/v1/datahubv1connect"
+)
+
+// fakeDataHub serves the slice of DataHubService the backfill path touches,
+// reproducing the one behaviour a client-interface mock cannot show: GetFeedID
+// resolves *feed* URLs only — alt-data-hub answers it by joining
+// feed_links.url (shared/driver/alt_db/feed_url_to_id_driver.go), so handing it
+// an article URL always comes back NotFound.
+type fakeDataHub struct {
+	datahubv1connect.UnimplementedDataHubServiceHandler
+
+	feedIDByFeedURL map[string]string // feed_links.url → feeds.id
+	existing        map[string]string // article url → feeds.id it already lives under
+
+	mu            sync.Mutex
+	getFeedIDURLs []string
+	existsChecks  []*datahubv1.CheckArticleExistsRequest
+	createdURLs   []string
+}
+
+func (f *fakeDataHub) GetFeedID(_ context.Context, req *connect.Request[datahubv1.GetFeedIDRequest]) (*connect.Response[datahubv1.GetFeedIDResponse], error) {
+	f.mu.Lock()
+	f.getFeedIDURLs = append(f.getFeedIDURLs, req.Msg.FeedUrl)
+	f.mu.Unlock()
+
+	feedID, ok := f.feedIDByFeedURL[req.Msg.FeedUrl]
+	if !ok {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("feed not found by URL"))
+	}
+	return connect.NewResponse(&datahubv1.GetFeedIDResponse{FeedId: feedID}), nil
+}
+
+func (f *fakeDataHub) CheckArticleExists(_ context.Context, req *connect.Request[datahubv1.CheckArticleExistsRequest]) (*connect.Response[datahubv1.CheckArticleExistsResponse], error) {
+	f.mu.Lock()
+	f.existsChecks = append(f.existsChecks, req.Msg)
+	f.mu.Unlock()
+
+	// Mirrors the handler's argument validation so a caller that forgets the
+	// feed_id fails here the way it would in production.
+	if req.Msg.FeedId == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("feed_id is required"))
+	}
+
+	feedID, ok := f.existing[req.Msg.Url]
+	return connect.NewResponse(&datahubv1.CheckArticleExistsResponse{
+		Exists: ok && feedID == req.Msg.FeedId,
+	}), nil
+}
+
+func (f *fakeDataHub) CreateArticle(_ context.Context, req *connect.Request[datahubv1.CreateArticleRequest]) (*connect.Response[datahubv1.CreateArticleResponse], error) {
+	f.mu.Lock()
+	f.createdURLs = append(f.createdURLs, req.Msg.Url)
+	f.mu.Unlock()
+
+	return connect.NewResponse(&datahubv1.CreateArticleResponse{ArticleId: "art-new"}), nil
+}
+
+func (f *fakeDataHub) snapshot() (feedLookups, created []string, checks []*datahubv1.CheckArticleExistsRequest) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getFeedIDURLs, f.createdURLs, f.existsChecks
+}
+
+func newBackfillTestRepo(t *testing.T, fake *fakeDataHub) *ArticleRepository {
+	t.Helper()
+
+	path, handler := datahubv1connect.NewDataHubServiceHandler(fake)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return NewArticleRepository(NewClient(srv.URL, "", srv.Client()), nil)
+}
+
+// TestUpsertArticlesWithFeedID_SkipsArticleAlreadyStoredUnderItsFeed pins the
+// DO NOTHING semantics the method promises: a backfill article whose URL is
+// already stored under the resolved feed must not be sent to CreateArticle
+// again, because the stored row may be a full-text fetch and the backfill row
+// is only an Inoreader RSS summary.
+//
+// The existence check has to run against the FeedID the caller already
+// resolved. Looking the feed up from the *article* URL cannot work — GetFeedID
+// matches feed_links.url — so that path returns NotFound for every backfill
+// article and the dedup silently degrades to "nothing exists".
+func TestUpsertArticlesWithFeedID_SkipsArticleAlreadyStoredUnderItsFeed(t *testing.T) {
+	fake := &fakeDataHub{
+		feedIDByFeedURL: map[string]string{"https://example.com/feed.xml": "feed-001"},
+		existing:        map[string]string{"https://example.com/articles/go-126": "feed-001"},
+	}
+	repo := newBackfillTestRepo(t, fake)
+
+	err := repo.UpsertArticlesWithFeedID(context.Background(), []*domain.Article{{
+		URL:     "https://example.com/articles/go-126",
+		Title:   "Go 1.26 Released",
+		Content: "RSS summary only.",
+		FeedID:  "feed-001",
+		UserID:  "user-001",
+	}})
+	require.NoError(t, err)
+
+	feedLookups, created, checks := fake.snapshot()
+
+	assert.Empty(t, created,
+		"an article already stored under feed-001 must be skipped, not re-created over the full-text row")
+	assert.Empty(t, feedLookups,
+		"the caller already resolved FeedID; GetFeedID must not be re-issued on the article URL, which can never match feed_links.url")
+	require.Len(t, checks, 1, "expected exactly one CheckArticleExists call")
+	assert.Equal(t, "feed-001", checks[0].FeedId,
+		"CheckArticleExists must carry the resolved FeedID")
+	assert.Equal(t, "https://example.com/articles/go-126", checks[0].Url)
+}
+
+// TestUpsertArticlesWithFeedID_CreatesArticleAbsentFromItsFeed is the other
+// half: the dedup must not turn into "skip everything". An article that is not
+// yet stored under its feed still gets created.
+func TestUpsertArticlesWithFeedID_CreatesArticleAbsentFromItsFeed(t *testing.T) {
+	fake := &fakeDataHub{
+		feedIDByFeedURL: map[string]string{"https://example.com/feed.xml": "feed-001"},
+		existing:        map[string]string{},
+	}
+	repo := newBackfillTestRepo(t, fake)
+
+	err := repo.UpsertArticlesWithFeedID(context.Background(), []*domain.Article{{
+		URL:     "https://example.com/articles/go-127",
+		Title:   "Go 1.27 Preview",
+		Content: "RSS summary only.",
+		FeedID:  "feed-001",
+		UserID:  "user-001",
+	}})
+	require.NoError(t, err)
+
+	feedLookups, created, _ := fake.snapshot()
+
+	assert.Equal(t, []string{"https://example.com/articles/go-127"}, created)
+	assert.Empty(t, feedLookups, "no GetFeedID round-trip is needed when FeedID is already resolved")
+}

--- a/pre-processor/app/driver/backend_api/article_driver.go
+++ b/pre-processor/app/driver/backend_api/article_driver.go
@@ -124,6 +124,37 @@ func (r *ArticleRepository) CheckExists(ctx context.Context, urls []string) (boo
 	return false, nil
 }
 
+// CheckExistsWithFeedID reports whether any of urls already exists under the
+// given feed.
+//
+// Unlike CheckExists it takes a feed_id the caller has already resolved. That
+// is the only form alt-data-hub can answer for an article URL: GetFeedID
+// matches feed_links.url, so looking a feed up from an article URL always
+// comes back NotFound and the check degrades to a silent "nothing exists".
+func (r *ArticleRepository) CheckExistsWithFeedID(ctx context.Context, feedID string, urls []string) (bool, error) {
+	if feedID == "" {
+		return false, fmt.Errorf("CheckExistsWithFeedID: feedID is required")
+	}
+
+	for _, u := range urls {
+		protoReq := &datahubv1.CheckArticleExistsRequest{
+			Url:    u,
+			FeedId: feedID,
+		}
+		req := connect.NewRequest(protoReq)
+		r.client.addAuth(req)
+
+		resp, err := r.client.client.CheckArticleExists(ctx, req)
+		if err != nil {
+			return false, fmt.Errorf("CheckArticleExists for %s: %w", u, err)
+		}
+		if resp.Msg.Exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // FindForSummarization finds articles that need summarization via the backend API.
 func (r *ArticleRepository) FindForSummarization(ctx context.Context, cursor *domain.Cursor, limit int) ([]*domain.Article, *domain.Cursor, error) {
 	protoReq := &datahubv1.ListUnsummarizedArticlesRequest{
@@ -262,28 +293,45 @@ func (r *ArticleRepository) FetchInoreaderArticlesForEmptyFeeds(ctx context.Cont
 	return result, scannedThrough, nil
 }
 
-// UpsertArticles batch upserts articles.
-// Articles with unresolvable feeds are skipped (matching legacy DB behavior),
-// while real errors (network, auth) abort the batch immediately.
+// UpsertArticles batch upserts articles, discarding the report of what it
+// refused. Callers that track a fetched_at watermark must use
+// UpsertArticlesReportingSkipped instead.
+func (r *ArticleRepository) UpsertArticles(ctx context.Context, articles []*domain.Article) error {
+	_, err := r.UpsertArticlesReportingSkipped(ctx, articles)
+	return err
+}
+
+// UpsertArticlesReportingSkipped batch upserts articles and returns the ones it
+// refused to write. Articles with unresolvable feeds are skipped (matching
+// legacy DB behavior), while real errors (network, auth) abort the batch
+// immediately.
+//
+// The refusals are reported rather than swallowed because none of them is a
+// property of the article: a missing inoreader_subscriptions row and a feed
+// alt-db has not registered yet both get fixed later without ever touching
+// inoreader_articles.fetched_at. A caller that advanced a fetched_at watermark
+// over such a row would sink it below its own window forever.
 //
 // A per-batch FeedURL → FeedID cache coalesces GetFeedID calls so a fan-out of
 // articles for the same feed only hits alt-backend once (Pillar 4, 2026-05-26).
 // The cache also remembers misses ("" sentinel) so a single unregistered feed
 // no longer produces N "feed not found" log lines — one warn per feed per
 // batch is enough to drive operator action.
-func (r *ArticleRepository) UpsertArticles(ctx context.Context, articles []*domain.Article) error {
+func (r *ArticleRepository) UpsertArticlesReportingSkipped(ctx context.Context, articles []*domain.Article) ([]*domain.Article, error) {
 	if len(articles) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	feedIDCache := make(map[string]string) // FeedURL → FeedID; "" means already-resolved miss.
 
 	var created int
 	var skippedFeedNotFound int
+	var skipped []*domain.Article
 	for _, article := range articles {
 		// Skip articles with empty FeedURL and no FeedID
 		if article.FeedURL == "" && article.FeedID == "" {
 			slog.WarnContext(ctx, "skipping article with empty FeedURL", "url", article.URL)
+			skipped = append(skipped, article)
 			continue
 		}
 
@@ -297,7 +345,7 @@ func (r *ArticleRepository) UpsertArticles(ctx context.Context, articles []*doma
 						// Real errors (network, auth, backend outage) abort the
 						// batch immediately instead of being silently treated as
 						// a missing feed — see doc comment above.
-						return fmt.Errorf("getFeedID for %s: %w", article.FeedURL, err)
+						return nil, fmt.Errorf("getFeedID for %s: %w", article.FeedURL, err)
 					}
 					// Feed not found in backend — log once per feed, cache the miss,
 					// and skip the rest of the batch's articles for the same URL.
@@ -316,6 +364,7 @@ func (r *ArticleRepository) UpsertArticles(ctx context.Context, articles []*doma
 			}
 			if cached == "" {
 				skippedFeedNotFound++
+				skipped = append(skipped, article)
 				continue
 			}
 			article.FeedID = cached
@@ -323,7 +372,7 @@ func (r *ArticleRepository) UpsertArticles(ctx context.Context, articles []*doma
 
 		// Create article — real errors (network, auth, etc.) abort the batch
 		if err := r.Create(ctx, article); err != nil {
-			return fmt.Errorf("upsert article %s: %w", article.URL, err)
+			return nil, fmt.Errorf("upsert article %s: %w", article.URL, err)
 		}
 		created++
 	}
@@ -332,7 +381,7 @@ func (r *ArticleRepository) UpsertArticles(ctx context.Context, articles []*doma
 		"created", created,
 		"total", len(articles),
 		"skipped_feed_not_found", skippedFeedNotFound)
-	return nil
+	return skipped, nil
 }
 
 // UpsertArticlesWithFeedID batch inserts articles that already have FeedID resolved.
@@ -350,8 +399,11 @@ func (r *ArticleRepository) UpsertArticlesWithFeedID(ctx context.Context, articl
 			continue
 		}
 
-		// Check existence first to avoid overwriting (ON CONFLICT DO NOTHING semantics)
-		exists, err := r.CheckExists(ctx, []string{article.URL})
+		// Check existence first to avoid overwriting (ON CONFLICT DO NOTHING
+		// semantics). The FeedID is already resolved here, so ask under it
+		// directly — CheckExists would try to re-derive a feed from the
+		// article URL and never find one.
+		exists, err := r.CheckExistsWithFeedID(ctx, article.FeedID, []string{article.URL})
 		if err != nil {
 			slog.WarnContext(ctx, "failed to check article existence, skipping", "url", article.URL, "error", err)
 			skipped++

--- a/pre-processor/app/driver/backend_api/article_driver_skipped_test.go
+++ b/pre-processor/app/driver/backend_api/article_driver_skipped_test.go
@@ -1,0 +1,99 @@
+package backend_api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	"pre-processor/domain"
+	datahubv1 "pre-processor/gen/proto/services/datahub/v1"
+)
+
+// TestUpsertArticlesReportingSkipped_ReportsFeedNotFound — a feed that
+// alt-data-hub has not registered yet is a refusal external to the article:
+// inoreader_articles.fetched_at is never bumped when the subscription lands
+// hours later, so a caller tracking a fetched_at watermark has to hear about
+// the refusal or the article is dropped for good.
+func TestUpsertArticlesReportingSkipped_ReportsFeedNotFound(t *testing.T) {
+	mock := &mockDataHubClient{
+		getFeedIDFunc: func(_ context.Context, req *connect.Request[datahubv1.GetFeedIDRequest]) (*connect.Response[datahubv1.GetFeedIDResponse], error) {
+			if req.Msg.FeedUrl == "https://unknown-feed.com" {
+				return nil, connect.NewError(connect.CodeNotFound, errors.New("feed not found"))
+			}
+			return connect.NewResponse(&datahubv1.GetFeedIDResponse{FeedId: "feed-1"}), nil
+		},
+	}
+	repo := newTestRepo(mock)
+
+	articles := []*domain.Article{
+		{URL: "https://example.com/unknown", FeedURL: "https://unknown-feed.com"},
+		{URL: "https://example.com/known", FeedURL: "https://known-feed.com"},
+	}
+
+	skipped, err := repo.UpsertArticlesReportingSkipped(context.Background(), articles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped article, got %d", len(skipped))
+	}
+	if skipped[0].URL != "https://example.com/unknown" {
+		t.Errorf("expected the unregistered-feed article to be reported, got %q", skipped[0].URL)
+	}
+}
+
+// TestUpsertArticlesReportingSkipped_ReportsEmptyFeedURL — the sync query
+// LEFT JOINs inoreader_subscriptions, so a missing subscription row surfaces
+// as an empty feed_url. That row too becomes writable once the subscription
+// arrives, hence it counts as a refusal rather than a permanently invalid row.
+func TestUpsertArticlesReportingSkipped_ReportsEmptyFeedURL(t *testing.T) {
+	mock := &mockDataHubClient{
+		getFeedIDFunc: func(_ context.Context, _ *connect.Request[datahubv1.GetFeedIDRequest]) (*connect.Response[datahubv1.GetFeedIDResponse], error) {
+			return connect.NewResponse(&datahubv1.GetFeedIDResponse{FeedId: "feed-1"}), nil
+		},
+	}
+	repo := newTestRepo(mock)
+
+	articles := []*domain.Article{
+		{URL: "https://example.com/no-feed"},
+		{URL: "https://example.com/has-feed", FeedURL: "https://feed.com"},
+	}
+
+	skipped, err := repo.UpsertArticlesReportingSkipped(context.Background(), articles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped article, got %d", len(skipped))
+	}
+	if skipped[0].URL != "https://example.com/no-feed" {
+		t.Errorf("expected the subscription-less article to be reported, got %q", skipped[0].URL)
+	}
+}
+
+// TestUpsertArticlesReportingSkipped_ReportsNothingWhenEverythingIsWritten
+// keeps the happy path silent — a caller must be free to advance its
+// watermark over a fully written batch.
+func TestUpsertArticlesReportingSkipped_ReportsNothingWhenEverythingIsWritten(t *testing.T) {
+	mock := &mockDataHubClient{
+		getFeedIDFunc: func(_ context.Context, _ *connect.Request[datahubv1.GetFeedIDRequest]) (*connect.Response[datahubv1.GetFeedIDResponse], error) {
+			return connect.NewResponse(&datahubv1.GetFeedIDResponse{FeedId: "feed-1"}), nil
+		},
+	}
+	repo := newTestRepo(mock)
+
+	articles := []*domain.Article{
+		{URL: "https://example.com/article1", FeedURL: "https://feed.com"},
+		{URL: "https://example.com/article2", FeedID: "preset-feed"},
+	}
+
+	skipped, err := repo.UpsertArticlesReportingSkipped(context.Background(), articles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("expected no skipped articles, got %d", len(skipped))
+	}
+}

--- a/pre-processor/app/quality-checker/quality_judger.go
+++ b/pre-processor/app/quality-checker/quality_judger.go
@@ -20,6 +20,14 @@ import (
 	logger "pre-processor/utils/logger"
 )
 
+// minValidScore/maxValidScore are the scale JudgeTemplate asks the model for
+// ("a single integer score from 1 to 10"), and the scale lowScoreThreshold is
+// compared against. A score outside it is a broken response, not a verdict.
+const (
+	minValidScore = 1
+	maxValidScore = 10
+)
+
 var (
 	// qualityCheckerAPIURL can be overridden in tests
 	qualityCheckerAPIURL = "http://news-creator:11434/api/generate"
@@ -270,22 +278,12 @@ func scoreSummary(ctx context.Context, prompt string) (*Score, error) {
 
 	score, err := parseScore(responseText)
 	if err != nil {
-		logger.Logger.ErrorContext(ctx, "Failed to parse score, attempting fallback", "error", err, "response", responseText)
-
-		// Try emergency fallback parsing strategies
-		fallbackScore := attemptEmergencyParsing(responseText)
-		if fallbackScore != nil {
-			logger.Logger.InfoContext(ctx, "Successfully parsed score using emergency fallback", "score", fallbackScore)
-			return fallbackScore, nil
-		}
-
-		// All parsing strategies exhausted. Return an error instead of a
-		// fabricated low score: Score{Overall: 1} falls below
-		// lowScoreThreshold and would get JudgeArticleQuality to delete a
-		// perfectly good summary purely because the model's output format
-		// broke, not because the summary is actually low quality — and a
-		// broken format tends to repeat, deleting summaries in a loop.
-		logger.Logger.ErrorContext(ctx, "Failed to parse score after all fallback strategies, skipping quality check", "response", responseText)
+		// No fallback parsing. A malformed response must skip the article
+		// rather than yield a fabricated score: anything below
+		// lowScoreThreshold gets JudgeArticleQuality to delete a perfectly good
+		// summary purely because the model's output format broke, and a broken
+		// format tends to repeat, deleting summaries in a loop.
+		logger.Logger.ErrorContext(ctx, "Failed to parse score, skipping quality check", "error", err, "response", responseText)
 		return nil, fmt.Errorf("could not parse score from model response: %w", err)
 	}
 
@@ -293,88 +291,54 @@ func scoreSummary(ctx context.Context, prompt string) (*Score, error) {
 	return &score, nil
 }
 
+// parseScore extracts the score from an anchored <score>N</score> tag and
+// rejects everything else.
+//
+// There is deliberately no "find any integer" fallback. An unanchored integer
+// is almost always part of the model's prose — 「3 つの事実が欠けている」 parsed
+// as Score{Overall: 3}, below lowScoreThreshold, so a perfectly good summary was
+// deleted and the article went back on the summarize queue. Because a broken
+// output format repeats, that turned into a delete → re-summarize loop.
 func parseScore(response string) (Score, error) {
 	response = strings.TrimSpace(response)
 	logger.Logger.Info("Parsing response", "original_response", response)
 
-	// Try to extract score from <score>X</score> pattern
 	// Closing tag is optional because Ollama's stop sequence includes "</score>",
 	// causing it to stop generating before outputting the closing tag.
-	re := regexp.MustCompile(`<score>(\d+)(?:</score>)?`)
+	//
+	// Whitespace around the digits is tolerated: `<score> 8 </score>` and
+	// `<score>\n8` are the model padding its own output, not prose, so rejecting
+	// them only burns all three scoreSummaryWithRetry attempts and leaves the
+	// article permanently unscoreable.
+	//
+	// The digits must still be followed by the closing tag or the end of the
+	// reply. Without that, `<score>\n3 つの事実が欠けている。` parses as 3 — the
+	// same prose adoption the removed fallback caused, just one tag further in.
+	re := regexp.MustCompile(`<score>\s*(\d+)\s*(?:</score>|$)`)
 	matches := re.FindStringSubmatch(response)
 
-	if len(matches) == 2 {
-		scoreStr := matches[1]
-		score, err := strconv.ParseInt(scoreStr, 10, strconv.IntSize)
-		if err != nil {
-			logger.Logger.Error("Failed to convert score to integer", "score_str", scoreStr, "error", err)
-			return Score{}, fmt.Errorf("failed to convert score to integer: %w", err)
-		}
-
-		// Clamp score to valid range (0-30)
-		if score < 0 {
-			score = 0
-		} else if score > 30 {
-			score = 30
-		}
-
-		return Score{Overall: int(score)}, nil
+	if len(matches) != 2 {
+		logger.Logger.Error("Could not extract score tag from response", "response", response)
+		return Score{}, fmt.Errorf("could not extract <score> tag from response: %s", response)
 	}
 
-	// Fallback: try to find any integer in the response
-	re = regexp.MustCompile(`\b(\d+)\b`)
-	matches = re.FindStringSubmatch(response)
-
-	if len(matches) == 2 {
-		scoreStr := matches[1]
-		score, err := strconv.ParseInt(scoreStr, 10, strconv.IntSize)
-		if err != nil {
-			logger.Logger.Error("Failed to convert fallback score to integer", "score_str", scoreStr, "error", err)
-			return Score{}, fmt.Errorf("failed to convert fallback score to integer: %w", err)
-		}
-
-		// Clamp score to valid range (0-30)
-		if score < 0 {
-			score = 0
-		} else if score > 30 {
-			score = 30
-		}
-
-		logger.Logger.Info("Used fallback score parsing", "score", score)
-		return Score{Overall: int(score)}, nil
+	scoreStr := matches[1]
+	score, err := strconv.ParseInt(scoreStr, 10, strconv.IntSize)
+	if err != nil {
+		logger.Logger.Error("Failed to convert score to integer", "score_str", scoreStr, "error", err)
+		return Score{}, fmt.Errorf("failed to convert score to integer: %w", err)
 	}
 
-	logger.Logger.Error("Could not extract score from response", "response", response)
-	return Score{}, fmt.Errorf("could not extract score from response: %s", response)
-}
-
-// attemptEmergencyParsing tries very aggressive parsing strategies as a last resort
-func attemptEmergencyParsing(response string) *Score {
-	// Remove all non-alphanumeric characters except spaces
-	cleaned := regexp.MustCompile(`[^\w\s]`).ReplaceAllString(response, " ")
-
-	// Find all integers in the response
-	re := regexp.MustCompile(`\b(\d+)\b`)
-	numbers := re.FindAllString(cleaned, -1)
-
-	// If we have at least 1 number, use the first one
-	if len(numbers) >= 1 {
-		score, err := strconv.ParseInt(numbers[0], 10, strconv.IntSize)
-		if err == nil {
-			// Clamp score to valid range (0-30)
-			if score < 0 {
-				score = 0
-			} else if score > 30 {
-				score = 30
-			}
-
-			logger.Logger.Info("Emergency parsing successful", "number", numbers[0], "score", score)
-			return &Score{Overall: int(score)}
-		}
+	// Out-of-scale values are rejected, not clamped: clamping down deletes a
+	// good summary and clamping up passes a bad one, both silently, when what
+	// actually happened is that the model ignored the output contract.
+	if score < minValidScore || score > maxValidScore {
+		logger.Logger.Error("Score outside the scale requested by JudgeTemplate",
+			"score", score, "min", minValidScore, "max", maxValidScore)
+		return Score{}, fmt.Errorf("score %d outside valid range %d-%d", score, minValidScore, maxValidScore)
 	}
 
-	logger.Logger.Warn("All emergency parsing strategies failed", "response", response)
-	return nil
+	return Score{Overall: int(score)}, nil
 }
 
 // RemoveLowScoreSummary deletes a low-quality summary via the repository.

--- a/pre-processor/app/quality-checker/quality_judger_test.go
+++ b/pre-processor/app/quality-checker/quality_judger_test.go
@@ -57,20 +57,20 @@ func TestParseScore(t *testing.T) {
 		description   string
 	}{
 		"valid_xml_format": {
-			input:         "<score>15</score>",
-			expectedScore: 15,
+			input:         "<score>7</score>",
+			expectedScore: 7,
 			expectedError: false,
 			description:   "Should parse valid XML-formatted score",
 		},
 		"valid_xml_with_whitespace": {
-			input:         "  <score>20</score>  ",
-			expectedScore: 20,
+			input:         "  <score>8</score>  ",
+			expectedScore: 8,
 			expectedError: false,
 			description:   "Should parse XML score with surrounding whitespace",
 		},
 		"valid_xml_with_surrounding_text": {
-			input:         "The quality is <score>25</score> out of 30",
-			expectedScore: 25,
+			input:         "The quality is <score>6</score> out of 10",
+			expectedScore: 6,
 			expectedError: false,
 			description:   "Should extract XML score from surrounding text",
 		},
@@ -80,41 +80,71 @@ func TestParseScore(t *testing.T) {
 			expectedError: false,
 			description:   "Should parse score without closing tag (Ollama stop sequence truncates it)",
 		},
-		"score_at_minimum_boundary": {
-			input:         "<score>0</score>",
-			expectedScore: 0,
+		"tag_with_surrounding_whitespace": {
+			input:         "<score> 8 </score>",
+			expectedScore: 8,
 			expectedError: false,
-			description:   "Should handle score at minimum boundary (0)",
+			description:   "Should parse a score padded with spaces inside the anchored tag",
+		},
+		"tag_with_newline_before_digits": {
+			input:         "<score>\n8",
+			expectedScore: 8,
+			expectedError: false,
+			description:   "Should parse a score on its own line inside the anchored tag",
+		},
+		"tag_then_prose_starting_with_a_digit": {
+			input:         "<score>\n3 つの事実が欠けている。",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Must not adopt a prose integer that merely follows the opening tag — that is the delete → re-summarize loop this parser exists to prevent",
+		},
+		"tag_then_prose_after_a_space": {
+			input:         "<score> 4 つの問題がある",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Whitespace tolerance must not extend to digits that begin a sentence",
+		},
+		"score_at_minimum_boundary": {
+			input:         "<score>1</score>",
+			expectedScore: 1,
+			expectedError: false,
+			description:   "Should handle score at minimum boundary (1)",
 		},
 		"score_at_maximum_boundary": {
-			input:         "<score>30</score>",
-			expectedScore: 30,
+			input:         "<score>10</score>",
+			expectedScore: 10,
 			expectedError: false,
-			description:   "Should handle score at maximum boundary (30)",
+			description:   "Should handle score at maximum boundary (10)",
 		},
-		"score_above_maximum_clamped": {
+		"error_score_above_scale": {
 			input:         "<score>50</score>",
-			expectedScore: 30,
-			expectedError: false,
-			description:   "Should clamp score above maximum to 30",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Should reject a score above the 1-10 scale instead of clamping it",
 		},
-		"score_below_minimum_clamped": {
+		"error_score_below_scale": {
+			input:         "<score>0</score>",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Should reject a score below the 1-10 scale instead of clamping it",
+		},
+		"error_negative_score": {
 			input:         "<score>-5</score>",
-			expectedScore: 5, // Regex extracts "5" from "-5", which is then clamped if needed
-			expectedError: false,
-			description:   "Should extract positive digit from negative score",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Should reject a negative score instead of reading its absolute value",
 		},
-		"fallback_plain_number": {
-			input:         "The score is 18",
-			expectedScore: 18,
-			expectedError: false,
-			description:   "Should use fallback parsing for plain number",
+		"error_plain_number_without_tag": {
+			input:         "The score is 8",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Should reject a bare integer: only the anchored <score> tag counts",
 		},
-		"fallback_first_number": {
-			input:         "Quality: 12 out of 30 points",
-			expectedScore: 12,
-			expectedError: false,
-			description:   "Should extract first number in fallback mode",
+		"error_integer_in_prose": {
+			input:         "この要約には 3 つの事実が欠けている。",
+			expectedScore: 0,
+			expectedError: true,
+			description:   "Should reject an integer that is part of the model's prose",
 		},
 		"error_no_score_found": {
 			input:         "No score available",
@@ -150,69 +180,6 @@ func TestParseScore(t *testing.T) {
 	}
 }
 
-// TestAttemptEmergencyParsing tests the emergency parsing fallback logic
-func TestAttemptEmergencyParsing(t *testing.T) {
-	tests := map[string]struct {
-		input         string
-		expectedScore *int
-		description   string
-	}{
-		"simple_number": {
-			input:         "15",
-			expectedScore: intPtr(15),
-			description:   "Should extract simple number",
-		},
-		"number_with_text": {
-			input:         "The quality score is 22 points",
-			expectedScore: intPtr(22),
-			description:   "Should extract number from text",
-		},
-		"number_with_special_chars": {
-			input:         "Score: [18] (good)",
-			expectedScore: intPtr(18),
-			description:   "Should extract number ignoring special characters",
-		},
-		"multiple_numbers_takes_first": {
-			input:         "12 out of 30",
-			expectedScore: intPtr(12),
-			description:   "Should take first number when multiple present",
-		},
-		"clamp_above_maximum": {
-			input:         "100",
-			expectedScore: intPtr(30),
-			description:   "Should clamp score above 30",
-		},
-		"clamp_below_minimum": {
-			input:         "-10",
-			expectedScore: intPtr(10), // Regex \b(\d+)\b only matches positive digits
-			description:   "Should extract positive digits from negative number",
-		},
-		"no_numbers": {
-			input:         "No score available",
-			expectedScore: nil,
-			description:   "Should return nil when no numbers found",
-		},
-		"empty_string": {
-			input:         "",
-			expectedScore: nil,
-			description:   "Should return nil for empty string",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := attemptEmergencyParsing(tc.input)
-
-			if tc.expectedScore == nil {
-				assert.Nil(t, result, tc.description)
-			} else {
-				require.NotNil(t, result, tc.description)
-				assert.Equal(t, *tc.expectedScore, result.Overall, tc.description)
-			}
-		})
-	}
-}
-
 // TestScoreSummary tests the scoreSummary function with mocked HTTP server
 func TestScoreSummary(t *testing.T) {
 	tests := map[string]struct {
@@ -224,33 +191,33 @@ func TestScoreSummary(t *testing.T) {
 		"successful_score_response": {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				response := ollamaResponse{
-					Response: "<score>20</score>",
+					Response: "<score>9</score>",
 					Done:     true,
 				}
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(response)
 			},
-			expectedScore: intPtr(20),
+			expectedScore: intPtr(9),
 			expectedError: false,
 			description:   "Should successfully parse valid Ollama response",
 		},
 		"response_with_text_and_score": {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				response := ollamaResponse{
-					Response: "The article quality is <score>25</score> because it's well-written.",
+					Response: "The article quality is <score>8</score> because it's well-written.",
 					Done:     true,
 				}
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(response)
 			},
-			expectedScore: intPtr(25),
+			expectedScore: intPtr(8),
 			expectedError: false,
 			description:   "Should extract score from response with surrounding text",
 		},
 		"response_incomplete": {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				response := ollamaResponse{
-					Response: "<score>15</score>",
+					Response: "<score>8</score>",
 					Done:     false, // Not completed
 				}
 				w.WriteHeader(http.StatusOK)
@@ -260,10 +227,10 @@ func TestScoreSummary(t *testing.T) {
 			expectedError: true,
 			description:   "Should error when Ollama response not completed",
 		},
-		"response_with_fallback_parsing": {
+		"response_without_score_tag_returns_error": {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				response := ollamaResponse{
-					Response: "Score is 18 points",
+					Response: "Score is 8 points",
 					Done:     true,
 				}
 				w.WriteHeader(http.StatusOK)
@@ -271,9 +238,9 @@ func TestScoreSummary(t *testing.T) {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
-			expectedScore: intPtr(18),
-			expectedError: false,
-			description:   "Should use fallback parsing when XML format not found",
+			expectedScore: nil,
+			expectedError: true,
+			description:   "Should error when the anchored <score> tag is missing, rather than adopting a bare integer",
 		},
 		"response_unparseable_returns_error": {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
@@ -349,7 +316,7 @@ func TestScoreSummaryWithRetry(t *testing.T) {
 		"success_on_first_attempt": {
 			serverBehavior: []func(w http.ResponseWriter, r *http.Request){
 				func(w http.ResponseWriter, r *http.Request) {
-					response := ollamaResponse{Response: "<score>20</score>", Done: true}
+					response := ollamaResponse{Response: "<score>9</score>", Done: true}
 					w.WriteHeader(http.StatusOK)
 					if err := json.NewEncoder(w).Encode(response); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -357,7 +324,7 @@ func TestScoreSummaryWithRetry(t *testing.T) {
 				},
 			},
 			maxRetries:    3,
-			expectedScore: intPtr(20),
+			expectedScore: intPtr(9),
 			expectedError: false,
 			description:   "Should succeed on first attempt",
 		},
@@ -367,7 +334,7 @@ func TestScoreSummaryWithRetry(t *testing.T) {
 					w.WriteHeader(http.StatusInternalServerError)
 				},
 				func(w http.ResponseWriter, r *http.Request) {
-					response := ollamaResponse{Response: "<score>15</score>", Done: true}
+					response := ollamaResponse{Response: "<score>8</score>", Done: true}
 					w.WriteHeader(http.StatusOK)
 					if err := json.NewEncoder(w).Encode(response); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -375,7 +342,7 @@ func TestScoreSummaryWithRetry(t *testing.T) {
 				},
 			},
 			maxRetries:    3,
-			expectedScore: intPtr(15),
+			expectedScore: intPtr(8),
 			expectedError: false,
 			description:   "Should succeed on second attempt after first failure",
 		},
@@ -473,7 +440,7 @@ func TestJudgeArticleQualityScoring(t *testing.T) {
 	// Test that scoring logic works correctly by mocking HTTP server
 	withMockTransport(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := ollamaResponse{
-			Response: "<score>25</score>", // High score
+			Response: "<score>9</score>", // High score
 			Done:     true,
 		}
 		w.WriteHeader(http.StatusOK)
@@ -562,24 +529,33 @@ func TestScoreSummaryContextCancellation(t *testing.T) {
 	require.Error(t, err, "Should error when context is cancelled")
 }
 
-// TestScoreBoundaryConditions tests score clamping edge cases
+// TestScoreBoundaryConditions pins the edges of the 1-10 scale JudgeTemplate
+// asks for. Values outside it are rejected rather than clamped: a clamped-down
+// value deletes a good summary and a clamped-up one passes a bad summary, both
+// without any signal that the model broke the output contract.
 func TestScoreBoundaryConditions(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected int
-		desc     string
+		input       string
+		expected    int
+		expectError bool
+		desc        string
 	}{
-		{"<score>-1</score>", 1, "Regex extracts 1 from -1"},
-		{"<score>0</score>", 0, "Zero score should remain 0"},
-		{"<score>30</score>", 30, "Max score should remain 30"},
-		{"<score>31</score>", 30, "Above max should clamp to 30"},
-		{"<score>1000</score>", 30, "Large value should clamp to 30"},
-		{"<score>-1000</score>", 30, "Regex extracts 1000 from -1000, clamped to 30"},
+		{"<score>1</score>", 1, false, "Min score should remain 1"},
+		{"<score>10</score>", 10, false, "Max score should remain 10"},
+		{"<score>0</score>", 0, true, "Zero is below the scale and must be rejected"},
+		{"<score>11</score>", 0, true, "Above max must be rejected"},
+		{"<score>1000</score>", 0, true, "Large value must be rejected"},
+		{"<score>-1</score>", 0, true, "Negative value must be rejected, not read as 1"},
+		{"<score>-1000</score>", 0, true, "Negative value must be rejected, not read as 1000"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			score, err := parseScore(tc.input)
+			if tc.expectError {
+				require.Error(t, err, tc.desc)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, score.Overall)
 		})
@@ -758,7 +734,7 @@ func TestJudgeArticleQualityContentWithinLimit(t *testing.T) {
 	// Create a server that returns a high score
 	withMockTransport(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := ollamaResponse{
-			Response: "<score>20</score>",
+			Response: "<score>9</score>",
 			Done:     true,
 		}
 		w.WriteHeader(http.StatusOK)
@@ -845,7 +821,7 @@ func TestJudgeArticleQualityContentBoundary(t *testing.T) {
 				// For proceed cases, we need a mock server
 				withMockTransport(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					response := ollamaResponse{
-						Response: "<score>20</score>",
+						Response: "<score>9</score>",
 						Done:     true,
 					}
 					w.WriteHeader(http.StatusOK)
@@ -1082,6 +1058,117 @@ func TestJudgeArticleQualityParseFailureDoesNotDelete(t *testing.T) {
 	err := JudgeArticleQuality(context.Background(), repo, nil, article)
 	require.Error(t, err, "a completely unparseable score response must surface as an error")
 	assert.False(t, repo.deleteCalled, "a parse failure must not delete the summary")
+}
+
+// TestJudgeArticleQualityMalformedScoreDoesNotDelete pins the data-loss path
+// behind the fallback parsers: any integer that is not an in-range
+// <score>N</score> used to be adopted as the score. Prose such as
+// 「3 つの事実が欠けている」 became Score{Overall: 3}, below lowScoreThreshold,
+// so the summary was deleted and the article went back on the summarize queue —
+// a delete → re-summarize loop for as long as the model's output format stayed
+// broken. A malformed score must surface as an error and leave the summary alone.
+func TestJudgeArticleQualityMalformedScoreDoesNotDelete(t *testing.T) {
+	tests := map[string]struct {
+		modelResponse string
+		description   string
+	}{
+		"prose_with_stray_integer": {
+			modelResponse: "この要約には 3 つの事実が欠けている。",
+			description:   "An integer inside prose is not a score",
+		},
+		"negative_anchored_score": {
+			modelResponse: "<score>-5</score>",
+			description:   "A negative score must not be read as its absolute value",
+		},
+		"anchored_score_above_scale": {
+			modelResponse: "<score>50</score>",
+			description:   "A score outside the 1-10 scale must not be silently clamped",
+		},
+		"anchored_score_below_scale": {
+			modelResponse: "<score>0</score>",
+			description:   "A score outside the 1-10 scale must not be treated as low quality",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			withMockTransport(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := ollamaResponse{
+					Response: tc.modelResponse,
+					Done:     true,
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+
+			originalURL := qualityCheckerAPIURL
+			qualityCheckerAPIURL = testQualityCheckerURL
+			t.Cleanup(func() { qualityCheckerAPIURL = originalURL })
+
+			article := &driver.ArticleWithSummary{
+				ArticleID:       "test-article-malformed-score",
+				Content:         "Test content",
+				SummaryJapanese: "テスト要約",
+			}
+
+			repo := &deleteTrackingSummaryRepo{}
+
+			err := JudgeArticleQuality(context.Background(), repo, nil, article)
+			require.Error(t, err, tc.description)
+			assert.False(t, repo.deleteCalled, "a malformed score must not delete the summary: %s", tc.description)
+		})
+	}
+}
+
+// TestJudgeArticleQualityAcceptsWhitespaceInScoreTag pins the other side of the
+// anchored-parser contract: dropping the fallback parsers also dropped the only
+// tolerance for whitespace inside the tag, so a reply such as `<score> 8 </score>`
+// failed to parse, burned all three scoreSummaryWithRetry attempts and made
+// JudgeArticleQuality error on every pass for that article. Whitespace padding is
+// still an anchored score, not prose — it must be accepted.
+func TestJudgeArticleQualityAcceptsWhitespaceInScoreTag(t *testing.T) {
+	tests := map[string]struct {
+		modelResponse string
+		description   string
+	}{
+		"spaces_inside_tag": {
+			modelResponse: "<score> 8 </score>",
+			description:   "Spaces padding the digits inside the tag",
+		},
+		"newline_before_digits": {
+			modelResponse: "<score>\n8",
+			description:   "Digits on the line after the opening tag (closing tag cut by the stop sequence)",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			withMockTransport(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := ollamaResponse{
+					Response: tc.modelResponse,
+					Done:     true,
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+
+			originalURL := qualityCheckerAPIURL
+			qualityCheckerAPIURL = testQualityCheckerURL
+			t.Cleanup(func() { qualityCheckerAPIURL = originalURL })
+
+			article := &driver.ArticleWithSummary{
+				ArticleID:       "test-article-whitespace-score",
+				Content:         "Test content",
+				SummaryJapanese: "テスト要約",
+			}
+
+			repo := &deleteTrackingSummaryRepo{}
+
+			err := JudgeArticleQuality(context.Background(), repo, nil, article)
+			require.NoError(t, err, "a whitespace-padded score tag must parse: %s", tc.description)
+			assert.False(t, repo.deleteCalled, "score 8 is above lowScoreThreshold, the summary must be kept")
+		})
+	}
 }
 
 // --- Gemma 4 chat template token tests ---

--- a/pre-processor/app/service/article_backfill_test.go
+++ b/pre-processor/app/service/article_backfill_test.go
@@ -23,7 +23,7 @@ func testLoggerBackfill() *slog.Logger {
 // --- Stubs ---
 
 type stubBackfillArticleRepo struct {
-	repository.ArticleRepository
+	SyncArticleRepository
 	emptyFeedArticles []*domain.Article
 	scannedThrough    time.Time
 	fetchCursors      []time.Time

--- a/pre-processor/app/service/article_sync_refused_rows_test.go
+++ b/pre-processor/app/service/article_sync_refused_rows_test.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"pre-processor/domain"
+	"pre-processor/repository"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stubRefusingArticleRepo mirrors the backend_api write path: an article whose
+// feed alt-db does not know yet is refused and UpsertArticles still returns
+// nil. The refusal is external to the row — inoreader_articles.fetched_at is
+// never bumped when the feed is registered hours later — so a watermark that
+// stepped over the row would drop the article forever.
+type stubRefusingArticleRepo struct {
+	repository.ArticleRepository
+	available   []*domain.Article
+	knownFeeds  map[string]bool
+	sinceValues []time.Time
+	written     []string
+}
+
+func (s *stubRefusingArticleRepo) FetchInoreaderArticles(_ context.Context, since time.Time) ([]*domain.Article, error) {
+	s.sinceValues = append(s.sinceValues, since)
+
+	var fetched []*domain.Article
+	for _, article := range s.available {
+		if article.CreatedAt.After(since) {
+			fetched = append(fetched, article)
+		}
+	}
+	sort.Slice(fetched, func(i, j int) bool { return fetched[i].CreatedAt.Before(fetched[j].CreatedAt) })
+
+	return fetched, nil
+}
+
+func (s *stubRefusingArticleRepo) UpsertArticlesReportingSkipped(_ context.Context, articles []*domain.Article) ([]*domain.Article, error) {
+	var skipped []*domain.Article
+	for _, article := range articles {
+		if !s.knownFeeds[article.FeedURL] {
+			skipped = append(skipped, article)
+			continue
+		}
+		s.written = append(s.written, article.URL)
+	}
+
+	return skipped, nil
+}
+
+func (s *stubRefusingArticleRepo) UpsertArticles(ctx context.Context, articles []*domain.Article) error {
+	_, err := s.UpsertArticlesReportingSkipped(ctx, articles)
+	return err
+}
+
+func TestSyncArticles_RedeliversArticlesTheWritePathRefused(t *testing.T) {
+	t.Run("should sync an article whose feed alt-db only learned about after the first run", func(t *testing.T) {
+		now := time.Now()
+		articleRepo := &stubRefusingArticleRepo{
+			available: []*domain.Article{
+				{
+					ID:        "inoreader-1",
+					URL:       "https://example.com/article1",
+					Title:     "Article 1",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-2 * time.Hour),
+				},
+			},
+			knownFeeds: map[string]bool{},
+		}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		// Run 1: the feed is not registered in alt-db yet, so the write path
+		// refuses the article while reporting success to the caller.
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+		assert.Empty(t, articleRepo.written)
+
+		// The feed gets registered between the two hourly runs.
+		articleRepo.knownFeeds["https://example.com/feed"] = true
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Equal(t, []string{"https://example.com/article1"}, articleRepo.written,
+			"an article the write path refused must stay inside the next run's window")
+		assert.Len(t, articleRepo.sinceValues, 2)
+		assert.True(t, articleRepo.sinceValues[1].Before(now.Add(-2*time.Hour)),
+			"the watermark must not advance past a row the write path refused")
+	})
+}
+
+func TestSyncArticles_WatermarkStopsBelowTheOldestRefusedRow(t *testing.T) {
+	t.Run("should keep re-offering only from the oldest refusal onwards", func(t *testing.T) {
+		now := time.Now()
+		articleRepo := &stubRefusingArticleRepo{
+			available: []*domain.Article{
+				{
+					ID:        "inoreader-1",
+					URL:       "https://example.com/known1",
+					Title:     "Known 1",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/known-feed",
+					CreatedAt: now.Add(-3 * time.Hour),
+				},
+				{
+					ID:        "inoreader-2",
+					URL:       "https://example.com/unknown",
+					Title:     "Unknown feed",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/unregistered-feed",
+					CreatedAt: now.Add(-2 * time.Hour),
+				},
+				{
+					ID:        "inoreader-3",
+					URL:       "https://example.com/known2",
+					Title:     "Known 2",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/known-feed",
+					CreatedAt: now.Add(-1 * time.Hour),
+				},
+			},
+			knownFeeds: map[string]bool{"https://example.com/known-feed": true},
+		}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Len(t, articleRepo.sinceValues, 1)
+
+		articleRepo.knownFeeds["https://example.com/unregistered-feed"] = true
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Equal(t, now.Add(-3*time.Hour), articleRepo.sinceValues[1],
+			"the watermark must stop below the oldest refused row, not at the newest scanned one")
+		assert.Equal(t, []string{
+			"https://example.com/known1",
+			"https://example.com/known2",
+			"https://example.com/unknown",
+			"https://example.com/known2",
+		}, articleRepo.written, "run 2 must re-offer the refused row and everything scanned after it")
+	})
+}
+
+func TestHoldWatermarkBelow_AbandonsARowRefusedFarBehindTheScanFront(t *testing.T) {
+	// A feed subscribed in Inoreader but never registered in alt-db is a stable
+	// state, not a transient one: nothing in pre-processor calls
+	// RegisterFeedLink. Holding the cursor below such a row forever pins the
+	// scan window open, so every already-synced article inside it is re-upserted
+	// on every hourly run — the amplification this watermark exists to stop.
+	// Past maxRefusalHold behind the scan front the row is abandoned loudly
+	// instead, which is what the fixed 24h window did anyway, only silently.
+	svc := &articleSyncService{logger: testLoggerBackfill()}
+	base := time.Now()
+
+	scanned := []*domain.Article{
+		{URL: "https://example.com/older-accepted", CreatedAt: base.Add(-3 * time.Hour)},
+		{URL: "https://example.com/stuck", FeedURL: "https://example.com/never", CreatedAt: base.Add(-2 * time.Hour)},
+	}
+	refused := []*domain.Article{scanned[1]}
+
+	t.Run("holds while the refusal is still within the hold window", func(t *testing.T) {
+		scannedThrough := base
+		held := svc.holdWatermarkBelow(context.Background(), scanned, refused, scannedThrough)
+
+		assert.Equal(t, base.Add(-3*time.Hour), held,
+			"a recently refused row must still pin the watermark below itself")
+	})
+
+	t.Run("abandons the refusal once the scan front has moved past the hold window", func(t *testing.T) {
+		scannedThrough := base.Add(maxRefusalHold + time.Hour)
+		held := svc.holdWatermarkBelow(context.Background(), scanned, refused, scannedThrough)
+
+		assert.Equal(t, scannedThrough, held,
+			"a row refused for longer than the hold window must not pin the cursor forever")
+	})
+}

--- a/pre-processor/app/service/article_sync_service.go
+++ b/pre-processor/app/service/article_sync_service.go
@@ -12,18 +12,51 @@ import (
 	"pre-processor/utils"
 )
 
+// syncStartupLookback bounds the first article-sync run of a process. The sync
+// watermark lives in memory, so after a restart the job re-scans this much
+// history instead of replaying the whole inoreader_articles table; every later
+// run starts strictly above what it already synced.
+const syncStartupLookback = 24 * time.Hour
+
+// maxRefusalHold bounds how far behind the scan front a refused row may pin the
+// watermark. A feed subscribed in Inoreader but never registered in alt-db is a
+// stable state, not a transient one — nothing here calls RegisterFeedLink — so
+// an unbounded hold keeps the scan window open forever and re-upserts every
+// already-synced article inside it on every run. Past this distance the row is
+// abandoned with a WARN naming the feed, which is what the fixed 24h window did
+// anyway, only silently.
+const maxRefusalHold = 24 * time.Hour
+
+// SyncArticleRepository is the article port article-sync needs: everything in
+// repository.ArticleRepository plus an upsert that reports what it refused to
+// write. Plain UpsertArticles returns nil even when the write path drops rows
+// for reasons external to them — a subscription row the sidecar has not
+// written yet, a feed alt-db has not registered yet — and those rows are the
+// ones the watermark must not step over, since nothing bumps their fetched_at
+// when the missing piece finally arrives.
+type SyncArticleRepository interface {
+	repository.ArticleRepository
+
+	// UpsertArticlesReportingSkipped upserts the batch and returns the
+	// articles it refused to write. A real failure (network, auth) is an
+	// error and aborts the batch as before.
+	UpsertArticlesReportingSkipped(ctx context.Context, articles []*domain.Article) ([]*domain.Article, error)
+}
+
 // ArticleSyncService implementation.
 type articleSyncService struct {
-	articleRepo     repository.ArticleRepository
+	articleRepo     SyncArticleRepository
 	externalAPIRepo repository.ExternalAPIRepository
 	sanitizer       *utils.Sanitizer
 	logger          *slog.Logger
 
-	// mu guards userID and lastBackfillFetchedAt, which are read and written
-	// by SyncArticles and BackfillEmptyFeeds — two independent JobRunner
-	// goroutines (article-sync, article-backfill) sharing this instance.
+	// mu guards userID, lastSyncedFetchedAt and lastBackfillFetchedAt, which
+	// are read and written by SyncArticles and BackfillEmptyFeeds — two
+	// independent JobRunner goroutines (article-sync, article-backfill)
+	// sharing this instance.
 	mu                    sync.Mutex
 	userID                string    // Cached system UserID
+	lastSyncedFetchedAt   time.Time // Watermark for sync progress (advances once a batch is upserted)
 	lastBackfillFetchedAt time.Time // Cursor for backfill progress (advances with each batch)
 }
 
@@ -49,6 +82,38 @@ func (s *articleSyncService) systemUserID(ctx context.Context) (string, error) {
 	s.mu.Unlock()
 
 	return userID, nil
+}
+
+// syncCursor returns the fetched_at watermark of the newest article-sync batch
+// that made it into alt-db.
+func (s *articleSyncService) syncCursor() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSyncedFetchedAt
+}
+
+// advanceSyncCursor moves the sync watermark forward, never backward.
+func (s *articleSyncService) advanceSyncCursor(t time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if t.After(s.lastSyncedFetchedAt) {
+		s.lastSyncedFetchedAt = t
+	}
+}
+
+// recordSyncProgress moves the watermark to the fetched_at of the last row the
+// run scanned, which includes the rows validation dropped: a skipped row never
+// becomes valid on its own, and if the sidecar later fixes it the upsert bumps
+// fetched_at, so the repaired row reappears above the watermark anyway. Rows
+// the write path refused are a different story and are excluded by the caller
+// — see holdWatermarkBelow.
+func (s *articleSyncService) recordSyncProgress(ctx context.Context, scannedThrough time.Time) {
+	if !scannedThrough.After(s.syncCursor()) {
+		return
+	}
+
+	s.advanceSyncCursor(scannedThrough)
+	s.logger.InfoContext(ctx, "sync watermark advanced", "watermark", s.syncCursor())
 }
 
 // backfillCursor returns the current backfill progress cursor.
@@ -83,7 +148,7 @@ func (s *articleSyncService) recordBackfillProgress(ctx context.Context, scanned
 
 // NewArticleSyncService creates a new article sync service.
 func NewArticleSyncService(
-	articleRepo repository.ArticleRepository,
+	articleRepo SyncArticleRepository,
 	externalAPIRepo repository.ExternalAPIRepository,
 	logger *slog.Logger,
 ) ArticleSyncService {
@@ -107,9 +172,15 @@ func (s *articleSyncService) SyncArticles(ctx context.Context) error {
 	}
 	s.logger.InfoContext(ctx, "retrieved system user id", "user_id", userID)
 
-	// Fetch articles from the last 24 hours (or configurable)
-	// For now, let's look back 24 hours to catch any lag
-	since := time.Now().Add(-24 * time.Hour)
+	// Take only what the sidecar wrote after the last batch we synced. The
+	// query is fetched_at > since with no LIMIT, so a fixed 24h window would
+	// re-upsert every article once per hourly run — 24 CreateArticle RPCs and
+	// 24 ArticleUpdated events per article. The 24h window is the startup
+	// re-scan only, until the first batch sets the watermark.
+	since := s.syncCursor()
+	if since.IsZero() {
+		since = time.Now().Add(-syncStartupLookback)
+	}
 
 	articles, err := s.articleRepo.FetchInoreaderArticles(ctx, since)
 	if err != nil {
@@ -124,8 +195,17 @@ func (s *articleSyncService) SyncArticles(ctx context.Context) error {
 
 	s.logger.InfoContext(ctx, "processing articles for sync", "count", len(articles))
 
+	// scannedThrough is the fetched_at watermark of this run. It is the max over
+	// every row fetched rather than the last one returned, because the fetch
+	// ordering is the driver's business, not this service's.
+	var scannedThrough time.Time
+
 	var validArticles []*domain.Article
 	for _, article := range articles {
+		if article.CreatedAt.After(scannedThrough) {
+			scannedThrough = article.CreatedAt
+		}
+
 		// 1. Sanitize content (Zero-Trust)
 		sanitizedContent := s.sanitizer.SanitizeHTMLAndTrim(article.Content)
 
@@ -150,16 +230,85 @@ func (s *articleSyncService) SyncArticles(ctx context.Context) error {
 
 	// 3. Upsert
 	if len(validArticles) > 0 {
-		if err := s.articleRepo.UpsertArticles(ctx, validArticles); err != nil {
+		refused, err := s.articleRepo.UpsertArticlesReportingSkipped(ctx, validArticles)
+		if err != nil {
 			s.logger.ErrorContext(ctx, "failed to upsert articles", "error", err)
 			return fmt.Errorf("failed to upsert articles: %w", err)
 		}
-		s.logger.InfoContext(ctx, "successfully synced articles", "count", len(validArticles))
+		s.logger.InfoContext(ctx, "successfully synced articles",
+			"count", len(validArticles)-len(refused),
+			"refused", len(refused))
+
+		scannedThrough = s.holdWatermarkBelow(ctx, articles, refused, scannedThrough)
 	} else {
 		s.logger.InfoContext(ctx, "no valid articles to upsert after validation")
 	}
 
+	// Only now that the batch is durable in alt-db: a failed upsert returns
+	// above, leaving the watermark where it was so the next run retries it.
+	s.recordSyncProgress(ctx, scannedThrough)
+
 	return nil
+}
+
+// holdWatermarkBelow pulls this run's watermark back under the oldest row the
+// write path refused, so the next run re-offers it. Refusals are external to
+// the row — the subscription or the feed shows up in alt-db hours later
+// without inoreader_articles.fetched_at moving — so a watermark left at
+// scannedThrough would sink those articles under `fetched_at > since` forever.
+// The next query is strictly greater-than, hence the watermark stops at the
+// newest row scanned *before* the refusal, not at the refusal itself.
+func (s *articleSyncService) holdWatermarkBelow(ctx context.Context, scanned, refused []*domain.Article, scannedThrough time.Time) time.Time {
+	holdFloor := scannedThrough.Add(-maxRefusalHold)
+
+	var refusedFrom time.Time
+	var abandoned []*domain.Article
+	for _, article := range refused {
+		// A row this far behind the scan front is not waiting on a registration
+		// that is about to happen; holding for it costs every later run.
+		if article.CreatedAt.Before(holdFloor) {
+			abandoned = append(abandoned, article)
+			continue
+		}
+		if refusedFrom.IsZero() || article.CreatedAt.Before(refusedFrom) {
+			refusedFrom = article.CreatedAt
+		}
+	}
+
+	if len(abandoned) > 0 {
+		s.logger.WarnContext(ctx, "abandoning rows the upsert has refused for longer than the hold window",
+			"abandoned", len(abandoned),
+			"oldest_url", abandoned[0].URL,
+			"oldest_feed_url", abandoned[0].FeedURL,
+			"hold_window", maxRefusalHold)
+	}
+
+	if refusedFrom.IsZero() {
+		return scannedThrough
+	}
+
+	var held time.Time
+	for _, article := range scanned {
+		if article.CreatedAt.Before(refusedFrom) && article.CreatedAt.After(held) {
+			held = article.CreatedAt
+		}
+	}
+
+	// recordSyncProgress never moves the cursor backwards, so the watermark that
+	// actually takes effect is whichever of the two is newer. Logging `held`
+	// alone reports 0001-01-01 whenever the oldest scanned row is the refused
+	// one, which reads as "the cursor was reset to the epoch".
+	effective := held
+	if cursor := s.syncCursor(); cursor.After(effective) {
+		effective = cursor
+	}
+
+	s.logger.WarnContext(ctx, "holding sync watermark below rows the upsert refused",
+		"refused", len(refused),
+		"refused_from", refusedFrom,
+		"watermark", effective)
+
+	return held
 }
 
 // BackfillEmptyFeeds inserts Inoreader articles as core articles for feeds that have no articles.

--- a/pre-processor/app/service/article_sync_service_race_test.go
+++ b/pre-processor/app/service/article_sync_service_race_test.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"pre-processor/domain"
-	"pre-processor/repository"
 )
 
-// raceArticleRepo implements the subset of repository.ArticleRepository used
-// by both SyncArticles and BackfillEmptyFeeds so the two code paths can be
-// driven concurrently in the same test.
+// raceArticleRepo implements the subset of SyncArticleRepository used by both
+// SyncArticles and BackfillEmptyFeeds so the two code paths can be driven
+// concurrently in the same test.
 type raceArticleRepo struct {
-	repository.ArticleRepository
+	SyncArticleRepository
 }
 
 func (r *raceArticleRepo) FetchInoreaderArticles(_ context.Context, _ time.Time) ([]*domain.Article, error) {
@@ -23,8 +22,8 @@ func (r *raceArticleRepo) FetchInoreaderArticles(_ context.Context, _ time.Time)
 	}, nil
 }
 
-func (r *raceArticleRepo) UpsertArticles(_ context.Context, _ []*domain.Article) error {
-	return nil
+func (r *raceArticleRepo) UpsertArticlesReportingSkipped(_ context.Context, _ []*domain.Article) ([]*domain.Article, error) {
+	return nil, nil
 }
 
 func (r *raceArticleRepo) FetchInoreaderArticlesForEmptyFeeds(_ context.Context, _ time.Time, _ int) ([]*domain.Article, time.Time, error) {

--- a/pre-processor/app/service/article_sync_watermark_test.go
+++ b/pre-processor/app/service/article_sync_watermark_test.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"pre-processor/domain"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stubSyncArticleRepo mirrors the driver query behind FetchInoreaderArticles
+// (`WHERE fetched_at > $1 ORDER BY fetched_at ASC`, no LIMIT) so consecutive
+// article-sync runs can be observed the way the hourly JobRunner drives them.
+type stubSyncArticleRepo struct {
+	SyncArticleRepository
+	available     []*domain.Article
+	sinceValues   []time.Time
+	upsertBatches [][]*domain.Article
+	upsertErr     error
+}
+
+func (s *stubSyncArticleRepo) FetchInoreaderArticles(_ context.Context, since time.Time) ([]*domain.Article, error) {
+	s.sinceValues = append(s.sinceValues, since)
+
+	var fetched []*domain.Article
+	for _, article := range s.available {
+		if article.CreatedAt.After(since) {
+			fetched = append(fetched, article)
+		}
+	}
+	sort.Slice(fetched, func(i, j int) bool { return fetched[i].CreatedAt.Before(fetched[j].CreatedAt) })
+
+	return fetched, nil
+}
+
+// UpsertArticlesReportingSkipped accepts every article it is given — these
+// tests cover the watermark against validation drops, not against the write
+// path refusing rows (see article_sync_refused_rows_test.go for that).
+func (s *stubSyncArticleRepo) UpsertArticlesReportingSkipped(_ context.Context, articles []*domain.Article) ([]*domain.Article, error) {
+	if s.upsertErr != nil {
+		return nil, s.upsertErr
+	}
+
+	s.upsertBatches = append(s.upsertBatches, articles)
+
+	return nil, nil
+}
+
+func (s *stubSyncArticleRepo) upsertedCount() int {
+	var total int
+	for _, batch := range s.upsertBatches {
+		total += len(batch)
+	}
+
+	return total
+}
+
+func TestSyncArticles_DoesNotResyncAlreadySyncedArticles(t *testing.T) {
+	t.Run("should upsert each article once across consecutive hourly runs", func(t *testing.T) {
+		now := time.Now()
+		articleRepo := &stubSyncArticleRepo{
+			available: []*domain.Article{
+				{
+					ID:        "inoreader-1",
+					URL:       "https://example.com/article1",
+					Title:     "Article 1",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-2 * time.Hour),
+				},
+				{
+					ID:        "inoreader-2",
+					URL:       "https://example.com/article2",
+					Title:     "Article 2",
+					Content:   "<p>Another valid article with sufficient content length.</p>",
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-30 * time.Minute),
+				},
+			},
+		}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Equal(t, 2, articleRepo.upsertedCount(), "already-synced articles must not be upserted again")
+		assert.Len(t, articleRepo.sinceValues, 3)
+		assert.Equal(t, now.Add(-30*time.Minute), articleRepo.sinceValues[1], "second run must start strictly above the newest synced fetched_at")
+		assert.Equal(t, now.Add(-30*time.Minute), articleRepo.sinceValues[2])
+	})
+}
+
+func TestSyncArticles_PicksUpArticlesArrivingAfterTheWatermark(t *testing.T) {
+	t.Run("should sync articles written after the previous run", func(t *testing.T) {
+		now := time.Now()
+		articleRepo := &stubSyncArticleRepo{
+			available: []*domain.Article{
+				{
+					ID:        "inoreader-1",
+					URL:       "https://example.com/article1",
+					Title:     "Article 1",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-2 * time.Hour),
+				},
+			},
+		}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		articleRepo.available = append(articleRepo.available, &domain.Article{
+			ID:        "inoreader-2",
+			URL:       "https://example.com/article2",
+			Title:     "Article 2",
+			Content:   "<p>Freshly harvested content that must still be synced.</p>",
+			FeedURL:   "https://example.com/feed",
+			CreatedAt: now.Add(-1 * time.Minute),
+		})
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Equal(t, 2, articleRepo.upsertedCount())
+		assert.Len(t, articleRepo.upsertBatches, 2)
+		assert.Equal(t, "https://example.com/article2", articleRepo.upsertBatches[1][0].URL)
+	})
+}
+
+func TestSyncArticles_FirstRunLooksBack24Hours(t *testing.T) {
+	t.Run("should rescan the last 24 hours on the first run of the process", func(t *testing.T) {
+		articleRepo := &stubSyncArticleRepo{}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Len(t, articleRepo.sinceValues, 1)
+		assert.WithinDuration(t, time.Now().Add(-24*time.Hour), articleRepo.sinceValues[0], time.Minute)
+	})
+}
+
+func TestSyncArticles_WatermarkPassesSkippedArticles(t *testing.T) {
+	t.Run("should not rescan articles the validation dropped", func(t *testing.T) {
+		now := time.Now()
+		articleRepo := &stubSyncArticleRepo{
+			available: []*domain.Article{
+				{
+					ID:        "inoreader-1",
+					URL:       "https://example.com/article1",
+					Title:     "Article 1",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-2 * time.Hour),
+				},
+				{
+					ID:        "inoreader-2",
+					URL:       "https://example.com/article2",
+					Title:     "Article 2",
+					Content:   "<script>alert('xss')</script>", // empty after sanitization
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-1 * time.Hour),
+				},
+			},
+		}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+		assert.NoError(t, svc.SyncArticles(context.Background()))
+
+		assert.Len(t, articleRepo.sinceValues, 2)
+		assert.Equal(t, now.Add(-1*time.Hour), articleRepo.sinceValues[1], "the watermark must cover every scanned row, not only the upserted ones")
+	})
+}
+
+func TestSyncArticles_KeepsWatermarkWhenUpsertFails(t *testing.T) {
+	t.Run("should re-fetch the batch that was never persisted", func(t *testing.T) {
+		now := time.Now()
+		articleRepo := &stubSyncArticleRepo{
+			available: []*domain.Article{
+				{
+					ID:        "inoreader-1",
+					URL:       "https://example.com/article1",
+					Title:     "Article 1",
+					Content:   "<p>Valid content long enough to survive sanitization.</p>",
+					FeedURL:   "https://example.com/feed",
+					CreatedAt: now.Add(-2 * time.Hour),
+				},
+			},
+			upsertErr: fmt.Errorf("datahub unavailable"),
+		}
+		externalAPI := &stubBackfillExternalAPI{userID: "system-user-id"}
+
+		svc := NewArticleSyncService(articleRepo, externalAPI, testLoggerBackfill())
+
+		assert.Error(t, svc.SyncArticles(context.Background()))
+		assert.Error(t, svc.SyncArticles(context.Background()))
+
+		assert.Len(t, articleRepo.sinceValues, 2)
+		assert.True(t, articleRepo.sinceValues[1].Before(now.Add(-2*time.Hour)), "a failed batch must stay inside the next run's window")
+	})
+}

--- a/rag-orchestrator/internal/backfill/runner.go
+++ b/rag-orchestrator/internal/backfill/runner.go
@@ -179,6 +179,10 @@ func (r *Runner) runByDateRange(ctx context.Context, cursor Cursor) error {
 	fromDate = time.Date(fromDate.Year(), fromDate.Month(), fromDate.Day(), 0, 0, 0, 0, time.UTC)
 	toDate = time.Date(toDate.Year(), toDate.Month(), toDate.Day(), 0, 0, 0, 0, time.UTC)
 
+	// Once an article fails the cursor is pinned in front of it, so the
+	// remaining days must not move the resume point either.
+	cursorHeld := false
+
 	// Process newest first (DESC order)
 	for day := toDate; !day.Before(fromDate); day = day.AddDate(0, 0, -1) {
 		select {
@@ -197,7 +201,7 @@ func (r *Runner) runByDateRange(ctx context.Context, cursor Cursor) error {
 
 		r.logger.Info("processing date", slog.String("date", dayStr))
 
-		count, err := r.processDay(ctx, day, &cursor)
+		count, held, err := r.processDay(ctx, day, &cursor, cursorHeld)
 		if err != nil {
 			return fmt.Errorf("process day %s: %w", dayStr, err)
 		}
@@ -206,6 +210,20 @@ func (r *Runner) runByDateRange(ctx context.Context, cursor Cursor) error {
 			slog.String("date", dayStr),
 			slog.Int("articles", count),
 		)
+
+		if held {
+			if !cursorHeld {
+				// This day still owns a failed article: keep it as the resume
+				// point instead of marking it done, otherwise the retry is
+				// skipped forever. Older days are still processed below.
+				cursor.CurrentDate = dayStr
+				if err := r.cursorManager.Save(cursor); err != nil {
+					r.logger.Warn("failed to save cursor", slog.String("error", err.Error()))
+				}
+				cursorHeld = true
+			}
+			continue
+		}
 
 		// Update cursor to next day
 		cursor.CurrentDate = day.AddDate(0, 0, -1).Format("2006-01-02")
@@ -219,13 +237,16 @@ func (r *Runner) runByDateRange(ctx context.Context, cursor Cursor) error {
 	r.logger.Info("backfill completed",
 		slog.Int64("total_processed", atomic.LoadInt64(&r.stats.Processed)),
 		slog.Int64("total_failed", atomic.LoadInt64(&r.stats.Failed)),
+		slog.Bool("cursor_held", cursorHeld),
 	)
 
 	return nil
 }
 
 // processDay processes all articles for a single day.
-func (r *Runner) processDay(ctx context.Context, day time.Time, cursor *Cursor) (int, error) {
+// cursorHeld carries over the "a failed article pinned the cursor" state from
+// earlier days; the updated state is returned to the caller.
+func (r *Runner) processDay(ctx context.Context, day time.Time, cursor *Cursor, cursorHeld bool) (int, bool, error) {
 	dayStart := day
 	dayEnd := day.AddDate(0, 0, 1)
 
@@ -247,7 +268,7 @@ func (r *Runner) processDay(ctx context.Context, day time.Time, cursor *Cursor) 
 
 	query += ` ORDER BY created_at DESC, id DESC`
 
-	return r.processBatches(ctx, query, args, cursor)
+	return r.processBatches(ctx, query, args, cursor, cursorHeld)
 }
 
 // runAll processes all articles using cursor-based pagination.
@@ -267,7 +288,7 @@ func (r *Runner) runAll(ctx context.Context, cursor Cursor) error {
 
 	query += ` ORDER BY created_at DESC, id DESC`
 
-	_, err := r.processBatches(ctx, query, args, &cursor)
+	_, cursorHeld, err := r.processBatches(ctx, query, args, &cursor, false)
 	if err != nil {
 		return err
 	}
@@ -275,16 +296,21 @@ func (r *Runner) runAll(ctx context.Context, cursor Cursor) error {
 	r.logger.Info("backfill completed",
 		slog.Int64("total_processed", atomic.LoadInt64(&r.stats.Processed)),
 		slog.Int64("total_failed", atomic.LoadInt64(&r.stats.Failed)),
+		slog.Bool("cursor_held", cursorHeld),
 	)
 
 	return nil
 }
 
 // processBatches processes articles in batches from the given query.
-func (r *Runner) processBatches(ctx context.Context, query string, args []interface{}, cursor *Cursor) (int, error) {
+// It returns whether the cursor is held: the keyset predicate is
+// `(created_at, id) < cursor`, so any row the cursor passes over is never
+// selected again. A per-article failure therefore pins the cursor in front of
+// that row for the rest of the run.
+func (r *Runner) processBatches(ctx context.Context, query string, args []interface{}, cursor *Cursor, cursorHeld bool) (int, bool, error) {
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return 0, fmt.Errorf("query articles: %w", err)
+		return 0, cursorHeld, fmt.Errorf("query articles: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -309,22 +335,23 @@ func (r *Runner) processBatches(ctx context.Context, query string, args []interf
 		}
 
 		// Process batch concurrently
+		failed := make([]bool, len(batch))
 		var wg sync.WaitGroup
-		for _, a := range batch {
+		for i, a := range batch {
 			select {
 			case <-ctx.Done():
-				return totalCount, ctx.Err()
+				return totalCount, cursorHeld, ctx.Err()
 			default:
 			}
 
 			// Rate limit
 			if err := r.limiter.Wait(ctx); err != nil {
-				return totalCount, err
+				return totalCount, cursorHeld, err
 			}
 
 			wg.Add(1)
 			sem <- struct{}{}
-			go func(article Article) {
+			go func(idx int, article Article) {
 				defer wg.Done()
 				defer func() { <-sem }()
 
@@ -342,23 +369,44 @@ func (r *Runner) processBatches(ctx context.Context, query string, args []interf
 						slog.String("id", article.ID),
 						slog.String("error", err.Error()),
 					)
+					failed[idx] = true
 					atomic.AddInt64(&r.stats.Failed, 1)
 				} else {
 					atomic.AddInt64(&r.stats.Processed, 1)
 				}
-			}(a)
+			}(i, a)
 		}
 		wg.Wait()
 
-		// Update cursor
-		lastArticle := batch[len(batch)-1]
-		cursor.LastCreatedAt = lastArticle.CreatedAt
-		cursor.LastID = lastArticle.ID
-		cursor.ProcessedCount += len(batch)
+		// Advance the cursor over the leading run of successes only. Stopping
+		// in front of the first failure is what makes the next run pick that
+		// article up again instead of losing it to the keyset predicate.
+		if !cursorHeld {
+			indexed := 0
+			for indexed < len(batch) && !failed[indexed] {
+				indexed++
+			}
 
-		if !r.cfg.DryRun {
-			if err := r.cursorManager.Save(*cursor); err != nil {
-				r.logger.Warn("failed to save cursor", slog.String("error", err.Error()))
+			if indexed < len(batch) {
+				cursorHeld = true
+				r.logger.Warn("cursor held in front of failed article",
+					slog.String("article_id", batch[indexed].ID),
+					slog.Time("article_created_at", batch[indexed].CreatedAt),
+					slog.Int("advanced", indexed),
+				)
+			}
+
+			if indexed > 0 {
+				lastArticle := batch[indexed-1]
+				cursor.LastCreatedAt = lastArticle.CreatedAt
+				cursor.LastID = lastArticle.ID
+				cursor.ProcessedCount += indexed
+
+				if !r.cfg.DryRun {
+					if err := r.cursorManager.Save(*cursor); err != nil {
+						r.logger.Warn("failed to save cursor", slog.String("error", err.Error()))
+					}
+				}
 			}
 		}
 
@@ -366,10 +414,10 @@ func (r *Runner) processBatches(ctx context.Context, query string, args []interf
 	}
 
 	if err := rows.Err(); err != nil {
-		return totalCount, fmt.Errorf("iterate rows: %w", err)
+		return totalCount, cursorHeld, fmt.Errorf("iterate rows: %w", err)
 	}
 
-	return totalCount, nil
+	return totalCount, cursorHeld, nil
 }
 
 // indexArticle dispatches to direct indexer or HTTP depending on mode.

--- a/rag-orchestrator/internal/backfill/runner_test.go
+++ b/rag-orchestrator/internal/backfill/runner_test.go
@@ -1,0 +1,395 @@
+package backfill
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func TestRunner_FailedArticleIsRetriedOnNextRun(t *testing.T) {
+	base := time.Date(2026, 3, 2, 9, 0, 0, 0, time.UTC)
+	rows := []Article{
+		testArticle("a3", base.Add(2*time.Hour)),
+		testArticle("a2", base.Add(1*time.Hour)),
+		testArticle("a1", base),
+	}
+
+	orch := newFakeOrchestrator("a2")
+	srv := httptest.NewServer(orch)
+	defer srv.Close()
+
+	cursorPath := filepath.Join(t.TempDir(), "cursor.json")
+
+	first := newTestRunner(t, cursorPath, srv.URL, rows)
+	require.NoError(t, first.Run(context.Background()))
+	require.Equal(t, int64(1), atomic.LoadInt64(&first.stats.Failed))
+	require.ElementsMatch(t, []string{"a3", "a1"}, orch.indexedIDs())
+
+	// The orchestrator recovers: the article that failed must still be
+	// reachable, otherwise it drops out of the index for good.
+	orch.healAll()
+	orch.forgetIndexed()
+
+	second := newTestRunner(t, cursorPath, srv.URL, rows)
+	require.NoError(t, second.Run(context.Background()))
+
+	assert.Contains(t, orch.indexedIDs(), "a2",
+		"article that failed in the first run must be re-selected by the next run")
+	assert.Equal(t, int64(0), atomic.LoadInt64(&second.stats.Failed))
+}
+
+func TestRunner_CursorStopsBeforeFailedArticle(t *testing.T) {
+	base := time.Date(2026, 3, 2, 9, 0, 0, 0, time.UTC)
+	rows := []Article{
+		testArticle("a3", base.Add(2*time.Hour)),
+		testArticle("a2", base.Add(1*time.Hour)),
+		testArticle("a1", base),
+	}
+
+	tests := []struct {
+		name string
+		// failID is the article the orchestrator rejects.
+		failID string
+		// wantLastID is the article the cursor must stop at; empty means the
+		// cursor must not move at all.
+		wantLastID string
+	}{
+		{
+			name:       "failure in the middle stops the cursor at the previous article",
+			failID:     "a2",
+			wantLastID: "a3",
+		},
+		{
+			name:       "failure on the first article leaves the cursor untouched",
+			failID:     "a3",
+			wantLastID: "",
+		},
+		{
+			name:       "failure on the last article stops the cursor at the previous article",
+			failID:     "a1",
+			wantLastID: "a2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orch := newFakeOrchestrator(tt.failID)
+			srv := httptest.NewServer(orch)
+			defer srv.Close()
+
+			cursorPath := filepath.Join(t.TempDir(), "cursor.json")
+			runner := newTestRunner(t, cursorPath, srv.URL, rows)
+			require.NoError(t, runner.Run(context.Background()))
+
+			cursor, err := runner.GetCursor()
+			require.NoError(t, err)
+
+			if tt.wantLastID == "" {
+				assert.True(t, cursor.IsEmpty(),
+					"cursor must not advance past a failed article, got %+v", cursor)
+				return
+			}
+			assert.Equal(t, tt.wantLastID, cursor.LastID)
+		})
+	}
+}
+
+func TestRunner_DateRange_FailedArticleIsRetriedOnNextRun(t *testing.T) {
+	day1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	rows := []Article{
+		testArticle("d2-b", day2.Add(11*time.Hour)),
+		testArticle("d2-a", day2.Add(10*time.Hour)),
+		testArticle("d1-a", day1.Add(10*time.Hour)),
+	}
+
+	orch := newFakeOrchestrator("d2-a")
+	srv := httptest.NewServer(orch)
+	defer srv.Close()
+
+	cursorPath := filepath.Join(t.TempDir(), "cursor.json")
+
+	first := newTestRunner(t, cursorPath, srv.URL, rows)
+	first.cfg.FromDate = day1
+	first.cfg.ToDate = day2
+	require.NoError(t, first.Run(context.Background()))
+	require.Equal(t, int64(1), atomic.LoadInt64(&first.stats.Failed))
+
+	cursor, err := first.GetCursor()
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-02", cursor.CurrentDate,
+		"the day holding a failed article must stay the resume point")
+
+	orch.healAll()
+	orch.forgetIndexed()
+
+	second := newTestRunner(t, cursorPath, srv.URL, rows)
+	second.cfg.FromDate = day1
+	second.cfg.ToDate = day2
+	require.NoError(t, second.Run(context.Background()))
+
+	assert.Contains(t, orch.indexedIDs(), "d2-a",
+		"article that failed in the first run must be re-selected by the next run")
+}
+
+func testArticle(id string, createdAt time.Time) Article {
+	return Article{
+		ID:        id,
+		Title:     "title " + id,
+		Body:      "body " + id,
+		URL:       "https://example.test/" + id,
+		UserID:    "user-1",
+		CreatedAt: createdAt,
+	}
+}
+
+// newTestRunner builds a Runner wired to an in-memory article table and the
+// given orchestrator, bypassing NewRunner so no live Postgres is needed.
+func newTestRunner(t *testing.T, cursorPath, orchestratorURL string, rows []Article) *Runner {
+	t.Helper()
+
+	db := sql.OpenDB(&fakeArticleConnector{rows: rows})
+	t.Cleanup(func() { _ = db.Close() })
+
+	cfg := DefaultConfig()
+	cfg.OrchestratorURL = orchestratorURL
+	cfg.CursorFile = cursorPath
+	cfg.Concurrency = 4
+	cfg.RequestTimeout = 5 * time.Second
+
+	return &Runner{
+		cfg:           cfg,
+		db:            db,
+		client:        &http.Client{Timeout: 10 * time.Second},
+		cursorManager: NewCursorManager(cursorPath),
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		stats:         &Stats{StartTime: time.Now()},
+		limiter:       rate.NewLimiter(rate.Inf, 1),
+	}
+}
+
+// fakeOrchestrator stands in for the indexing endpoint and rejects a
+// configurable set of article IDs, the way a flaky embedder does.
+type fakeOrchestrator struct {
+	mu      sync.Mutex
+	failIDs map[string]struct{}
+	indexed []string
+}
+
+func newFakeOrchestrator(failIDs ...string) *fakeOrchestrator {
+	fail := make(map[string]struct{}, len(failIDs))
+	for _, id := range failIDs {
+		fail[id] = struct{}{}
+	}
+	return &fakeOrchestrator{failIDs: fail}
+}
+
+func (o *fakeOrchestrator) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var payload struct {
+		ArticleID string `json:"article_id"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if _, fail := o.failIDs[payload.ArticleID]; fail {
+		http.Error(w, "embedder unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	o.indexed = append(o.indexed, payload.ArticleID)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (o *fakeOrchestrator) healAll() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.failIDs = map[string]struct{}{}
+}
+
+func (o *fakeOrchestrator) forgetIndexed() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.indexed = nil
+}
+
+func (o *fakeOrchestrator) indexedIDs() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.indexed...)
+}
+
+// fakeArticleConnector serves the backfill queries from an in-memory table.
+// rows must already be ordered the way the query asks for them
+// (created_at DESC, id DESC).
+type fakeArticleConnector struct {
+	rows []Article
+}
+
+func (c *fakeArticleConnector) Connect(context.Context) (driver.Conn, error) {
+	return &fakeArticleConn{rows: c.rows}, nil
+}
+
+func (c *fakeArticleConnector) Driver() driver.Driver { return fakeArticleDriver{} }
+
+type fakeArticleDriver struct{}
+
+func (fakeArticleDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("fake db: Open is not supported, use sql.OpenDB")
+}
+
+type fakeArticleConn struct {
+	rows []Article
+}
+
+func (c *fakeArticleConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("fake db: Prepare is not supported")
+}
+
+func (c *fakeArticleConn) Close() error { return nil }
+
+func (c *fakeArticleConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("fake db: Begin is not supported")
+}
+
+// QueryContext applies the day window and the keyset predicate
+// `(created_at, id) < ($n, $n+1)` exactly as Postgres would, so a cursor that
+// jumped over a row really does lose that row.
+func (c *fakeArticleConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	filter, err := parseArticleQueryArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
+	selected := make([]Article, 0, len(c.rows))
+	for _, a := range c.rows {
+		if filter.hasDayWindow && (a.CreatedAt.Before(filter.dayStart) || !a.CreatedAt.Before(filter.dayEnd)) {
+			continue
+		}
+		if filter.hasKeyset && !beforeKey(a, filter.lastCreatedAt, filter.lastID) {
+			continue
+		}
+		selected = append(selected, a)
+	}
+
+	return &fakeArticleRows{rows: selected}, nil
+}
+
+type articleQueryFilter struct {
+	dayStart      time.Time
+	dayEnd        time.Time
+	hasDayWindow  bool
+	lastCreatedAt time.Time
+	lastID        string
+	hasKeyset     bool
+}
+
+func parseArticleQueryArgs(args []driver.NamedValue) (articleQueryFilter, error) {
+	var f articleQueryFilter
+
+	values := make([]any, len(args))
+	for i, a := range args {
+		values[i] = a.Value
+	}
+
+	switch len(values) {
+	case 0:
+	case 2:
+		// Either the day window (time, time) or the keyset (time, string).
+		if _, isKeyset := values[1].(string); isKeyset {
+			return withKeyset(f, values[0], values[1])
+		}
+		return withDayWindow(f, values[0], values[1])
+	case 4:
+		f, err := withDayWindow(f, values[0], values[1])
+		if err != nil {
+			return f, err
+		}
+		return withKeyset(f, values[2], values[3])
+	default:
+		return f, fmt.Errorf("fake db: unexpected arg count %d", len(values))
+	}
+
+	return f, nil
+}
+
+func withDayWindow(f articleQueryFilter, start, end any) (articleQueryFilter, error) {
+	dayStart, ok := start.(time.Time)
+	if !ok {
+		return f, fmt.Errorf("fake db: day start: want time.Time, got %T", start)
+	}
+	dayEnd, ok := end.(time.Time)
+	if !ok {
+		return f, fmt.Errorf("fake db: day end: want time.Time, got %T", end)
+	}
+	f.dayStart, f.dayEnd, f.hasDayWindow = dayStart, dayEnd, true
+	return f, nil
+}
+
+func withKeyset(f articleQueryFilter, createdAt, id any) (articleQueryFilter, error) {
+	lastCreatedAt, ok := createdAt.(time.Time)
+	if !ok {
+		return f, fmt.Errorf("fake db: cursor created_at: want time.Time, got %T", createdAt)
+	}
+	lastID, ok := id.(string)
+	if !ok {
+		return f, fmt.Errorf("fake db: cursor id: want string, got %T", id)
+	}
+	f.lastCreatedAt, f.lastID, f.hasKeyset = lastCreatedAt, lastID, true
+	return f, nil
+}
+
+// beforeKey reports whether (a.created_at, a.id) < (createdAt, id).
+func beforeKey(a Article, createdAt time.Time, id string) bool {
+	if a.CreatedAt.Before(createdAt) {
+		return true
+	}
+	return a.CreatedAt.Equal(createdAt) && a.ID < id
+}
+
+type fakeArticleRows struct {
+	rows []Article
+	next int
+}
+
+func (r *fakeArticleRows) Columns() []string {
+	return []string{"id", "title", "content", "url", "user_id", "created_at"}
+}
+
+func (r *fakeArticleRows) Close() error { return nil }
+
+func (r *fakeArticleRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.rows) {
+		return io.EOF
+	}
+	a := r.rows[r.next]
+	r.next++
+
+	dest[0] = a.ID
+	dest[1] = a.Title
+	dest[2] = a.Body
+	dest[3] = a.URL
+	dest[4] = a.UserID
+	dest[5] = a.CreatedAt
+	return nil
+}

--- a/rag-orchestrator/internal/usecase/morning_letter_published_at_test.go
+++ b/rag-orchestrator/internal/usecase/morning_letter_published_at_test.go
@@ -1,0 +1,228 @@
+package usecase_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"rag-orchestrator/internal/domain"
+	"rag-orchestrator/internal/usecase"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMorningLetterUsecase_Execute_BoostsAndCitesByArticlePublishedAt pins the
+// post-reindex behaviour. ContextItem.PublishedAt is filled from
+// rag_chunks.created_at (see retrieval/allocate.go), which is the index time,
+// not the publication date — after a re-index every chunk looks equally fresh
+// and the recency boost degenerates into "unchanged retrieval order". The
+// authoritative published_at is the one alt-backend already returned in
+// ArticleMetadata, and it must drive both the boost and the citation dates.
+func TestMorningLetterUsecase_Execute_BoostsAndCitesByArticlePublishedAt(t *testing.T) {
+	mockArticleClient := new(MockArticleClient)
+	mockRetrieveUC := new(mockRetrieveContextUsecase)
+	mockPromptBuilder := new(MockMorningLetterPromptBuilder)
+	mockLLM := new(mockLLMClient)
+	testLogger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	uc := usecase.NewMorningLetterUsecase(
+		mockArticleClient,
+		mockRetrieveUC,
+		mockPromptBuilder,
+		mockLLM,
+		4096,
+		6000,
+		usecase.DefaultTemporalBoostConfig(),
+		testLogger,
+	)
+
+	ctx := context.Background()
+	input := usecase.MorningLetterInput{
+		Query:       "What are the important news?",
+		WithinHours: 168,
+		TopicLimit:  5,
+		Locale:      "ja",
+	}
+
+	now := time.Now()
+	// The whole corpus was re-indexed 10 minutes ago, so every chunk carries
+	// the same created_at regardless of when its article was published.
+	indexedAt := now.Add(-10 * time.Minute).Truncate(time.Second)
+	freshPublished := now.Add(-2 * time.Hour).Truncate(time.Second)   // 1.3x boost
+	stalePublished := now.Add(-100 * time.Hour).Truncate(time.Second) // no boost
+
+	freshID := uuid.New()
+	staleID := uuid.New()
+
+	mockArticleClient.On("GetRecentArticles", ctx, 168, 0).Return([]domain.ArticleMetadata{
+		{ID: freshID, Title: "Fresh Article", URL: "https://example.com/fresh", PublishedAt: freshPublished, FeedID: uuid.New()},
+		{ID: staleID, Title: "Old Article", URL: "https://example.com/old", PublishedAt: stalePublished, FeedID: uuid.New()},
+	}, nil)
+
+	// Raw retrieval ranks the old article first (0.90 > 0.80). Boosting on the
+	// real publication dates flips it: 0.80*1.3 = 1.04 > 0.90*1.0.
+	mockRetrieveUC.On("Execute", ctx, mock.Anything).Return(&usecase.RetrieveContextOutput{
+		Contexts: []usecase.ContextItem{
+			{
+				ChunkText:   "Old article content.",
+				URL:         "https://example.com/old",
+				Title:       "Old Article",
+				PublishedAt: indexedAt.Format(time.RFC3339),
+				Score:       0.90,
+				ArticleID:   staleID.String(),
+			},
+			{
+				ChunkText:   "Fresh article content.",
+				URL:         "https://example.com/fresh",
+				Title:       "Fresh Article",
+				PublishedAt: indexedAt.Format(time.RFC3339),
+				Score:       0.80,
+				ArticleID:   freshID.String(),
+			},
+		},
+	}, nil)
+
+	var promptContexts []usecase.ContextItem
+	mockPromptBuilder.On("Build", mock.AnythingOfType("usecase.MorningLetterPromptInput")).
+		Run(func(args mock.Arguments) {
+			promptContexts = args.Get(0).(usecase.MorningLetterPromptInput).Contexts
+		}).
+		Return([]domain.Message{
+			{Role: "system", Content: "You are a news analyst..."},
+			{Role: "user", Content: "Analyze these articles..."},
+		}, nil)
+
+	mockLLM.On("Chat", ctx, mock.AnythingOfType("[]domain.Message"), 4096).Return(&domain.LLMResponse{
+		Text: `{
+			"topics": [
+				{
+					"topic": "Tech News",
+					"headline": "Major tech announcement",
+					"summary": "A significant tech development was announced today.",
+					"importance": 0.9,
+					"article_refs": [1],
+					"keywords": ["tech"]
+				}
+			],
+			"meta": {"topics_found": 1, "coverage_assessment": "comprehensive"}
+		}`,
+		Done: true,
+	}, nil)
+
+	output, err := uc.Execute(ctx, input)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	require.Len(t, promptContexts, 2)
+	assert.Equal(t, "Fresh Article", promptContexts[0].Title,
+		"the 2h-old article must outrank the 100h-old one; the boost must not read the shared index time")
+	assert.Equal(t, freshPublished.Format(time.RFC3339), promptContexts[0].PublishedAt,
+		"the LLM must be shown the publication date, not the index date")
+	assert.Equal(t, stalePublished.Format(time.RFC3339), promptContexts[1].PublishedAt)
+
+	require.Len(t, output.Topics, 1)
+	refs := output.Topics[0].ArticleRefs
+	require.Len(t, refs, 1)
+	assert.Equal(t, freshID, refs[0].ID)
+	assert.WithinDuration(t, freshPublished, refs[0].PublishedAt, time.Second,
+		"citation date must be the publication date, not the index date")
+}
+
+// TestMorningLetterUsecase_Execute_DoesNotBoostUnknownPublishedAt covers the
+// context whose article alt-backend did not report: with no publication date
+// there is nothing to boost by, and the index time must not be passed off as
+// one.
+func TestMorningLetterUsecase_Execute_DoesNotBoostUnknownPublishedAt(t *testing.T) {
+	mockArticleClient := new(MockArticleClient)
+	mockRetrieveUC := new(mockRetrieveContextUsecase)
+	mockPromptBuilder := new(MockMorningLetterPromptBuilder)
+	mockLLM := new(mockLLMClient)
+	testLogger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	uc := usecase.NewMorningLetterUsecase(
+		mockArticleClient,
+		mockRetrieveUC,
+		mockPromptBuilder,
+		mockLLM,
+		4096,
+		6000,
+		usecase.DefaultTemporalBoostConfig(),
+		testLogger,
+	)
+
+	ctx := context.Background()
+	input := usecase.MorningLetterInput{
+		Query:       "What are the important news?",
+		WithinHours: 24,
+		TopicLimit:  5,
+		Locale:      "ja",
+	}
+
+	now := time.Now()
+	indexedAt := now.Add(-5 * time.Minute).Truncate(time.Second)
+	knownPublished := now.Add(-1 * time.Hour).Truncate(time.Second) // 1.3x boost
+
+	knownID := uuid.New()
+
+	mockArticleClient.On("GetRecentArticles", ctx, 24, 0).Return([]domain.ArticleMetadata{
+		{ID: knownID, Title: "Known Article", URL: "https://example.com/known", PublishedAt: knownPublished, FeedID: uuid.New()},
+	}, nil)
+
+	// The orphan chunk outranks the known one on raw score (0.90 > 0.80) but
+	// must stay unboosted, so the known article's 0.80*1.3 = 1.04 wins.
+	mockRetrieveUC.On("Execute", ctx, mock.Anything).Return(&usecase.RetrieveContextOutput{
+		Contexts: []usecase.ContextItem{
+			{
+				ChunkText:   "Orphan chunk content.",
+				URL:         "https://example.com/orphan",
+				Title:       "Orphan Article",
+				PublishedAt: indexedAt.Format(time.RFC3339),
+				Score:       0.90,
+				ArticleID:   uuid.New().String(),
+			},
+			{
+				ChunkText:   "Known article content.",
+				URL:         "https://example.com/known",
+				Title:       "Known Article",
+				PublishedAt: indexedAt.Format(time.RFC3339),
+				Score:       0.80,
+				ArticleID:   knownID.String(),
+			},
+		},
+	}, nil)
+
+	var promptContexts []usecase.ContextItem
+	mockPromptBuilder.On("Build", mock.AnythingOfType("usecase.MorningLetterPromptInput")).
+		Run(func(args mock.Arguments) {
+			promptContexts = args.Get(0).(usecase.MorningLetterPromptInput).Contexts
+		}).
+		Return([]domain.Message{
+			{Role: "system", Content: "You are a news analyst..."},
+			{Role: "user", Content: "Analyze these articles..."},
+		}, nil)
+
+	mockLLM.On("Chat", ctx, mock.AnythingOfType("[]domain.Message"), 4096).Return(&domain.LLMResponse{
+		Text: `{"topics": [{"topic": "Tech", "headline": "News", "summary": "Summary", "importance": 0.9, "article_refs": [2], "keywords": ["tech"]}], "meta": {"topics_found": 1, "coverage_assessment": "partial"}}`,
+		Done: true,
+	}, nil)
+
+	output, err := uc.Execute(ctx, input)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	require.Len(t, promptContexts, 2)
+	assert.Equal(t, "Known Article", promptContexts[0].Title,
+		"an article with no known publication date must not be boosted ahead of a genuinely recent one")
+	assert.Empty(t, promptContexts[1].PublishedAt,
+		"an unknown publication date must be omitted rather than reported as the index date")
+
+	require.Len(t, output.Topics, 1)
+	refs := output.Topics[0].ArticleRefs
+	require.Len(t, refs, 1)
+	assert.True(t, refs[0].PublishedAt.IsZero(),
+		"a citation for an article with no known publication date must not carry the index date")
+}

--- a/rag-orchestrator/internal/usecase/morning_letter_usecase.go
+++ b/rag-orchestrator/internal/usecase/morning_letter_usecase.go
@@ -145,10 +145,20 @@ func (u *morningLetterUsecase) Execute(ctx context.Context, input MorningLetterI
 		}, nil
 	}
 
-	// 3. Extract article IDs for context retrieval
+	// 3. Extract article IDs for context retrieval and index the authoritative
+	// publication times. ContextItem.PublishedAt is derived from
+	// rag_chunks.created_at (the index time), so alt-backend's published_at is
+	// the only real publication date available to the boost and the citations.
+	// A zero value means alt-backend could not report one (see
+	// adapter/altdb/article_client.go) and must stay "unknown".
 	articleIDs := make([]string, len(articles))
+	publishedAtByArticleID := make(map[string]time.Time, len(articles))
 	for i, a := range articles {
-		articleIDs[i] = a.ID.String()
+		id := a.ID.String()
+		articleIDs[i] = id
+		if !a.PublishedAt.IsZero() {
+			publishedAtByArticleID[id] = a.PublishedAt
+		}
 	}
 
 	// 4. Retrieve context with temporal filtering
@@ -173,7 +183,7 @@ func (u *morningLetterUsecase) Execute(ctx context.Context, input MorningLetterI
 	}
 
 	// 5. Apply temporal boost to context scores
-	boostedContexts := u.applyTemporalBoost(retrieveOutput.Contexts, now)
+	boostedContexts := u.applyTemporalBoost(retrieveOutput.Contexts, publishedAtByArticleID, now)
 
 	// 5.5 Dynamic token-based context limiting (same pattern as answer_with_rag_usecase)
 	// Prevents prompt from exceeding LLM context window.
@@ -247,19 +257,37 @@ func (u *morningLetterUsecase) Execute(ctx context.Context, input MorningLetterI
 	}, nil
 }
 
-// applyTemporalBoost increases scores for more recent articles
-// using configurable boost factors from TemporalBoostConfig.
-func (u *morningLetterUsecase) applyTemporalBoost(contexts []ContextItem, now time.Time) []ContextItem {
+// applyTemporalBoost stamps each context with its article's real publication
+// time and increases the scores of recent ones using the configurable boost
+// factors from TemporalBoostConfig.
+//
+// The PublishedAt the retrieval pipeline fills in is rag_chunks.created_at
+// (see retrieval/allocate.go), i.e. the index time: after a re-index every
+// chunk carries the same instant, which makes the boost a no-op and hands the
+// prompt and the citations an index date dressed up as a publication date.
+// publishedAt therefore carries alt-backend's article metadata, keyed by
+// article ID. A context whose article has no known publication date keeps its
+// raw score and carries no date at all rather than an invented one.
+func (u *morningLetterUsecase) applyTemporalBoost(contexts []ContextItem, publishedAt map[string]time.Time, now time.Time) []ContextItem {
+	unresolved := 0
 	for i := range contexts {
-		publishedAt, err := time.Parse(time.RFC3339, contexts[i].PublishedAt)
-		if err != nil {
+		pub, ok := publishedAt[contexts[i].ArticleID]
+		if !ok {
+			contexts[i].PublishedAt = ""
+			unresolved++
 			continue
 		}
-		hoursSince := now.Sub(publishedAt).Hours()
+		contexts[i].PublishedAt = pub.Format(time.RFC3339)
 
 		// Use configurable temporal boost factors
-		boost := u.temporalBoostCfg.GetBoostFactor(hoursSince)
+		boost := u.temporalBoostCfg.GetBoostFactor(now.Sub(pub).Hours())
 		contexts[i].Score *= boost
+	}
+
+	if unresolved > 0 {
+		u.logger.Warn("morning_letter_published_at_unresolved",
+			slog.Int("unresolved_count", unresolved),
+			slog.Int("context_count", len(contexts)))
 	}
 
 	// Re-sort by boosted score
@@ -348,7 +376,9 @@ type rawTopicSummary struct {
 // back to the numbered context list the prompt showed it and hydrates them
 // into domain.ArticleRef with the real article UUID/title/URL. Out-of-range
 // indices, duplicates, and contexts without a parseable ArticleID are
-// dropped rather than surfaced as fake refs.
+// dropped rather than surfaced as fake refs. The date is the publication time
+// applyTemporalBoost stamped on the context, and stays zero when alt-backend
+// reported none.
 func enrichArticleRefs(refs []int, contexts []ContextItem) []domain.ArticleRef {
 	enriched := make([]domain.ArticleRef, 0, len(refs))
 	seen := make(map[int]struct{}, len(refs))

--- a/rag-orchestrator/internal/usecase/retrieval/embed_and_search.go
+++ b/rag-orchestrator/internal/usecase/retrieval/embed_and_search.go
@@ -20,7 +20,13 @@ import (
 // inside the SQL query. It only applies to the unscoped (no candidate
 // article IDs) case: HybridSearcher has no SearchWithinArticles-equivalent,
 // so candidate-scoped retrieval (e.g. Morning Letter) falls back to the
-// bm25Searcher/chunkRepo path below.
+// chunkRepo path below.
+//
+// Candidate-scoped retrieval runs the vector arm alone. SearchBM25 takes no
+// article filter, so a BM25 arm would search the whole corpus and
+// fuseHybridResults would inject its out-of-scope hits — a 24h Morning Letter
+// citing a half-year-old article, dated year 1 because a BM25-only hit has no
+// Chunk.CreatedAt.
 func EmbedAndSearch(
 	ctx context.Context,
 	sc *StageContext,
@@ -58,7 +64,16 @@ func EmbedAndSearch(
 	// goroutine E: BM25 Search (original + expanded queries for cross-language matching)
 	// Skipped when useHybridSearcher: the in-DB hybrid search below already
 	// fuses lexical + vector signals, so a separate BM25 arm would be redundant.
-	if !useHybridSearcher && hybridEnabled && bm25Searcher != nil {
+	// Skipped when hasCandidateArticles: BM25 cannot honour the article scope
+	// (see the doc comment above).
+	bm25Available := hybridEnabled && bm25Searcher != nil
+	if bm25Available && hasCandidateArticles {
+		logger.Info("hybrid_bm25_search_skipped",
+			slog.String("retrieval_id", sc.RetrievalID),
+			slog.String("reason", "candidate_article_scope"),
+			slog.Int("candidate_articles", len(sc.CandidateArticleIDs)))
+	}
+	if bm25Available && !useHybridSearcher && !hasCandidateArticles {
 		g.Go(func() error {
 			bm25Start := time.Now()
 

--- a/rag-orchestrator/internal/usecase/retrieval/embed_and_search_candidate_scope_test.go
+++ b/rag-orchestrator/internal/usecase/retrieval/embed_and_search_candidate_scope_test.go
@@ -1,0 +1,123 @@
+package retrieval_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"rag-orchestrator/internal/domain"
+	"rag-orchestrator/internal/usecase/retrieval"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrievalGraph_Execute_CandidateScoped_DoesNotLeakCorpusWideBM25Hits(t *testing.T) {
+	// Morning Letter scopes retrieval to the article IDs of a 24h window.
+	// SearchBM25 carries no article filter, so a corpus-wide BM25 arm fuses
+	// hits from outside the window into the original-query results, and the
+	// letter ends up citing a months-old article — dated year 1, because a
+	// BM25-only hit has no Chunk.CreatedAt.
+	expander := new(mockQueryExpander)
+	search := new(mockSearchClient)
+	encoder := new(mockVectorEncoder)
+	chunkRepo := new(mockChunkRepo)
+	bm25 := new(mockBM25Searcher)
+
+	queryVec := []float32{0.1, 0.2, 0.3}
+	articleIDs := []string{"art-in-window"}
+
+	expander.On("ExpandQuery", mock.Anything, "today's news", 1, 3).Return([]string{}, nil)
+	search.On("Search", mock.Anything, "today's news").Return([]domain.SearchHit{}, nil)
+	encoder.On("Encode", mock.Anything, mock.Anything).Return([][]float32{queryVec}, nil)
+	chunkRepo.On("SearchWithinArticles", mock.Anything, queryVec, articleIDs, 50).Return([]domain.SearchResult{
+		{
+			Chunk:           domain.RagChunk{ID: uuid.New(), Content: "fresh content", CreatedAt: time.Now()},
+			Score:           0.92,
+			ArticleID:       "art-in-window",
+			Title:           "In Window",
+			URL:             "https://example.com/in-window",
+			DocumentVersion: 1,
+		},
+	}, nil)
+	// The whole corpus answers this keyword query, including a half-year-old article.
+	bm25.On("SearchBM25", mock.Anything, mock.Anything, mock.Anything).Return([]domain.BM25SearchResult{
+		{ArticleID: "art-six-months-old", Content: "stale content", Title: "Stale Article", Rank: 1, Score: 30.0},
+	}, nil)
+
+	g := retrieval.NewRetrievalGraph(retrieval.GraphDeps{
+		QueryExpander: expander,
+		LLMClient:     new(mockLLMClient),
+		SearchClient:  search,
+		Encoder:       encoder,
+		ChunkRepo:     chunkRepo,
+		BM25Searcher:  bm25,
+		Config: retrieval.GraphConfig{
+			SearchLimit:                      50,
+			RRFK:                             60.0,
+			QuotaOriginal:                    5,
+			QuotaExpanded:                    5,
+			HybridSearchEnabled:              true,
+			BM25Limit:                        50,
+			DynamicLanguageAllocationEnabled: true,
+		},
+		Logger: discardLogger(),
+	})
+
+	result, err := g.Execute(context.Background(), retrieval.GraphInput{
+		Query:               "today's news",
+		CandidateArticleIDs: articleIDs,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Contexts, "the in-window article must still be retrieved")
+
+	for _, c := range result.Contexts {
+		assert.Contains(t, articleIDs, c.ArticleID,
+			"candidate-scoped retrieval must not return an article outside the requested scope")
+		assert.False(t, strings.HasPrefix(c.PublishedAt, "0001-"),
+			"a context with a zero-value CreatedAt would be cited as a year-1 publication date")
+	}
+
+	// A corpus-wide BM25 query cannot contribute anything usable to a scoped
+	// retrieval — every hit outside the scope has to be discarded — so it must
+	// not be issued at all.
+	bm25.AssertNotCalled(t, "SearchBM25", mock.Anything, mock.Anything, mock.Anything)
+	assert.Zero(t, result.BM25HitCount, "no BM25 arm runs under candidate scoping")
+}
+
+func TestEmbedAndSearch_CandidateArticles_SkipsUnfilterableBM25Arm(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	mockEncoder := new(MockVectorEncoder)
+	mockBM25 := new(MockBM25Searcher)
+	mockChunkRepo := new(MockRagChunkRepository)
+
+	queryVec := []float32{0.1, 0.2, 0.3}
+	sc := &retrieval.StageContext{
+		RetrievalID:         "test-scoped-bm25",
+		Query:               "test query",
+		OriginalEmbedding:   queryVec,
+		CandidateArticleIDs: []string{"art-1"},
+		SearchLimit:         50,
+	}
+
+	mockBM25.On("SearchBM25", mock.Anything, mock.Anything, mock.Anything).Return([]domain.BM25SearchResult{
+		{ArticleID: "art-out-of-scope", Content: "unscoped", Title: "Unscoped", Rank: 1, Score: 9.0},
+	}, nil)
+	mockChunkRepo.On("SearchWithinArticles", mock.Anything, queryVec, sc.CandidateArticleIDs, 50).Return([]domain.SearchResult{
+		{Chunk: domain.RagChunk{Content: "scoped result"}, Score: 0.7, ArticleID: "art-1"},
+	}, nil)
+
+	err := retrieval.EmbedAndSearch(context.Background(), sc, mockEncoder, mockBM25, nil, mockChunkRepo, true, 50, logger)
+	require.NoError(t, err)
+
+	assert.Empty(t, sc.BM25Results, "BM25 has no article filter, so it must not run under candidate scoping")
+	mockBM25.AssertNotCalled(t, "SearchBM25", mock.Anything, mock.Anything, mock.Anything)
+	assert.Len(t, sc.OriginalResults, 1, "the scoped vector arm must still run")
+}

--- a/rask-log-aggregator/app/src/adapter/clickhouse/batch_writer.rs
+++ b/rask-log-aggregator/app/src/adapter/clickhouse/batch_writer.rs
@@ -12,7 +12,7 @@ use clickhouse::{Client, RowOwned, RowWrite};
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -57,12 +57,17 @@ const INITIAL_RETRY_BACKOFF: Duration = Duration::from_millis(250);
 /// enough to notice ClickHouse coming back.
 const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(10);
 
+/// Resolves once the batch it travelled with is durably in ClickHouse, or with
+/// the error that stopped it. The ingest handler awaits this before it answers,
+/// so a 2xx means the rows are written and the forwarder may drop its copy.
+type LogAck = oneshot::Sender<Result<(), AggregatorError>>;
+
 /// Batch writer that buffers rows through channels before writing to ClickHouse.
 ///
 /// Implements both `LogExporter` and `OTelExporter`. Handlers send rows
 /// through bounded channels; a background task drains and flushes them.
 pub struct BatchWriter {
-    logs: mpsc::Sender<Vec<LogRow>>,
+    logs: mpsc::Sender<(Vec<LogRow>, LogAck)>,
     otel_logs: mpsc::Sender<Vec<OTelLogRow>>,
     otel_traces: mpsc::Sender<Vec<OTelTraceRow>>,
 }
@@ -77,7 +82,7 @@ impl BatchWriter {
     /// on shutdown, silently losing the final batch.
     #[must_use]
     pub fn spawn(client: Client, shutdown_token: CancellationToken) -> (Self, JoinHandle<()>) {
-        let (logs_tx, logs_rx) = mpsc::channel::<Vec<LogRow>>(CHANNEL_CAPACITY);
+        let (logs_tx, logs_rx) = mpsc::channel::<(Vec<LogRow>, LogAck)>(CHANNEL_CAPACITY);
         let (otel_logs_tx, otel_logs_rx) = mpsc::channel::<Vec<OTelLogRow>>(CHANNEL_CAPACITY);
         let (otel_traces_tx, otel_traces_rx) = mpsc::channel::<Vec<OTelTraceRow>>(CHANNEL_CAPACITY);
 
@@ -110,10 +115,20 @@ impl crate::port::LogExporter for BatchWriter {
                 return Ok(());
             }
             let rows: Vec<LogRow> = logs.into_iter().map(LogRow::from).collect();
+            let (ack_tx, ack_rx) = oneshot::channel();
             self.logs
-                .send(rows)
+                .send((rows, ack_tx))
                 .await
-                .map_err(|_| AggregatorError::Export("log batch channel closed".to_string()))
+                .map_err(|_| AggregatorError::Export("log batch channel closed".to_string()))?;
+            // Park until the flush loop has actually written the rows. Without
+            // this the caller is told Ok while the batch is still only in
+            // memory, and a SIGKILL in that window loses it with the forwarder
+            // already instructed to discard its copy.
+            ack_rx.await.unwrap_or_else(|_| {
+                Err(AggregatorError::Export(
+                    "flush loop dropped the batch before acknowledging it".to_string(),
+                ))
+            })
         })
     }
 }
@@ -158,12 +173,16 @@ impl crate::port::OTelExporter for BatchWriter {
 
 async fn flush_loop(
     client: Client,
-    mut log_rx: mpsc::Receiver<Vec<LogRow>>,
+    mut log_rx: mpsc::Receiver<(Vec<LogRow>, LogAck)>,
     mut otel_log_rx: mpsc::Receiver<Vec<OTelLogRow>>,
     mut otel_trace_rx: mpsc::Receiver<Vec<OTelTraceRow>>,
     shutdown_token: CancellationToken,
 ) {
     let mut log_buf: Vec<LogRow> = Vec::new();
+    // One entry per caller currently parked on `export_batch`, covering the
+    // rows sitting in `log_buf`. Resolved together whenever that buffer is
+    // flushed, so nobody is answered before their rows land.
+    let mut log_acks: Vec<LogAck> = Vec::new();
     let mut otel_log_buf: Vec<OTelLogRow> = Vec::new();
     let mut otel_trace_buf: Vec<OTelTraceRow> = Vec::new();
     let mut flush_interval = tokio::time::interval(Duration::from_secs(FLUSH_INTERVAL_SECS));
@@ -177,17 +196,32 @@ async fn flush_loop(
             // Periodic flush
             _ = flush_interval.tick() => {
                 flush_all(
-                    &client, &mut log_buf, &mut otel_log_buf, &mut otel_trace_buf,
+                    &client, &mut log_buf, &mut log_acks, &mut otel_log_buf, &mut otel_trace_buf,
                     MAX_FLUSH_ATTEMPTS,
                 ).await;
             }
 
             // Drain log rows
-            Some(rows) = log_rx.recv() => {
+            Some((rows, ack)) = log_rx.recv() => {
                 log_buf.extend(rows);
-                if log_buf.len() >= MAX_BATCH_SIZE {
-                    flush_rows(&client, "logs", &mut log_buf, MAX_FLUSH_ATTEMPTS).await;
+                log_acks.push(ack);
+
+                // Opportunistic batching: absorb whatever else is already
+                // queued so ClickHouse still sees large inserts, but do not
+                // wait for the tick - every batch here has a caller parked on
+                // its ack, and holding them for up to FLUSH_INTERVAL_SECS
+                // would put that latency on the forwarder's request.
+                while log_buf.len() < MAX_BATCH_SIZE {
+                    match log_rx.try_recv() {
+                        Ok((more, more_ack)) => {
+                            log_buf.extend(more);
+                            log_acks.push(more_ack);
+                        }
+                        Err(_) => break,
+                    }
                 }
+
+                flush_logs(&client, &mut log_buf, &mut log_acks, MAX_FLUSH_ATTEMPTS).await;
             }
 
             // Drain OTel log rows
@@ -209,11 +243,11 @@ async fn flush_loop(
             // Shutdown signal
             () = shutdown_token.cancelled() => {
                 info!("BatchWriter shutting down: draining channels before final flush");
-                drain_channel(&mut log_rx, &mut log_buf);
+                drain_log_channel(&mut log_rx, &mut log_buf, &mut log_acks);
                 drain_channel(&mut otel_log_rx, &mut otel_log_buf);
                 drain_channel(&mut otel_trace_rx, &mut otel_trace_buf);
                 flush_all(
-                    &client, &mut log_buf, &mut otel_log_buf, &mut otel_trace_buf,
+                    &client, &mut log_buf, &mut log_acks, &mut otel_log_buf, &mut otel_trace_buf,
                     SHUTDOWN_FLUSH_ATTEMPTS,
                 ).await;
                 let unwritten = log_buf.len() + otel_log_buf.len() + otel_trace_buf.len();
@@ -241,15 +275,87 @@ fn drain_channel<T>(rx: &mut mpsc::Receiver<Vec<T>>, buf: &mut Vec<T>) {
     }
 }
 
+/// `drain_channel` for the log channel, which carries a durability ack
+/// alongside its rows. The acks are collected too, so the final flush can
+/// answer callers that were still parked when shutdown began.
+fn drain_log_channel(
+    rx: &mut mpsc::Receiver<(Vec<LogRow>, LogAck)>,
+    buf: &mut Vec<LogRow>,
+    acks: &mut Vec<LogAck>,
+) {
+    rx.close();
+    while let Ok((rows, ack)) = rx.try_recv() {
+        buf.extend(rows);
+        acks.push(ack);
+    }
+}
+
+/// Flush the log buffer and settle every caller waiting on it.
+///
+/// A caller is answered Ok only when the buffer actually drained. If the retry
+/// budget is exhausted the rows stay buffered for the next attempt *and* the
+/// callers are answered Err, so the forwarder keeps its copy and retries
+/// rather than discarding rows this process may still lose.
+async fn flush_logs(
+    client: &Client,
+    buf: &mut Vec<LogRow>,
+    acks: &mut Vec<LogAck>,
+    max_attempts: u32,
+) {
+    let sink = ClickHouseSink {
+        client,
+        table: "logs",
+    };
+    flush_logs_via(&sink, buf, acks, max_attempts).await;
+}
+
+/// The sink-generic half of `flush_logs`, so the ack contract can be exercised
+/// against a failing write without a ClickHouse connection.
+async fn flush_logs_via<S: FlushSink<LogRow>>(
+    sink: &S,
+    buf: &mut Vec<LogRow>,
+    acks: &mut Vec<LogAck>,
+    max_attempts: u32,
+) {
+    if buf.is_empty() {
+        settle(acks, &Ok(()));
+        return;
+    }
+
+    let pending = buf.len();
+    flush_with_retry("logs", buf, sink, max_attempts).await;
+
+    let outcome = if buf.is_empty() {
+        Ok(())
+    } else {
+        Err(AggregatorError::Export(format!(
+            "ClickHouse did not accept {pending} rows within {max_attempts} attempts"
+        )))
+    };
+    settle(acks, &outcome);
+}
+
+/// Resolve and clear every parked caller with the same outcome.
+fn settle(acks: &mut Vec<LogAck>, outcome: &Result<(), AggregatorError>) {
+    for ack in acks.drain(..) {
+        // Err means the caller's request was already cancelled; nothing to do.
+        let _ = ack.send(match outcome {
+            Ok(()) => Ok(()),
+            Err(e) => Err(AggregatorError::Export(e.to_string())),
+        });
+    }
+}
+
 async fn flush_all(
     client: &Client,
     log_buf: &mut Vec<LogRow>,
+    log_acks: &mut Vec<LogAck>,
     otel_log_buf: &mut Vec<OTelLogRow>,
     otel_trace_buf: &mut Vec<OTelTraceRow>,
     max_attempts: u32,
 ) {
-    if !log_buf.is_empty() {
-        flush_rows(client, "logs", log_buf, max_attempts).await;
+    if !log_buf.is_empty() || !log_acks.is_empty() {
+        flush_logs(client, log_buf, log_acks, max_attempts).await;
     }
     if !otel_log_buf.is_empty() {
         flush_rows(client, "otel_logs", otel_log_buf, max_attempts).await;
@@ -352,18 +458,41 @@ async fn write_batch<T: clickhouse::Row + RowOwned + RowWrite + serde::Serialize
         .with_max_bytes(INSERTER_MAX_BYTES)
         .with_max_rows(INSERTER_MAX_ROWS);
 
-    // Individual row failures here are per-row (de)serialization problems,
-    // not transient network errors - retrying the batch wouldn't help them.
-    // Count and report them as a single aggregated error (rather than one
-    // `error!` per row, and rather than swallowing them with no signal at
-    // all) so a persistently non-zero drop count is visible.
+    // A failure here is usually a per-row (de)serialization problem, which
+    // retrying the batch would not help - so those rows are counted and
+    // reported in aggregate rather than aborting their whole batch.
+    //
+    // But `Inserter::write` also opens the connection on first use, so an
+    // unreachable ClickHouse fails on *every* row and never reaches `end()`.
+    // Treating that as a pile of bad rows returned Ok having sent nothing,
+    // which cleared the buffer in `flush_with_retry`; the retry ladder and the
+    // durability ack were both sitting behind a write that could not fail.
+    // A batch where nothing could be written is therefore an error, not a
+    // drop.
     let mut dropped = 0usize;
+    let mut last_error = None;
     for row in rows {
         if let Err(e) = inserter.write(row).await {
             warn!(table, error = %e, "Failed to write row to ClickHouse inserter, dropping row");
             dropped += 1;
+            last_error = Some(e);
         }
     }
+
+    if dropped == rows.len() && !rows.is_empty() {
+        let detail = last_error.map_or_else(|| "unknown".to_string(), |e| e.to_string());
+        error!(
+            table,
+            total = rows.len(),
+            error = %detail,
+            "No row in the batch could be written; treating as a failed flush"
+        );
+        return Err(AggregatorError::Export(format!(
+            "no row of {} could be written to {table}: {detail}",
+            rows.len()
+        )));
+    }
+
     if dropped > 0 {
         error!(
             table,
@@ -454,13 +583,13 @@ mod tests {
 
     type WriterChannels = (
         BatchWriter,
-        mpsc::Receiver<Vec<LogRow>>,
+        mpsc::Receiver<(Vec<LogRow>, LogAck)>,
         mpsc::Receiver<Vec<OTelLogRow>>,
         mpsc::Receiver<Vec<OTelTraceRow>>,
     );
 
     fn make_writer() -> WriterChannels {
-        let (logs_tx, logs_rx) = mpsc::channel(16);
+        let (logs_tx, logs_rx) = mpsc::channel::<(Vec<LogRow>, LogAck)>(16);
         let (otel_logs_tx, otel_logs_rx) = mpsc::channel(16);
         let (otel_traces_tx, otel_traces_rx) = mpsc::channel(16);
         let writer = BatchWriter {
@@ -493,14 +622,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn export_batch_sends_rows_to_channel() {
+    async fn export_batch_sends_rows_to_channel_and_waits_for_the_ack() {
         let (writer, mut logs_rx, _, _) = make_writer();
 
         let entries = vec![make_enriched_log(), make_enriched_log()];
-        writer.export_batch(entries).await.unwrap();
+        let export = tokio::spawn(async move { writer.export_batch(entries).await });
 
-        let received = logs_rx.recv().await.unwrap();
+        let (received, ack) = logs_rx.recv().await.unwrap();
         assert_eq!(received.len(), 2);
+
+        // Still parked: the rows are queued but nothing has written them yet.
+        assert!(!export.is_finished());
+
+        ack.send(Ok(())).unwrap();
+        export.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn export_batch_surfaces_a_failed_durable_write() {
+        let (writer, mut logs_rx, _, _) = make_writer();
+
+        let export =
+            tokio::spawn(async move { writer.export_batch(vec![make_enriched_log()]).await });
+        let (_rows, ack) = logs_rx.recv().await.unwrap();
+        ack.send(Err(AggregatorError::Export("clickhouse down".to_string())))
+            .unwrap();
+
+        let result = export.await.unwrap();
+        assert!(
+            result.is_err(),
+            "a rejected durable write must reach the handler so it answers 5xx and the \
+             forwarder keeps its copy"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_batch_errors_when_the_flush_loop_drops_the_ack() {
+        let (writer, mut logs_rx, _, _) = make_writer();
+
+        let export =
+            tokio::spawn(async move { writer.export_batch(vec![make_enriched_log()]).await });
+        let (_rows, ack) = logs_rx.recv().await.unwrap();
+        drop(ack);
+
+        assert!(
+            export.await.unwrap().is_err(),
+            "a dropped ack must not read as a successful export"
+        );
     }
 
     #[tokio::test]
@@ -797,6 +965,82 @@ mod tests {
         assert!(
             gaps[3] >= gaps[0] * 8,
             "backoff must grow exponentially, not linearly: {gaps:?}"
+        );
+    }
+
+    /// A 200 from the aggregate handler must mean the rows are in ClickHouse.
+    /// `export_batch` used to resolve Ok as soon as the rows were queued on the
+    /// in-process channel, so the forwarder dropped its only copy while the
+    /// batch was still sitting in `log_buf` - and a SIGKILL in that window lost
+    /// it silently.
+    #[tokio::test]
+    async fn a_batch_clickhouse_never_accepted_is_acked_as_a_failure() {
+        let mut buf = vec![LogRow::from(make_enriched_log())];
+        let mut acks = Vec::new();
+        let (ack_tx, ack_rx) = oneshot::channel();
+        acks.push(ack_tx);
+
+        let sink = FailingLogSink;
+        flush_logs_via(&sink, &mut buf, &mut acks, 2).await;
+
+        assert!(
+            ack_rx.await.unwrap().is_err(),
+            "a caller must not be told Ok for rows ClickHouse rejected; a 200 built on this \
+             tells the forwarder to discard rows that exist nowhere else"
+        );
+        assert_eq!(
+            buf.len(),
+            1,
+            "rejected rows stay buffered for the next attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_batch_clickhouse_accepted_is_acked_as_a_success() {
+        let mut buf = vec![LogRow::from(make_enriched_log())];
+        let mut acks = Vec::new();
+        let (ack_tx, ack_rx) = oneshot::channel();
+        acks.push(ack_tx);
+
+        flush_logs_via(&AcceptingLogSink, &mut buf, &mut acks, 2).await;
+
+        assert!(ack_rx.await.unwrap().is_ok());
+        assert!(buf.is_empty(), "a written batch must leave the buffer");
+    }
+
+    struct FailingLogSink;
+    impl FlushSink<LogRow> for FailingLogSink {
+        async fn write(&self, _rows: &[LogRow]) -> Result<(), AggregatorError> {
+            Err(AggregatorError::Export(
+                "clickhouse unreachable".to_string(),
+            ))
+        }
+    }
+
+    struct AcceptingLogSink;
+    impl FlushSink<LogRow> for AcceptingLogSink {
+        async fn write(&self, _rows: &[LogRow]) -> Result<(), AggregatorError> {
+            Ok(())
+        }
+    }
+
+    /// `Inserter::write` opens the HTTP connection lazily, so an unreachable
+    /// ClickHouse fails there rather than at `end()`. Counting those as
+    /// per-row serialization drops made `write_batch` return Ok having sent
+    /// nothing - which cleared the buffer in `flush_with_retry`, so the retry
+    /// ladder, the disk fallback and the durability ack all sat behind a write
+    /// that always claimed success.
+    #[tokio::test]
+    async fn write_batch_fails_when_no_row_could_be_written() {
+        let client = Client::default().with_url("http://127.0.0.1:1");
+        let rows = vec![LogRow::from(make_enriched_log())];
+
+        let result = write_batch(&client, "logs", &rows).await;
+
+        assert!(
+            result.is_err(),
+            "a batch where every row failed is an unreachable server, not a batch of \
+             malformed rows; returning Ok silently discards it"
         );
     }
 }

--- a/rask-log-aggregator/app/src/handler/aggregate.rs
+++ b/rask-log-aggregator/app/src/handler/aggregate.rs
@@ -24,6 +24,21 @@ fn truncate_for_log(s: &str, max_len: usize) -> &str {
 }
 
 /// Handler for POST /v1/aggregate (legacy NDJSON logs from rask-log-forwarder)
+///
+/// The 2xx returned here is a durability ack, not a receipt: the forwarder
+/// `mem::take`s its buffer and drops the batch the moment it sees one, so
+/// after a 200 this process holds the only copy. That makes the response the
+/// HTTP edition of CLAUDE.md rule 10 - ack only once the side effect is
+/// durable. Two obligations follow, and only the first is enforceable here:
+///
+/// 1. Never answer before `LogExporter::export_batch` has resolved, and
+///    answer 5xx when it fails, so the forwarder retries from its own copy.
+/// 2. `export_batch` returning `Ok` must mean "durably written", not
+///    "buffered". `BatchWriter` currently resolves `Ok` on channel send and
+///    flushes up to `FLUSH_INTERVAL_SECS` later, so a SIGKILL/OOM between
+///    the two loses the batch. Fixing that needs a durability ack on the
+///    port itself and belongs in `port::LogExporter` /
+///    `adapter::clickhouse::BatchWriter`, not in this layer.
 pub async fn aggregate_handler(
     State(exporter): State<Arc<dyn LogExporter>>,
     body: String,
@@ -63,12 +78,145 @@ pub async fn aggregate_handler(
 
     match exporter.export_batch(logs).await {
         Ok(()) => {
-            info!("Successfully exported {log_count} log entries to ClickHouse");
+            // Report what this layer actually observed - the export port
+            // took the batch - rather than a completed ClickHouse write it
+            // has no way to confirm. A log that claims success for rows a
+            // SIGKILL is about to discard is worse than no log at all.
+            info!(log_count, "Accepted log batch for export");
             (StatusCode::OK, "OK")
         }
         Err(e) => {
-            error!("Failed to export logs to ClickHouse: {e}");
+            error!(log_count, error = %e, "Export port rejected log batch");
             (StatusCode::INTERNAL_SERVER_ERROR, "Export failed")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AggregatorError;
+    use crate::port::BoxFuture;
+    use crate::test_support::MockExporter;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Notify;
+    use tracing_test::traced_test;
+
+    const VALID_LINE: &str = r#"{"service_type":"http","log_type":"access","message":"hello","timestamp":"2025-01-10T12:00:00Z","stream":"stdout","container_id":"abc123","service_name":"test-svc","fields":{}}"#;
+
+    async fn post(exporter: Arc<dyn LogExporter>, body: &str) -> StatusCode {
+        aggregate_handler(State(exporter), body.to_string())
+            .await
+            .into_response()
+            .status()
+    }
+
+    /// Exporter whose `export_batch` future stays pending until `release` is
+    /// signalled - stands in for a backend that has taken the rows but has
+    /// not yet made them durable.
+    struct GatedExporter {
+        release: Notify,
+        accepted: AtomicUsize,
+    }
+
+    impl GatedExporter {
+        fn new() -> Self {
+            Self {
+                release: Notify::new(),
+                accepted: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl LogExporter for GatedExporter {
+        fn export_batch(
+            &self,
+            logs: Vec<EnrichedLogEntry>,
+        ) -> BoxFuture<'_, Result<(), AggregatorError>> {
+            Box::pin(async move {
+                self.accepted.fetch_add(logs.len(), Ordering::SeqCst);
+                self.release.notified().await;
+                Ok(())
+            })
+        }
+    }
+
+    /// The 200 this handler returns is a durability ack: rask-log-forwarder
+    /// drops its only copy of the batch on any 2xx. Claiming a completed
+    /// ClickHouse write for rows the export port has merely taken makes an
+    /// unrecoverable loss (SIGKILL before the batch is flushed) look like a
+    /// clean success in the log.
+    #[tokio::test]
+    #[traced_test]
+    async fn success_log_does_not_claim_a_write_the_handler_never_observed() {
+        let exporter: Arc<dyn LogExporter> = Arc::new(MockExporter::new());
+
+        let status = post(exporter, VALID_LINE).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            !logs_contain("Successfully exported"),
+            "the handler only knows the export port returned Ok; it must not \
+             report a completed backend write it never observed"
+        );
+        assert!(
+            !logs_contain("to ClickHouse"),
+            "the handler talks to a LogExporter port, not to ClickHouse - \
+             naming the driver here is both a layer leak and a false claim \
+             when the batch is still buffered"
+        );
+        assert!(
+            logs_contain("Accepted log batch for export"),
+            "the accepted batch must still be recorded, just described \
+             honestly"
+        );
+    }
+
+    /// Regression guard for the other half of the ack contract: a failing
+    /// export must be answered 5xx so the forwarder retries instead of
+    /// discarding the batch.
+    #[tokio::test]
+    async fn export_failure_is_answered_5xx_so_the_forwarder_keeps_the_batch() {
+        let mock = Arc::new(MockExporter::new());
+        mock.set_should_fail(true);
+        let exporter: Arc<dyn LogExporter> = mock;
+
+        let status = post(exporter, VALID_LINE).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    /// Regression guard: the response must not race ahead of the export
+    /// port. Answering 200 while `export_batch` is still pending would let
+    /// the forwarder drop the batch before anything downstream owns it.
+    #[tokio::test(start_paused = true)]
+    async fn no_2xx_is_sent_while_the_export_port_is_still_pending() {
+        let gate = Arc::new(GatedExporter::new());
+        let exporter: Arc<dyn LogExporter> = gate.clone();
+        let body = VALID_LINE.to_string();
+
+        let mut handle = tokio::spawn(async move {
+            aggregate_handler(State(exporter), body)
+                .await
+                .into_response()
+                .status()
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(30), &mut handle)
+                .await
+                .is_err(),
+            "handler answered before the export port resolved"
+        );
+        assert_eq!(gate.accepted.load(Ordering::SeqCst), 1);
+
+        gate.release.notify_one();
+
+        let status = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("handler must answer once the export port resolves")
+            .unwrap();
+        assert_eq!(status, StatusCode::OK);
     }
 }

--- a/rask-log-forwarder/app/src/app/pipeline.rs
+++ b/rask-log-forwarder/app/src/app/pipeline.rs
@@ -61,8 +61,8 @@ pub async fn run_processing_loop(params: ProcessingLoopParams) {
     } = params;
 
     info!(
-        "Starting main processing loop (batch_size={}, flush_interval={:?}, channel_capacity={})",
-        batch_size, flush_interval, channel_capacity
+        "Starting main processing loop for service '{}' (batch_size={}, flush_interval={:?}, channel_capacity={})",
+        target_service, batch_size, flush_interval, channel_capacity
     );
 
     // Bounded log collection channel. Backpressure policy: once full, the
@@ -86,11 +86,6 @@ pub async fn run_processing_loop(params: ProcessingLoopParams) {
 
     // Buffer for batching logs - directly collect EnrichedLogEntry (no double conversion)
     let mut log_batch: Vec<EnrichedLogEntry> = Vec::with_capacity(batch_size);
-
-    // Cache of the current container's info, rebuilt only when the
-    // collector reports a different container id (e.g. after a reconnect).
-    // Avoids a fresh `ContainerInfo` allocation on every single log entry.
-    let mut container_info_cache: Option<crate::collector::ContainerInfo> = None;
 
     // Fire flush ticks on a fixed cadence, created once outside the loop so a
     // steady stream of incoming logs (faster than flush_interval) can never
@@ -124,8 +119,7 @@ pub async fn run_processing_loop(params: ProcessingLoopParams) {
         tokio::select! {
             // Process incoming log entries
             Some(log_entry) = log_rx.recv() => {
-                let container_info = container_info_for(&mut container_info_cache, &log_entry.id, &target_service);
-                log_batch.push(enrich_log_entry(&parser, log_entry, container_info).await);
+                log_batch.push(enrich_log_entry(&parser, log_entry).await);
 
                 // Send batch when it reaches the configured size
                 if log_batch.len() >= batch_size {
@@ -150,8 +144,7 @@ pub async fn run_processing_loop(params: ProcessingLoopParams) {
                 // final flush - otherwise logs in flight at shutdown are lost.
                 log_rx.close();
                 while let Ok(log_entry) = log_rx.try_recv() {
-                    let container_info = container_info_for(&mut container_info_cache, &log_entry.id, &target_service);
-                    log_batch.push(enrich_log_entry(&parser, log_entry, container_info).await);
+                    log_batch.push(enrich_log_entry(&parser, log_entry).await);
                 }
 
                 // Flush any remaining logs before shutting down
@@ -167,55 +160,43 @@ pub async fn run_processing_loop(params: ProcessingLoopParams) {
     info!("Main processing loop stopped");
 }
 
-/// Returns a `ContainerInfo` for `id`, reusing the cached one when it still
-/// matches instead of allocating a fresh one for every single log entry.
-/// Only a container reconnect (id change) rebuilds it.
-fn container_info_for<'a>(
-    cache: &'a mut Option<crate::collector::ContainerInfo>,
-    id: &str,
-    target_service: &str,
-) -> &'a crate::collector::ContainerInfo {
-    let needs_rebuild = !matches!(cache, Some(info) if info.id == id);
-    if needs_rebuild {
-        *cache = Some(crate::collector::ContainerInfo {
-            id: id.to_string(),
-            service_name: target_service.to_string(),
-            group: None,
-            labels: std::collections::HashMap::new(),
-        });
-    }
-    cache.as_ref().expect("just initialized above")
-}
-
 /// Parse a raw collected log entry into an `EnrichedLogEntry`, falling back to
 /// a plain-text entry if parsing fails. Shared by the main select loop and the
 /// shutdown drain path so both apply identical enrichment.
+///
+/// The container metadata and the stream both ride along on the collected
+/// entry: discovery resolved the `rask.group` label and Docker demultiplexed
+/// the stream, and neither can be reconstructed from the payload here.
 async fn enrich_log_entry(
     parser: &UniversalParser,
     log_entry: crate::collector::LogEntry,
-    container_info: &crate::collector::ContainerInfo,
 ) -> EnrichedLogEntry {
-    match parser.parse_docker_log(log_entry.raw_bytes.as_ref(), container_info) {
+    let container = &log_entry.container;
+    match parser.parse_docker_log_with_stream(
+        log_entry.raw_bytes.as_ref(),
+        container,
+        log_entry.stream,
+    ) {
         Ok(enriched_entry) => enriched_entry,
         Err(e) => {
             error!("Failed to parse log entry: {}", e);
             // Fallback: create a plain text EnrichedLogEntry directly
             EnrichedLogEntry {
-                service_type: container_info.service_name.clone(),
+                service_type: container.service_name.clone(),
                 log_type: "plain".to_string(),
                 message: String::from_utf8_lossy(&log_entry.raw_bytes).to_string(),
                 level: Some(crate::domain::LogLevel::Info),
                 timestamp: chrono::Utc::now().to_rfc3339(),
-                stream: "stdout".to_string(),
+                stream: log_entry.stream.as_str().to_string(),
                 method: None,
                 path: None,
                 status_code: None,
                 response_size: None,
                 ip_address: None,
                 user_agent: None,
-                container_id: log_entry.container_id.clone(),
-                service_name: container_info.service_name.clone(),
-                service_group: None,
+                container_id: container.id.clone(),
+                service_name: container.service_name.clone(),
+                service_group: container.group.clone(),
                 trace_id: None,
                 span_id: None,
                 fields: std::collections::HashMap::new(),
@@ -329,6 +310,20 @@ mod tests {
         }
     }
 
+    /// What `ServiceDiscovery::find_container_by_service` hands back for a
+    /// container labelled `rask.group=alt-backend`.
+    fn discovered_container() -> Arc<crate::collector::ContainerInfo> {
+        Arc::new(crate::collector::ContainerInfo {
+            id: "abc123def456".to_string(),
+            service_name: "alt-backend".to_string(),
+            labels: std::collections::HashMap::from([(
+                "rask.group".to_string(),
+                "alt-backend".to_string(),
+            )]),
+            group: Some("alt-backend".to_string()),
+        })
+    }
+
     fn test_entry(message: &str) -> EnrichedLogEntry {
         EnrichedLogEntry {
             service_type: "test".to_string(),
@@ -439,6 +434,62 @@ mod tests {
         assert_eq!(
             stored, 1,
             "the failed batch should actually be persisted to disk, not just counted"
+        );
+    }
+
+    /// Discovery resolves `rask.group` off the container's labels. An entry
+    /// that reaches the aggregator without it is stored with service_group set
+    /// to the literal "unknown" (adapter/clickhouse/row.rs), so every query or
+    /// Grafana panel that groups by service_group collapses each such service
+    /// into one shared bucket.
+    ///
+    /// Not a partitioning concern: 001_create_logs_table.sql does partition by
+    /// (service_group, service_name), but entrypoint-wrapper.sh rebuilds the
+    /// table as `PARTITION BY toDate(timestamp)` on first boot, leaving
+    /// service_group an ordinary LowCardinality column.
+    #[tokio::test]
+    async fn enriched_entries_keep_the_discovered_rask_group() {
+        let parser = UniversalParser::new();
+
+        let collected = crate::collector::LogEntry {
+            container: discovered_container(),
+            stream: crate::collector::LogStream::Stdout,
+            raw_bytes: bytes::Bytes::from_static(b"backend is up\n"),
+        };
+
+        let enriched = enrich_log_entry(&parser, collected).await;
+
+        assert_eq!(
+            enriched.service_group,
+            Some("alt-backend".to_string()),
+            "the rask.group discovery already resolved must survive to the aggregator, \
+             otherwise every row lands in the 'unknown' partition"
+        );
+    }
+
+    /// Docker demultiplexes stdout/stderr for us and bollard exposes it as the
+    /// `LogOutput` variant. `into_bytes()` throws that away, and nothing
+    /// downstream can recover it - `WHERE stream='stderr'` then returns zero
+    /// rows for every service, panic backtraces included.
+    #[tokio::test]
+    async fn stderr_lines_are_recorded_as_stderr() {
+        let parser = UniversalParser::new();
+
+        let frame = bollard::container::LogOutput::StdErr {
+            message: bytes::Bytes::from_static(b"thread 'main' panicked at src/main.rs:10:5\n"),
+        };
+
+        let collected = crate::collector::LogEntry {
+            container: discovered_container(),
+            stream: crate::collector::LogStream::from_log_output(&frame),
+            raw_bytes: frame.into_bytes(),
+        };
+
+        let enriched = enrich_log_entry(&parser, collected).await;
+
+        assert_eq!(
+            enriched.stream, "stderr",
+            "a line Docker demultiplexed onto stderr must be recorded as stderr"
         );
     }
 

--- a/rask-log-forwarder/app/src/app/service.rs
+++ b/rask-log-forwarder/app/src/app/service.rs
@@ -247,6 +247,7 @@ impl ServiceManager {
                 self.config.disk_fallback_config.retention_hours * 3600,
             ),
             compression: self.config.disk_fallback_config.compression,
+            enabled: self.config.disk_fallback_config.enabled,
         };
 
         let metrics_config = crate::reliability::MetricsConfig {

--- a/rask-log-forwarder/app/src/app/shutdown.rs
+++ b/rask-log-forwarder/app/src/app/shutdown.rs
@@ -7,6 +7,18 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
+/// Docker's `stop_grace_period` for the forwarder containers
+/// (`compose/logging.yaml`): SIGKILL lands this long after SIGTERM.
+const STOP_GRACE_PERIOD: Duration = Duration::from_secs(12);
+
+/// Deadline for the processing loop to drain the channel and flush its last
+/// batch. That final flush goes through the retry ladder before it reaches
+/// disk fallback, so it needs as much of the grace period as we can give it -
+/// a shorter deadline drops the batch without sending it or persisting it.
+/// The remaining headroom is for the runtime to unwind and the tracing
+/// subscriber to flush before Docker SIGKILLs us.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(STOP_GRACE_PERIOD.as_secs() - 2);
+
 #[derive(Debug)]
 pub struct ShutdownHandle {
     shutdown_tx: mpsc::UnboundedSender<()>,
@@ -39,11 +51,7 @@ impl ShutdownHandle {
         // polling a flag it sets - this resolves the instant the task exits
         // instead of up to 100ms late, and doesn't spin a wakeup every tick
         // while shutdown is in progress.
-        // Note: 4 seconds is chosen to fit within Docker's stop_grace_period (12s)
-        // while leaving buffer time for cleanup operations
-        let timeout_duration = Duration::from_secs(4);
-
-        match tokio::time::timeout(timeout_duration, self.processing_loop).await {
+        match tokio::time::timeout(SHUTDOWN_TIMEOUT, self.processing_loop).await {
             Ok(Ok(())) => {
                 info!("Graceful shutdown completed");
                 Ok(())
@@ -218,6 +226,105 @@ mod tests {
         assert!(
             wait_result.is_err(),
             "wait() returned before any signal was observed"
+        );
+    }
+
+    /// Stands in for `pipeline::run_processing_loop`: wakes on the shutdown
+    /// signal, then spends `flush_duration` draining and flushing its last
+    /// batch (the real one walks the retry ladder before disk fallback).
+    fn fake_processing_loop(
+        flush_duration: Duration,
+    ) -> (mpsc::UnboundedSender<()>, tokio::task::JoinHandle<()>) {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            rx.recv().await;
+            tokio::time::sleep(flush_duration).await;
+        });
+        (tx, handle)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_waits_for_a_final_flush_that_needs_most_of_the_grace_period() {
+        // The last batch only reaches the aggregator (or disk fallback) after
+        // the retry ladder has run, which routinely takes several seconds. A
+        // deadline that expires first drops those entries entirely.
+        let (tx, processing_loop) = fake_processing_loop(Duration::from_secs(9));
+
+        ShutdownHandle::new(tx, test_handler(), processing_loop)
+            .shutdown()
+            .await
+            .expect(
+                "shutdown must wait out the final flush - giving up early drops the last batch \
+                 without sending it or persisting it to disk",
+            );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_gives_up_inside_the_container_stop_grace_period() {
+        // The deadline still has to land before Docker's SIGKILL, otherwise
+        // the process is killed mid-flush instead of reporting the timeout.
+        let (tx, processing_loop) = fake_processing_loop(Duration::from_secs(300));
+
+        let started = tokio::time::Instant::now();
+        let result = ShutdownHandle::new(tx, test_handler(), processing_loop)
+            .shutdown()
+            .await;
+
+        assert!(
+            matches!(result, Err(ServiceError::ShutdownTimeout)),
+            "a processing loop that never finishes must surface as a shutdown timeout"
+        );
+        // Lower bound first: this is what makes the test a regression guard for
+        // the 4s deadline. Without it the assertion below is satisfied by
+        // construction, since SHUTDOWN_TIMEOUT is derived from STOP_GRACE_PERIOD.
+        assert!(
+            started.elapsed() >= SHUTDOWN_TIMEOUT,
+            "shutdown gave up after {:?}, short of the {SHUTDOWN_TIMEOUT:?} deadline - the final \
+             flush is being cut off early",
+            started.elapsed()
+        );
+        assert!(
+            started.elapsed() < STOP_GRACE_PERIOD,
+            "shutdown gave up after {:?}, at or past the {STOP_GRACE_PERIOD:?} stop_grace_period - \
+             Docker would SIGKILL us before we could report it",
+            started.elapsed()
+        );
+    }
+
+    /// The deadline and compose's `stop_grace_period` are one contract living in
+    /// two files. Parse the container spec rather than trusting the local
+    /// constant, so raising STOP_GRACE_PERIOD here without touching
+    /// compose/logging.yaml fails the build here instead of in production.
+    #[test]
+    fn stop_grace_period_matches_the_compose_service_spec() {
+        const LOGGING_COMPOSE: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../compose/logging.yaml"
+        ));
+
+        let declared: Vec<u64> = LOGGING_COMPOSE
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("stop_grace_period:"))
+            .map(|value| {
+                value
+                    .trim()
+                    .trim_end_matches('s')
+                    .parse::<u64>()
+                    .expect("stop_grace_period must be a whole number of seconds")
+            })
+            .collect();
+
+        assert_eq!(
+            declared.len(),
+            1,
+            "expected exactly one stop_grace_period in compose/logging.yaml, found {declared:?} - \
+             this test would otherwise pin the wrong service's value"
+        );
+        assert_eq!(
+            STOP_GRACE_PERIOD.as_secs(),
+            declared[0],
+            "STOP_GRACE_PERIOD disagrees with compose/logging.yaml; the deadline derived from it \
+             would let Docker SIGKILL the forwarder mid-flush"
         );
     }
 }

--- a/rask-log-forwarder/app/src/collector/mod.rs
+++ b/rask-log-forwarder/app/src/collector/mod.rs
@@ -1,11 +1,13 @@
 pub mod discovery;
 pub mod docker;
 
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 // Ensure zero-copy processing by using Bytes throughout
+use bollard::container::LogOutput;
 use bytes::Bytes;
 
 /// Initial delay before the first reconnect attempt after a Docker log
@@ -45,14 +47,56 @@ pub enum CollectorError {
     CollectionStopped,
 }
 
-/// Raw collected log line. `log`/`stream`/`time` are deliberately absent:
-/// they get re-derived from `raw_bytes` by the downstream Docker JSON parser,
-/// so allocating placeholder values for them here would be pure waste on the
-/// per-line hot path.
+/// Which of the container's standard streams Docker demultiplexed a line
+/// from. It has to be carried explicitly: `LogOutput::into_bytes()` drops the
+/// variant, and the payload bollard hands us has no frame header left, so
+/// nothing downstream can tell a panic backtrace from ordinary output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+impl LogStream {
+    /// Value written to the aggregator's `stream` column, which
+    /// `WHERE stream='stderr'` matches against.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+
+    /// Classify a Docker log frame. Variants are listed exhaustively rather
+    /// than collapsed into `_` so a new bollard variant breaks the build
+    /// instead of quietly being recorded as stdout.
+    pub(crate) fn from_log_output(output: &LogOutput) -> Self {
+        match output {
+            LogOutput::StdErr { .. } => Self::Stderr,
+            LogOutput::StdOut { .. } => Self::Stdout,
+            // TTY-attached containers: Docker merges both streams into a
+            // single console stream and reports it as stdout.
+            LogOutput::Console { .. } => Self::Stdout,
+            // Only produced by the attach endpoint's input side, never by
+            // `docker logs`.
+            LogOutput::StdIn { .. } => Self::Stdout,
+        }
+    }
+}
+
+/// Raw collected log line. `log`/`time` are deliberately absent: they get
+/// re-derived from `raw_bytes` by the downstream Docker JSON parser, so
+/// allocating placeholder values for them here would be pure waste on the
+/// per-line hot path. `stream` and `container` are the opposite case - they
+/// are known here and nowhere else, so dropping them loses them for good.
 #[derive(Debug, Clone)]
 pub struct LogEntry {
-    pub id: String,
-    pub container_id: String,
+    /// Container metadata discovery resolved for the connection this line
+    /// arrived on, including the `rask.group` label. Shared per connection
+    /// rather than cloned per line.
+    pub container: Arc<ContainerInfo>,
+    pub stream: LogStream,
     pub raw_bytes: Bytes,
 }
 
@@ -80,7 +124,7 @@ pub struct LogCollector {
     #[allow(dead_code)]
     config: CollectorConfig,
     discovery: discovery::ServiceDiscovery,
-    container_info: Option<discovery::ContainerInfo>,
+    container_info: Option<Arc<discovery::ContainerInfo>>,
     target_service: String,
 }
 
@@ -131,7 +175,10 @@ impl LogCollector {
                 .find_container_by_service(&self.target_service)
                 .await
             {
-                Ok(info) => info,
+                // Shared with every entry streamed off this connection, so
+                // the `rask.group` resolved here reaches the aggregator
+                // instead of being rebuilt (and lost) further downstream.
+                Ok(info) => Arc::new(info),
                 Err(e) => {
                     tracing::warn!(
                         "Container discovery failed for service '{}': {e}; retrying in {:?}",
@@ -145,7 +192,7 @@ impl LogCollector {
                     continue;
                 }
             };
-            self.container_info = Some(container_info.clone());
+            self.container_info = Some(Arc::clone(&container_info));
 
             let docker_collector = match DockerCollector::new().await {
                 Ok(c) => c,
@@ -172,7 +219,7 @@ impl LogCollector {
             match self
                 .start_docker_api_streaming(
                     docker_collector,
-                    &container_info.id,
+                    &container_info,
                     tx.clone(),
                     cancel_token.clone(),
                 )
@@ -221,7 +268,7 @@ impl LogCollector {
     async fn start_docker_api_streaming(
         &self,
         docker_collector: DockerCollector,
-        container_id: &str,
+        container: &Arc<ContainerInfo>,
         tx: mpsc::Sender<LogEntry>,
         cancel_token: CancellationToken,
     ) -> Result<StreamExit, CollectorError> {
@@ -243,7 +290,7 @@ impl LogCollector {
             ..Default::default()
         };
 
-        let mut stream = docker.logs(container_id, Some(options));
+        let mut stream = docker.logs(&container.id, Some(options));
 
         loop {
             tokio::select! {
@@ -256,14 +303,16 @@ impl LogCollector {
                 log_output = stream.next() => {
                     match log_output {
                         Some(Ok(log_chunk)) => {
-                            // Convert Docker log output to LogEntry
-                            let log_bytes = log_chunk.into_bytes();
+                            // Read the stream off the frame before into_bytes()
+                            // discards the variant - it is the only place
+                            // stderr is still distinguishable.
+                            let stream = LogStream::from_log_output(&log_chunk);
 
                             // Create LogEntry with raw bytes - let the parser handle the actual parsing
                             let entry = LogEntry {
-                                id: container_id.to_string(),
-                                container_id: container_id.to_string(),
-                                raw_bytes: log_bytes,
+                                container: Arc::clone(container),
+                                stream,
+                                raw_bytes: log_chunk.into_bytes(),
                             };
 
                             // Bounded channel: block (apply backpressure) rather than
@@ -298,7 +347,43 @@ impl LogCollector {
     }
 
     pub fn get_container_info(&self) -> Option<&discovery::ContainerInfo> {
-        self.container_info.as_ref()
+        self.container_info.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod log_stream_tests {
+    use super::*;
+
+    fn frame_of(output: &LogOutput) -> &'static str {
+        LogStream::from_log_output(output).as_str()
+    }
+
+    #[test]
+    fn docker_frame_variant_decides_the_stream() {
+        let message = Bytes::from_static(b"boom\n");
+
+        assert_eq!(
+            frame_of(&LogOutput::StdErr {
+                message: message.clone()
+            }),
+            "stderr"
+        );
+        assert_eq!(
+            frame_of(&LogOutput::StdOut {
+                message: message.clone()
+            }),
+            "stdout"
+        );
+        // TTY containers only ever produce Console frames; Docker itself
+        // reports those as stdout.
+        assert_eq!(
+            frame_of(&LogOutput::Console {
+                message: message.clone()
+            }),
+            "stdout"
+        );
+        assert_eq!(frame_of(&LogOutput::StdIn { message }), "stdout");
     }
 }
 

--- a/rask-log-forwarder/app/src/parser/universal.rs
+++ b/rask-log-forwarder/app/src/parser/universal.rs
@@ -7,7 +7,7 @@ use super::{
         PostgresParser, PythonStructlogParser, RustTracingParser, ServiceParser,
     },
 };
-use crate::collector::ContainerInfo;
+use crate::collector::{ContainerInfo, LogStream};
 use std::collections::HashMap;
 
 // Re-export EnrichedLogEntry from the domain layer (canonical definition)
@@ -214,6 +214,24 @@ impl UniversalParser {
         Ok(())
     }
 
+    /// Parse a log line for which the OS stream is already known, because
+    /// Docker demultiplexed it for us (see `collector::LogStream`). Callers
+    /// reading straight off the Docker API must use this: once bollard has
+    /// stripped the frame header the payload alone cannot say whether the
+    /// line went to stdout or stderr.
+    pub fn parse_docker_log_with_stream(
+        &self,
+        log_bytes: &[u8],
+        container_info: &ContainerInfo,
+        stream: LogStream,
+    ) -> Result<EnrichedLogEntry, ParseError> {
+        self.parse_docker_log_inner(log_bytes, container_info, Some(stream))
+    }
+
+    /// Parse a log line with no out-of-band stream information, so the stream
+    /// can only come from the payload itself (Docker json-file format) and
+    /// otherwise defaults to stdout.
+    ///
     /// Pure CPU-bound parsing - no `.await` points, so this is a plain
     /// (non-async) fn rather than paying for a per-line `Future` for no
     /// reason.
@@ -221,6 +239,15 @@ impl UniversalParser {
         &self,
         log_bytes: &[u8],
         container_info: &ContainerInfo,
+    ) -> Result<EnrichedLogEntry, ParseError> {
+        self.parse_docker_log_inner(log_bytes, container_info, None)
+    }
+
+    fn parse_docker_log_inner(
+        &self,
+        log_bytes: &[u8],
+        container_info: &ContainerInfo,
+        stream_hint: Option<LogStream>,
     ) -> Result<EnrichedLogEntry, ParseError> {
         // Validate input size first
         self.validate_input_size(log_bytes)?;
@@ -247,7 +274,12 @@ impl UniversalParser {
             self.validate_field_size(&docker_entry.stream, "stream")?;
             self.validate_field_size(&docker_entry.time, "timestamp")?;
 
-            (log, docker_entry.stream, docker_entry.time)
+            // The demultiplexed frame wins when we have one: a payload that
+            // merely looks like json-file format (an application logging its
+            // own "log" key) must not talk us out of the real stream.
+            let stream = stream_hint.map_or(docker_entry.stream, |s| s.as_str().to_string());
+
+            (log, stream, docker_entry.time)
         } else {
             // This is raw application log (when timestamps: false in Docker API)
             // Remove trailing newline/carriage return
@@ -255,7 +287,11 @@ impl UniversalParser {
                 .trim_end_matches('\n')
                 .trim_end_matches('\r')
                 .to_string();
-            (log, "stdout".to_string(), chrono::Utc::now().to_rfc3339())
+            let stream = stream_hint
+                .unwrap_or(LogStream::Stdout)
+                .as_str()
+                .to_string();
+            (log, stream, chrono::Utc::now().to_rfc3339())
         };
 
         // Now parse the actual log content

--- a/rask-log-forwarder/app/src/reliability/disk.rs
+++ b/rask-log-forwarder/app/src/reliability/disk.rs
@@ -34,6 +34,10 @@ pub struct DiskConfig {
     pub max_disk_usage: u64, // bytes
     pub retention_period: Duration,
     pub compression: bool,
+    /// Mirrors ENABLE_DISK_FALLBACK. When false the store is never constructed,
+    /// so no directory is created and no batch is ever written; a batch that
+    /// exhausts its retry budget is then dropped loudly instead of persisted.
+    pub enabled: bool,
 }
 
 impl Default for DiskConfig {
@@ -43,6 +47,7 @@ impl Default for DiskConfig {
             max_disk_usage: 1024 * 1024 * 1024, // 1GB
             retention_period: Duration::from_secs(24 * 3600), // 24 hours
             compression: true,
+            enabled: true,
         }
     }
 }

--- a/rask-log-forwarder/app/src/reliability/mod.rs
+++ b/rask-log-forwarder/app/src/reliability/mod.rs
@@ -18,7 +18,10 @@ use tokio_util::sync::CancellationToken;
 
 pub struct ReliabilityManager {
     retry_manager: Arc<Mutex<RetryManager>>,
-    disk_fallback: Arc<Mutex<DiskFallback>>,
+    /// `None` when ENABLE_DISK_FALLBACK is false. Not a "might not be wired
+    /// yet" option: the two states are distinguished by a startup log, and the
+    /// disabled branch fails loudly rather than pretending the batch was saved.
+    disk_fallback: Option<Arc<Mutex<DiskFallback>>>,
     metrics_collector: Arc<Mutex<MetricsCollector>>,
     health_monitor: Arc<HealthMonitor>,
     log_sender: LogSender,
@@ -34,7 +37,22 @@ impl ReliabilityManager {
         log_sender: LogSender,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let retry_manager = Arc::new(Mutex::new(RetryManager::new(retry_config)));
-        let disk_fallback = Arc::new(Mutex::new(DiskFallback::new(disk_config).await?));
+        // Loud either way, so "operator turned it off" is never confused with
+        // "the wiring forgot about it" (CLAUDE.md rule 8).
+        let disk_fallback = if disk_config.enabled {
+            tracing::info!(
+                storage_path = %disk_config.storage_path.display(),
+                max_disk_usage = disk_config.max_disk_usage,
+                "disk_fallback_enabled"
+            );
+            Some(Arc::new(Mutex::new(DiskFallback::new(disk_config).await?)))
+        } else {
+            tracing::warn!(
+                "disk_fallback_disabled: batches that exhaust the retry budget will be dropped, \
+                 not persisted"
+            );
+            None
+        };
         let metrics_collector = Arc::new(Mutex::new(
             MetricsCollector::new(metrics_config).unwrap_or_else(|e| {
                 tracing::error!(
@@ -177,13 +195,29 @@ impl ReliabilityManager {
         let batch_id = batch.id().to_string();
         let entry_count = batch.size();
 
+        let Some(store) = self.disk_fallback.as_ref() else {
+            // Disabled by config, so this batch is genuinely lost. Say so at
+            // error level with the count — silently returning Ok here would
+            // report a successful persist that never happened.
+            tracing::error!(
+                batch_id = %batch_id,
+                entry_count,
+                "disk_fallback_disabled: dropping batch that exhausted its retry budget"
+            );
+            return Err(TransmissionError::ClientError(
+                crate::sender::ClientError::InvalidConfiguration(
+                    "disk fallback is disabled; batch dropped after retry exhaustion".to_string(),
+                ),
+            ));
+        };
+
         tracing::warn!(
             "Storing batch {} to disk fallback after failed retries",
             batch_id
         );
 
         {
-            let mut disk_fallback = self.disk_fallback.lock().await;
+            let mut disk_fallback = store.lock().await;
             if let Err(e) = disk_fallback.store_batch(batch).await {
                 tracing::error!("Failed to store batch {batch_id} to disk: {e}");
                 self.health_monitor
@@ -222,15 +256,22 @@ impl ReliabilityManager {
     /// protects against data loss on the wire, but nothing ever reads the
     /// data back out and forwards it on.
     pub async fn replay_stored_batches(&self) -> Result<usize, DiskError> {
+        // Nothing was ever written when the store is off, so there is nothing
+        // to replay. Not a silent skip: construction already logged
+        // disk_fallback_disabled.
+        let Some(store) = self.disk_fallback.as_ref() else {
+            return Ok(0);
+        };
+
         let batch_ids = {
-            let disk_fallback = self.disk_fallback.lock().await;
+            let disk_fallback = store.lock().await;
             disk_fallback.list_stored_batches().await?
         };
 
         let mut replayed = 0;
         for batch_id in batch_ids {
             let batch = {
-                let disk_fallback = self.disk_fallback.lock().await;
+                let disk_fallback = store.lock().await;
                 match disk_fallback.retrieve_batch(&batch_id).await {
                     Ok(batch) => batch,
                     Err(e) => {
@@ -253,7 +294,7 @@ impl ReliabilityManager {
             };
 
             if sent {
-                let mut disk_fallback = self.disk_fallback.lock().await;
+                let mut disk_fallback = store.lock().await;
                 if let Err(e) = disk_fallback.delete_batch(&batch_id).await {
                     tracing::error!(
                         "Disk fallback replay: resent batch {batch_id} but failed to delete it from disk: {e}"
@@ -297,8 +338,23 @@ impl ReliabilityManager {
     /// to replay (e.g. the aggregator rejects them with a persistent 4xx)
     /// stay on disk forever and eventually trip `DiskSpaceExceeded`.
     pub async fn cleanup_disk_fallback(&self) -> Result<u32, DiskError> {
-        let mut disk_fallback = self.disk_fallback.lock().await;
+        // Nothing is stored when the fallback is off, so there is nothing to
+        // reap. Construction already logged disk_fallback_disabled.
+        let Some(store) = self.disk_fallback.as_ref() else {
+            return Ok(0);
+        };
+        let mut disk_fallback = store.lock().await;
         disk_fallback.cleanup_old_batches().await
+    }
+
+    /// Test-only handle on the disk store. Panics when the fallback is
+    /// disabled, so a test that means to exercise storage cannot quietly pass
+    /// against a manager that has no store at all.
+    #[cfg(test)]
+    fn disk_store(&self) -> &Arc<Mutex<DiskFallback>> {
+        self.disk_fallback
+            .as_ref()
+            .expect("this test requires DiskConfig::enabled = true")
     }
 
     /// Spawns a periodic task that deletes disk-fallback batches past their
@@ -419,7 +475,7 @@ mod replay_tests {
         // down replay behavior in isolation.
         let batch = Batch::new(vec![test_entry()], BatchType::SizeBased);
         {
-            let mut disk_fallback = manager.disk_fallback.lock().await;
+            let mut disk_fallback = manager.disk_store().lock().await;
             disk_fallback.store_batch(batch).await.unwrap();
         }
         assert_eq!(storage_dir.path().read_dir().unwrap().count(), 1);
@@ -447,7 +503,7 @@ mod replay_tests {
 
         let batch = Batch::new(vec![test_entry()], BatchType::SizeBased);
         {
-            let mut disk_fallback = manager.disk_fallback.lock().await;
+            let mut disk_fallback = manager.disk_store().lock().await;
             disk_fallback.store_batch(batch).await.unwrap();
         }
 
@@ -504,7 +560,7 @@ mod replay_tests {
 
         let batch = Batch::new(vec![test_entry()], BatchType::SizeBased);
         {
-            let mut disk_fallback = manager.disk_fallback.lock().await;
+            let mut disk_fallback = manager.disk_store().lock().await;
             disk_fallback.store_batch(batch).await.unwrap();
         }
         assert_eq!(storage_dir.path().read_dir().unwrap().count(), 1);
@@ -546,5 +602,45 @@ mod replay_tests {
             .await
             .expect("disk cleanup task must stop once cancelled")
             .expect("disk cleanup task must not panic");
+    }
+
+    /// ENABLE_DISK_FALLBACK=false must actually turn the disk store off.
+    /// The flag was parsed into Config and then never read, so every forwarder
+    /// kept gzipping batches into its fallback directory regardless — up to
+    /// max_disk_usage per container, on hosts where an operator had explicitly
+    /// said no.
+    #[tokio::test]
+    async fn disk_fallback_is_not_created_when_disabled_in_config() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage_path = temp.path().join("fallback");
+
+        let log_sender = LogSender::new(ClientConfig {
+            endpoint: "http://127.0.0.1:1".to_string(),
+            timeout: Duration::from_millis(500),
+            connection_timeout: Duration::from_millis(500),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let _manager = ReliabilityManager::new(
+            RetryConfig::default(),
+            DiskConfig {
+                storage_path: storage_path.clone(),
+                enabled: false,
+                ..Default::default()
+            },
+            MetricsConfig::default(),
+            HealthConfig::default(),
+            log_sender,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !storage_path.exists(),
+            "ENABLE_DISK_FALLBACK=false must not stand up the disk-fallback store; \
+             every forwarder otherwise keeps writing gzip batches an operator turned off"
+        );
     }
 }

--- a/rask-log-forwarder/app/tests/disk_fallback_test.rs
+++ b/rask-log-forwarder/app/tests/disk_fallback_test.rs
@@ -12,6 +12,7 @@ async fn test_store_and_retrieve_batch() {
         max_disk_usage: 100 * 1024 * 1024,           // 100MB
         retention_period: Duration::from_secs(3600), // 1 hour
         compression: true,
+        enabled: true,
     };
 
     let mut disk_fallback = DiskFallback::new(config).await.unwrap();
@@ -39,6 +40,7 @@ async fn test_list_stored_batches() {
         max_disk_usage: 100 * 1024 * 1024,
         retention_period: Duration::from_secs(3600),
         compression: true,
+        enabled: true,
     };
 
     let mut disk_fallback = DiskFallback::new(config).await.unwrap();
@@ -71,6 +73,7 @@ async fn test_disk_usage_limits() {
         max_disk_usage: 1024, // Very small limit (1KB)
         retention_period: Duration::from_secs(3600),
         compression: true,
+        enabled: true,
     };
 
     let mut disk_fallback = DiskFallback::new(config).await.unwrap();
@@ -91,6 +94,7 @@ async fn test_batch_cleanup_by_age() {
         max_disk_usage: 100 * 1024 * 1024,
         retention_period: Duration::from_secs(1), // 1 second retention for testing
         compression: false,
+        enabled: true,
     };
 
     let mut disk_fallback = DiskFallback::new(config).await.unwrap();
@@ -120,6 +124,7 @@ async fn test_delete_batch() {
         max_disk_usage: 100 * 1024 * 1024,
         retention_period: Duration::from_secs(3600),
         compression: false,
+        enabled: true,
     };
 
     let mut disk_fallback = DiskFallback::new(config).await.unwrap();

--- a/rask-log-forwarder/app/tests/reliability_integration_test.rs
+++ b/rask-log-forwarder/app/tests/reliability_integration_test.rs
@@ -24,6 +24,7 @@ async fn test_reliability_manager_success_path() {
         max_disk_usage: 10 * 1024 * 1024, // 10MB
         retention_period: Duration::from_secs(3600),
         compression: true,
+        enabled: true,
     };
 
     let metrics_config = MetricsConfig {
@@ -91,6 +92,7 @@ async fn test_reliability_manager_metrics_collection() {
         max_disk_usage: 10 * 1024 * 1024,
         retention_period: Duration::from_secs(3600),
         compression: false,
+        enabled: true,
     };
     let metrics_config = MetricsConfig::default();
     let health_config = HealthConfig::default();
@@ -140,6 +142,7 @@ async fn test_reliability_manager_health_monitoring() {
         max_disk_usage: 10 * 1024 * 1024,
         retention_period: Duration::from_secs(3600),
         compression: false,
+        enabled: true,
     };
     let metrics_config = MetricsConfig::default();
     let health_config = HealthConfig::default();

--- a/recap-evaluator/src/recap_evaluator/evaluator/cluster_evaluator.py
+++ b/recap-evaluator/src/recap_evaluator/evaluator/cluster_evaluator.py
@@ -1,5 +1,7 @@
 """Clustering quality evaluator with DI."""
 
+from collections.abc import Iterable
+from typing import Final
 from uuid import UUID
 
 import numpy as np
@@ -18,6 +20,21 @@ from recap_evaluator.domain.models import AlertLevel, ClusterMetrics
 from recap_evaluator.port.database_port import DatabasePort
 
 logger = structlog.get_logger()
+
+_SEVERITY_RANK: Final[dict[AlertLevel, int]] = {
+    AlertLevel.OK: 0,
+    AlertLevel.WARN: 1,
+    AlertLevel.CRITICAL: 2,
+}
+
+
+def _worst(levels: Iterable[AlertLevel]) -> AlertLevel:
+    """Highest severity among *levels*, OK when there is none.
+
+    Same rule as usecase.AlertResolver.resolve, kept local because the
+    evaluator layer sits below usecase and must not depend upward.
+    """
+    return max(levels, key=_SEVERITY_RANK.__getitem__, default=AlertLevel.OK)
 
 
 class ClusterEvaluator:
@@ -168,13 +185,21 @@ class ClusterEvaluator:
             warn = self._thresholds.get_warn("clustering_silhouette")
             critical = self._thresholds.get_critical("clustering_silhouette")
             if sil is None:
-                alert = AlertLevel.OK
+                sil_alert = AlertLevel.OK
             elif critical is not None and sil < critical:
-                alert = AlertLevel.CRITICAL
+                sil_alert = AlertLevel.CRITICAL
             elif warn is not None and sil < warn:
-                alert = AlertLevel.WARN
+                sil_alert = AlertLevel.WARN
             else:
-                alert = AlertLevel.OK
+                sil_alert = AlertLevel.OK
+
+            # The per-job alerts are the only signal the DB-only path ever
+            # produces (cluster-count heuristic in evaluate_job); recomputing
+            # the aggregate from silhouette alone would drop every one of them
+            # and report OK on the night a genre collapsed to one cluster.
+            # Keep the worst severity rather than an average — one bad night
+            # in a healthy window is exactly what the alert is for.
+            alert = _worst([m.alert_level for m in metrics_list] + [sil_alert])
 
             aggregated[genre] = ClusterMetrics(
                 num_clusters=int(np.mean([m.num_clusters for m in metrics_list])),

--- a/recap-evaluator/src/recap_evaluator/evaluator/summary_evaluator.py
+++ b/recap-evaluator/src/recap_evaluator/evaluator/summary_evaluator.py
@@ -4,7 +4,7 @@ import asyncio
 import random
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Literal
+from typing import Any, Final, Literal
 from uuid import UUID
 
 import structlog
@@ -23,6 +23,15 @@ from recap_evaluator.gateway.ollama_gateway import OllamaGateway
 from recap_evaluator.port.database_port import DatabasePort
 
 logger = structlog.get_logger()
+
+# The axes that carry a weight in the composite score. An axis that raised in
+# _run_multi_evaluation never reaches _apply_result, so its metrics stay at
+# 0.0 — indistinguishable from a genuinely terrible measurement. Coverage is
+# therefore tracked by name and never inferred from a value, for the same
+# reason success_count exists for the G-Eval axis.
+_COMPOSITE_AXES: Final[frozenset[str]] = frozenset(
+    {"geval", "bertscore", "faithfulness", "rouge"}
+)
 
 
 class SummaryEvaluator:
@@ -100,18 +109,23 @@ class SummaryEvaluator:
         )
 
         if all_eval_items:
-            metrics = await self._run_multi_evaluation(all_eval_items)
+            metrics, measured_axes = await self._run_multi_evaluation(all_eval_items)
         else:
             metrics = SummaryMetrics(sample_count=0, success_count=0)
+            measured_axes = frozenset()
 
         await self._apply_morning_letter_axes(metrics, all_outputs_flat)
 
-        metrics.alert_level = self._determine_alert_level(metrics)
+        metrics.alert_level = self._determine_alert_level(metrics, measured_axes)
 
         logger.info(
             "Multi-dimensional batch evaluation completed",
             sample_count=metrics.sample_count,
             overall_quality_score=metrics.overall_quality_score,
+            # The composite is only comparable between runs when the same
+            # axes fed it, and SummaryMetrics has nowhere to carry that, so
+            # the coverage lives in the run log.
+            measured_axes=sorted(measured_axes),
             alert_level=metrics.alert_level.value,
         )
 
@@ -127,7 +141,7 @@ class SummaryEvaluator:
 
     async def _run_multi_evaluation(
         self, eval_items: list[tuple[str, str]]
-    ) -> SummaryMetrics:
+    ) -> tuple[SummaryMetrics, frozenset[str]]:
         sources = [item[0] for item in eval_items]
         summaries = [item[1] for item in eval_items]
 
@@ -184,6 +198,7 @@ class SummaryEvaluator:
         # would cancel siblings on the first exception (DECREE §6 prefers
         # TaskGroup for all-or-nothing fan-out; this path needs best-effort).
 
+        measured_axes: set[str] = set()
         for i, (name, _) in enumerate(tasks):
             result = results[i]
             if isinstance(result, BaseException):
@@ -194,9 +209,18 @@ class SummaryEvaluator:
                 )
                 continue
             self._apply_result(metrics, name, result)
+            measured_axes.add(name)
 
-        metrics.overall_quality_score = self._calculate_composite_score(metrics)
-        return metrics
+        # The G-Eval task can return without a single successful judgement
+        # (every item errored inside the gateway). success_count is the only
+        # record of that, so the axis counts as unmeasured even though the
+        # task itself did not raise.
+        if metrics.success_count == 0:
+            measured_axes.discard("geval")
+
+        axes = frozenset(measured_axes)
+        metrics.overall_quality_score = self._calculate_composite_score(metrics, axes)
+        return metrics, axes
 
     async def _run_geval(self, eval_items: list[tuple[str, str]]) -> dict:
         # self._ollama.evaluate_batch() already absorbs per-item failures via
@@ -305,35 +329,67 @@ class SummaryEvaluator:
             metrics.faithfulness_score = result.get("faithfulness_score", 0.0)
             metrics.hallucination_rate = result.get("hallucination_rate", 0.0)
 
-    def _calculate_composite_score(self, metrics: SummaryMetrics) -> float:
-        total_weight = 0.0
+    def _calculate_composite_score(
+        self, metrics: SummaryMetrics, measured_axes: frozenset[str]
+    ) -> float:
+        """Weighted mean over the *configured* weights, not the surviving ones.
+
+        Dividing by the surviving weight makes an outage look like an
+        improvement — losing the 40 % G-Eval axis used to leave a score of
+        ~0.71, comfortably above the 0.50 warn line — and makes the value
+        stored in recap_evaluation_runs incomparable between runs. An
+        unmeasured axis contributes nothing and is still paid for, so the
+        composite is a floor on quality that only ever moves downward.
+        """
         weighted_sum = 0.0
 
-        if metrics.geval_overall > 0:
+        if "geval" in measured_axes:
             geval_normalized = (metrics.geval_overall - 1) / 4
             weighted_sum += self._weights.geval * geval_normalized
-            total_weight += self._weights.geval
 
-        if metrics.bertscore_f1 > 0:
+        if "bertscore" in measured_axes:
             weighted_sum += self._weights.bertscore * metrics.bertscore_f1
-            total_weight += self._weights.bertscore
 
-        if metrics.faithfulness_score > 0:
+        if "faithfulness" in measured_axes:
             weighted_sum += self._weights.faithfulness * metrics.faithfulness_score
-            total_weight += self._weights.faithfulness
 
-        if metrics.rouge_l_f1 > 0:
+        if "rouge" in measured_axes:
             weighted_sum += self._weights.rouge_l * metrics.rouge_l_f1
-            total_weight += self._weights.rouge_l
 
-        return weighted_sum / total_weight if total_weight > 0 else 0.0
+        # EvaluatorWeights.validate_sum keeps this at 1.0 ± 0.001.
+        total_weight = (
+            self._weights.geval
+            + self._weights.bertscore
+            + self._weights.faithfulness
+            + self._weights.rouge_l
+        )
+        return weighted_sum / total_weight
 
-    def _determine_alert_level(self, metrics: SummaryMetrics) -> AlertLevel:
-        # success_count is the only explicit record of whether the judge ran.
+    def _count_geval_breaches(self, metrics: SummaryMetrics) -> tuple[int, int]:
+        """(critical, warn) counts across the four G-Eval dimensions."""
+        critical_count = 0
+        warn_count = 0
+
+        for dim in ["coherence", "consistency", "fluency", "relevance"]:
+            warn = self._thresholds.get_warn(f"geval_{dim}")
+            critical = self._thresholds.get_critical(f"geval_{dim}")
+            value = getattr(metrics, dim)
+
+            if critical is not None and value < critical:
+                critical_count += 1
+            elif warn is not None and value < warn:
+                warn_count += 1
+
+        return critical_count, warn_count
+
+    def _determine_alert_level(
+        self, metrics: SummaryMetrics, measured_axes: frozenset[str]
+    ) -> AlertLevel:
+        # measured_axes is the only explicit record of whether an axis ran.
         # The G-Eval axes and the composite sit at 0.0 both when nothing was
         # measured and when the judge scored the batch at rock bottom, so
         # measurement is decided here and never inferred from a value.
-        geval_measured = metrics.success_count > 0
+        geval_measured = "geval" in measured_axes
 
         if metrics.sample_count > 0 and not geval_measured:
             logger.error(
@@ -345,23 +401,34 @@ class SummaryEvaluator:
         critical_count = 0
         warn_count = 0
 
-        if geval_measured:
-            for dim in ["coherence", "consistency", "fluency", "relevance"]:
-                warn = self._thresholds.get_warn(f"geval_{dim}")
-                critical = self._thresholds.get_critical(f"geval_{dim}")
-                value = getattr(metrics, dim)
+        # An axis that never ran leaves its metrics at 0.0, so the composite
+        # is a floor rather than a measurement — one outage already makes the
+        # run's quality verdict unreliable, two make it worthless. Counting
+        # them as failed dimensions is what keeps a silent evaluator outage
+        # from being reported as healthy summaries.
+        missing_axes = sorted(_COMPOSITE_AXES - measured_axes)
+        if metrics.sample_count > 0 and missing_axes:
+            logger.error(
+                "composite_axes_unmeasured",
+                missing_axes=missing_axes,
+                sample_count=metrics.sample_count,
+            )
+            critical_count += len(missing_axes)
 
-                if critical is not None and value < critical:
-                    critical_count += 1
-                elif warn is not None and value < warn:
-                    warn_count += 1
+        if geval_measured:
+            geval_critical, geval_warn = self._count_geval_breaches(metrics)
+            critical_count += geval_critical
+            warn_count += geval_warn
 
         if metrics.hallucination_rate > 0.5:
             critical_count += 1
         elif metrics.hallucination_rate > 0.3:
             warn_count += 1
 
-        if geval_measured:
+        # Only judge the composite when every weighted axis fed it; an
+        # incomplete composite is already counted above and reading it as a
+        # quality signal would just double-count the same outage.
+        if geval_measured and not missing_axes:
             if metrics.overall_quality_score < 0.3:
                 critical_count += 1
             elif metrics.overall_quality_score < 0.5:

--- a/recap-evaluator/tests/unit/evaluator/test_cluster_evaluator.py
+++ b/recap-evaluator/tests/unit/evaluator/test_cluster_evaluator.py
@@ -1,12 +1,19 @@
 """Tests for ClusterEvaluator."""
 
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import numpy as np
 import pytest
 
 from recap_evaluator.domain.models import AlertLevel, ClusterMetrics
 from recap_evaluator.evaluator.cluster_evaluator import ClusterEvaluator
-from tests.fixtures.job_data import SAMPLE_CLUSTER, SAMPLE_SUBWORKER_RUN
+from recap_evaluator.usecase.run_evaluation import RunEvaluationUsecase
+from tests.fixtures.job_data import (
+    SAMPLE_CLUSTER,
+    SAMPLE_JOB,
+    SAMPLE_SUBWORKER_RUN,
+)
 
 
 @pytest.fixture
@@ -15,13 +22,10 @@ def cluster_evaluator(mock_db, alert_thresholds):
 
 
 class TestClusterEvaluator:
-    async def test_evaluate_job_returns_per_genre_metrics(
-        self, cluster_evaluator, mock_db
-    ):
+    async def test_evaluate_job_returns_per_genre_metrics(self, cluster_evaluator, mock_db):
         mock_db.fetch_subworker_runs.return_value = [SAMPLE_SUBWORKER_RUN]
         mock_db.fetch_clusters_for_run.return_value = [
-            {**SAMPLE_CLUSTER, "cluster_id": i, "size": 10 + i}
-            for i in range(5)
+            {**SAMPLE_CLUSTER, "cluster_id": i, "size": 10 + i} for i in range(5)
         ]
 
         result = await cluster_evaluator.evaluate_job(uuid4())
@@ -29,20 +33,14 @@ class TestClusterEvaluator:
         assert "technology" in result
         assert result["technology"].num_clusters == 5
 
-    async def test_evaluate_job_skips_failed_runs(
-        self, cluster_evaluator, mock_db
-    ):
-        mock_db.fetch_subworker_runs.return_value = [
-            {**SAMPLE_SUBWORKER_RUN, "status": "failed"}
-        ]
+    async def test_evaluate_job_skips_failed_runs(self, cluster_evaluator, mock_db):
+        mock_db.fetch_subworker_runs.return_value = [{**SAMPLE_SUBWORKER_RUN, "status": "failed"}]
 
         result = await cluster_evaluator.evaluate_job(uuid4())
 
         assert result == {}
 
-    async def test_evaluate_job_warns_on_few_clusters(
-        self, cluster_evaluator, mock_db
-    ):
+    async def test_evaluate_job_warns_on_few_clusters(self, cluster_evaluator, mock_db):
         mock_db.fetch_subworker_runs.return_value = [SAMPLE_SUBWORKER_RUN]
         mock_db.fetch_clusters_for_run.return_value = [
             {**SAMPLE_CLUSTER, "size": 15},
@@ -53,13 +51,10 @@ class TestClusterEvaluator:
 
         assert result["technology"].alert_level == AlertLevel.WARN
 
-    async def test_evaluate_batch_aggregates_across_jobs(
-        self, cluster_evaluator, mock_db
-    ):
+    async def test_evaluate_batch_aggregates_across_jobs(self, cluster_evaluator, mock_db):
         mock_db.fetch_subworker_runs.return_value = [SAMPLE_SUBWORKER_RUN]
         mock_db.fetch_clusters_for_run.return_value = [
-            {**SAMPLE_CLUSTER, "cluster_id": i, "size": 10}
-            for i in range(5)
+            {**SAMPLE_CLUSTER, "cluster_id": i, "size": 10} for i in range(5)
         ]
 
         result = await cluster_evaluator.evaluate_batch([uuid4(), uuid4()])
@@ -77,8 +72,7 @@ class TestClusterEvaluator:
         """
         mock_db.fetch_subworker_runs.return_value = [SAMPLE_SUBWORKER_RUN]
         mock_db.fetch_clusters_for_run.return_value = [
-            {**SAMPLE_CLUSTER, "cluster_id": i, "size": 10}
-            for i in range(5)
+            {**SAMPLE_CLUSTER, "cluster_id": i, "size": 10} for i in range(5)
         ]
 
         evaluator = ClusterEvaluator(mock_db, alert_thresholds)
@@ -86,6 +80,67 @@ class TestClusterEvaluator:
 
         assert result["technology"].silhouette_score is None
         assert result["technology"].alert_level == AlertLevel.OK
+
+    async def test_evaluate_batch_keeps_worst_per_job_alert(self, cluster_evaluator, mock_db):
+        """One collapsed night must not be averaged away by the healthy ones.
+
+        The aggregate carries the worst per-job severity; taking the mean
+        cluster count instead (5 and 1 average to 3, i.e. "OK") would hide
+        exactly the night that needs looking at.
+        """
+        mock_db.fetch_subworker_runs.return_value = [SAMPLE_SUBWORKER_RUN]
+        mock_db.fetch_clusters_for_run.side_effect = [
+            [{**SAMPLE_CLUSTER, "cluster_id": i, "size": 10} for i in range(5)],
+            [{**SAMPLE_CLUSTER, "size": 50}],
+        ]
+
+        result = await cluster_evaluator.evaluate_batch([uuid4(), uuid4()])
+
+        assert result["technology"].alert_level == AlertLevel.WARN
+
+    async def test_collapsed_clusters_reach_the_caller_as_warn(self, mock_db, alert_thresholds):
+        """Production reaches ClusterEvaluator only through evaluate_batch.
+
+        A night where a genre collapsed into a single cluster must surface as
+        WARN on both the per-genre metrics and the run's overall level — the
+        DB-only path has no silhouette to recompute from, so dropping the
+        per-job alerts pins the whole dimension at OK forever.
+        """
+        mock_db.fetch_recent_jobs.return_value = [SAMPLE_JOB]
+        mock_db.fetch_subworker_runs.return_value = [SAMPLE_SUBWORKER_RUN]
+        mock_db.fetch_clusters_for_run.return_value = [{**SAMPLE_CLUSTER, "size": 42}]
+
+        usecase = RunEvaluationUsecase(
+            genre_evaluator=AsyncMock(),
+            cluster_evaluator=ClusterEvaluator(mock_db, alert_thresholds),
+            summary_evaluator=AsyncMock(),
+            pipeline_evaluator=AsyncMock(),
+            db=mock_db,
+        )
+
+        run = await usecase.execute(
+            include_genre=False, include_summary=False, include_pipeline=False
+        )
+
+        assert run.cluster_metrics["technology"].alert_level == AlertLevel.WARN
+        assert run.overall_alert_level == AlertLevel.WARN
+
+    def test_evaluate_with_embeddings_reports_critical_on_degraded_clustering(
+        self, cluster_evaluator
+    ):
+        """Meta-test: deliberately shredded clustering must trip CRITICAL.
+
+        Two well-separated point pairs labelled across the gap give a strongly
+        negative silhouette — if this returns OK the threshold wiring is dead.
+        """
+        embeddings = np.array([[0.0, 0.0], [0.1, 0.0], [10.0, 0.0], [10.1, 0.0]])
+        labels = np.array([0, 1, 0, 1])
+
+        metrics = cluster_evaluator.evaluate_with_embeddings(embeddings, labels)
+
+        assert metrics.silhouette_score is not None
+        assert metrics.silhouette_score < 0
+        assert metrics.alert_level == AlertLevel.CRITICAL
 
     async def test_evaluate_batch_applies_thresholds_to_computed_silhouette(
         self, mock_db, alert_thresholds, monkeypatch

--- a/recap-evaluator/tests/unit/evaluator/test_summary_evaluator.py
+++ b/recap-evaluator/tests/unit/evaluator/test_summary_evaluator.py
@@ -9,6 +9,11 @@ from recap_evaluator.domain.models import AlertLevel, SummaryMetrics
 from recap_evaluator.evaluator.summary_evaluator import SummaryEvaluator
 from tests.fixtures.job_data import SAMPLE_ARTICLE, SAMPLE_OUTPUT
 
+# Every weighted axis reported a result. Spelled out here rather than imported
+# from the evaluator so a renamed axis fails these tests instead of following
+# the implementation silently.
+ALL_AXES = frozenset({"geval", "bertscore", "faithfulness", "rouge"})
+
 
 @pytest.fixture
 def mock_rouge():
@@ -98,7 +103,7 @@ class TestSummaryEvaluator:
             rouge_l_f1=0.4,
         )
 
-        score = summary_evaluator._calculate_composite_score(metrics)
+        score = summary_evaluator._calculate_composite_score(metrics, ALL_AXES)
 
         assert score == pytest.approx(0.715, abs=0.001)
 
@@ -112,7 +117,7 @@ class TestSummaryEvaluator:
             overall_quality_score=0.7,
         )
 
-        level = summary_evaluator._determine_alert_level(metrics)
+        level = summary_evaluator._determine_alert_level(metrics, ALL_AXES)
 
         assert level == AlertLevel.OK
 
@@ -130,7 +135,7 @@ class TestSummaryEvaluator:
             success_count=5,
         )
 
-        level = summary_evaluator._determine_alert_level(metrics)
+        level = summary_evaluator._determine_alert_level(metrics, ALL_AXES)
 
         assert level == AlertLevel.CRITICAL
 
@@ -143,9 +148,70 @@ class TestSummaryEvaluator:
         """
         metrics = SummaryMetrics(sample_count=10, success_count=0)
 
-        level = summary_evaluator._determine_alert_level(metrics)
+        level = summary_evaluator._determine_alert_level(metrics, frozenset())
 
         assert level == AlertLevel.CRITICAL
+
+    async def test_evaluate_batch_does_not_inflate_score_when_an_axis_dies(
+        self, summary_evaluator, mock_db, mock_bertscore
+    ):
+        """A dead 25 % axis must not make the composite read *better*.
+
+        Re-normalizing over the surviving axes turns an outage into a score
+        of 0.711 — higher than the 0.708 a fully measured healthy batch
+        scores. The missing weight stays in the denominator instead, and the
+        incomplete run warns rather than passing silently.
+        """
+        mock_db.fetch_outputs.return_value = [SAMPLE_OUTPUT]
+        mock_db.fetch_job_articles.return_value = [SAMPLE_ARTICLE]
+        mock_bertscore.evaluate_batch.side_effect = RuntimeError("model not loaded")
+
+        from uuid import uuid4
+        result = await summary_evaluator.evaluate_batch([uuid4()])
+
+        # 0.40*((4.075-1)/4) + 0.25*0.75 + 0.10*0.38, bertscore contributing 0
+        assert result.overall_quality_score == pytest.approx(0.533, abs=0.001)
+        assert result.alert_level == AlertLevel.WARN
+
+    async def test_evaluate_batch_criticals_when_half_the_weight_is_unmeasured(
+        self, summary_evaluator, mock_db, mock_bertscore, mock_faithfulness_evaluator
+    ):
+        """Meta-test: losing 50 % of the weighted axes must trip CRITICAL.
+
+        Under the survivors-only normalization the same batch scored 0.691 —
+        within a rounding error of the healthy 0.708 — and reported OK.
+        """
+        mock_db.fetch_outputs.return_value = [SAMPLE_OUTPUT]
+        mock_db.fetch_job_articles.return_value = [SAMPLE_ARTICLE]
+        mock_bertscore.evaluate_batch.side_effect = RuntimeError("model not loaded")
+        mock_faithfulness_evaluator.detect_batch.side_effect = RuntimeError("NLI down")
+
+        from uuid import uuid4
+        result = await summary_evaluator.evaluate_batch([uuid4()])
+
+        assert result.overall_quality_score == pytest.approx(0.3455, abs=0.001)
+        assert result.alert_level == AlertLevel.CRITICAL
+
+    def test_calculate_composite_score_keeps_missing_weight_in_denominator(
+        self, summary_evaluator
+    ):
+        """An unmeasured axis contributes nothing and is still paid for.
+
+        Same metrics as test_calculate_composite_score minus the G-Eval axis:
+        0.25*0.7 + 0.25*0.8 + 0.10*0.4 = 0.415, not 0.415/0.60 = 0.692.
+        """
+        metrics = SummaryMetrics(
+            geval_overall=4.0,
+            bertscore_f1=0.7,
+            faithfulness_score=0.8,
+            rouge_l_f1=0.4,
+        )
+
+        score = summary_evaluator._calculate_composite_score(
+            metrics, frozenset({"bertscore", "faithfulness", "rouge"})
+        )
+
+        assert score == pytest.approx(0.415, abs=0.001)
 
     async def test_evaluate_batch_alerts_when_geval_returns_all_zeros(
         self, summary_evaluator, mock_db, mock_ollama

--- a/search-indexer/app/consumer/config.go
+++ b/search-indexer/app/consumer/config.go
@@ -35,6 +35,31 @@ type Config struct {
 	// ReaperInterval is how often the consumer scans the pending entries list
 	// for messages that have exceeded MaxDeliveries.
 	ReaperInterval time.Duration
+	// DLQMaxLen caps the DLQ stream's length at XADD time. Zero or negative
+	// falls back to defaultDLQMaxLen -- see effectiveDLQMaxLen.
+	DLQMaxLen int64
+}
+
+// defaultDLQMaxLen bounds the DLQ stream when no cap is configured. Its own
+// XADD is the DLQ's first line of defence: mq-hub's periodic XTRIM pass is the
+// only other bound, and no service consumes a DLQ. redis-streams runs
+// maxmemory 1gb under noeviction where XADD is denyoom, so an unbounded DLQ
+// carrying whole original payloads eventually rejects every producer's publish
+// (compose/mq.yaml records that self-locking condition). The value matches
+// mq-hub's STREAM_MAX_LEN so the DLQ can never outgrow the live stream it
+// shadows.
+const defaultDLQMaxLen int64 = 10000
+
+// effectiveDLQMaxLen resolves the cap actually handed to XADD. An unset cap
+// resolves to the bounded default rather than to "unbounded": Config is also
+// built as a struct literal (tests, future call sites), and an unbounded DLQ
+// is precisely the failure mode this cap exists to prevent, so forgetting a
+// field must not be able to reach it.
+func (c Config) effectiveDLQMaxLen() int64 {
+	if c.DLQMaxLen > 0 {
+		return c.DLQMaxLen
+	}
+	return defaultDLQMaxLen
 }
 
 // DefaultConfig returns a default consumer configuration.
@@ -51,6 +76,7 @@ func DefaultConfig() Config {
 		DLQStreamKey:   "alt:events:articles:dlq",
 		MaxDeliveries:  5,
 		ReaperInterval: 60 * time.Second,
+		DLQMaxLen:      defaultDLQMaxLen,
 	}
 }
 
@@ -89,6 +115,11 @@ func ConfigFromEnv() Config {
 	if v := os.Getenv("CONSUMER_REAPER_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			cfg.ReaperInterval = d
+		}
+	}
+	if v := os.Getenv("CONSUMER_DLQ_MAX_LEN"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			cfg.DLQMaxLen = n
 		}
 	}
 

--- a/search-indexer/app/consumer/dlq.go
+++ b/search-indexer/app/consumer/dlq.go
@@ -38,8 +38,15 @@ func (c *Consumer) sendToDLQ(ctx context.Context, message redis.XMessage, delive
 		values[k] = v
 	}
 
+	// The DLQ is capped here or by mq-hub's periodic XTRIM pass, and by
+	// nothing else -- no service consumes a DLQ, so its length only ever
+	// grows. Unlike mq-hub's live-stream publishes this deliberately omits
+	// Mode "ACKED": the DLQ has no consumer group, so restricting trimming to
+	// fully-acked entries would trim nothing and leave the cap decorative.
 	if err := c.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: c.config.DLQStreamKey,
+		MaxLen: c.config.effectiveDLQMaxLen(),
+		Approx: true,
 		Values: values,
 	}).Err(); err != nil {
 		c.logger.Error("failed to write DLQ entry", "message_id", message.ID, "error", err)

--- a/search-indexer/app/consumer/dlq_maxlen_test.go
+++ b/search-indexer/app/consumer/dlq_maxlen_test.go
@@ -1,0 +1,229 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestReclaimPending_BoundsDLQStreamLength reproduces the finding: the DLQ
+// XADD carried no MAXLEN, and nothing else trims that stream -- mq-hub's
+// periodic XTRIM pass only walked the four live streams in
+// domain.AllStreamKeys() and no service consumes a DLQ. redis-streams runs
+// maxmemory 1gb under noeviction where XADD is denyoom, so an unbounded DLQ
+// carrying whole original payloads eventually rejects every producer's
+// publish -- and publish-time trimming cannot shrink anything back afterwards,
+// because it only runs as part of a successful XADD (compose/mq.yaml records
+// that self-locking condition).
+//
+// The cap is driven through ConfigFromEnv rather than a struct literal so the
+// test covers the path the container actually boots on (bootstrap/app.go).
+func TestReclaimPending_BoundsDLQStreamLength(t *testing.T) {
+	srv := miniredis.RunT(t)
+
+	ctx := context.Background()
+	seedClient := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+	defer func() { _ = seedClient.Close() }()
+
+	if err := seedClient.XGroupCreateMkStream(ctx, reclaimTestStream, reclaimTestGroup, "0").Err(); err != nil {
+		t.Fatalf("seed XGroupCreateMkStream: %v", err)
+	}
+
+	const poisonCount = 10
+	for i := 0; i < poisonCount; i++ {
+		if err := seedClient.XAdd(ctx, &redis.XAddArgs{
+			Stream: reclaimTestStream,
+			Values: map[string]interface{}{
+				"event_id": fmt.Sprintf("poison-%d", i),
+				"payload":  `{"article_id":"abc"}`,
+			},
+		}).Err(); err != nil {
+			t.Fatalf("seed poison XAdd %d: %v", i, err)
+		}
+	}
+
+	// Deliver to a ghost consumer that never ACKs, so every entry is already
+	// at one delivery when the reclaim sweep claims it.
+	if _, err := seedClient.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    reclaimTestGroup,
+		Consumer: "ghost-consumer",
+		Streams:  []string{reclaimTestStream, ">"},
+		Count:    poisonCount,
+	}).Result(); err != nil {
+		t.Fatalf("seed XReadGroup: %v", err)
+	}
+
+	claimIdleTime := 10 * time.Millisecond
+	const dlqMaxLen = 3
+
+	t.Setenv("CONSUMER_DLQ_MAX_LEN", fmt.Sprintf("%d", dlqMaxLen))
+
+	cfg := ConfigFromEnv()
+	cfg.RedisURL = fmt.Sprintf("redis://%s", srv.Addr())
+	cfg.GroupName = reclaimTestGroup
+	cfg.ConsumerName = "consumer-a"
+	cfg.StreamKey = reclaimTestStream
+	cfg.BatchSize = poisonCount
+	cfg.ClaimIdleTime = claimIdleTime
+	cfg.MaxDeliveries = 1
+	cfg.Enabled = true
+
+	handler := &recordingHandler{err: fmt.Errorf("poison message: always fails")}
+
+	c, err := NewConsumer(cfg, handler, newQuietLogger())
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	defer c.Stop()
+
+	srv.SetTime(time.Now().Add(claimIdleTime + time.Second))
+
+	if err := c.reclaimPending(ctx); err != nil {
+		t.Fatalf("reclaimPending: %v", err)
+	}
+
+	// miniredis trims exactly and ignores the "~" modifier; real Redis keeps
+	// at least the cap. Either way the point is that a cap is attached at all,
+	// so the DLQ cannot grow without bound.
+	dlqLen, err := seedClient.XLen(ctx, cfg.DLQStreamKey).Result()
+	if err != nil {
+		t.Fatalf("XLen DLQ: %v", err)
+	}
+	if dlqLen == 0 {
+		t.Fatalf("DLQ stream is empty: the %d poison messages were never routed", poisonCount)
+	}
+	if dlqLen > dlqMaxLen {
+		t.Fatalf("DLQ stream length = %d after routing %d poison messages, want <= %d (the XADD carries no MAXLEN, so nothing bounds this stream)", dlqLen, poisonCount, dlqMaxLen)
+	}
+}
+
+// TestDLQMaxLen_UnsetConfigStillBounded pins the fallback: Config is also
+// built as a struct literal, so a field the call site does not know about
+// stays zero. A zero cap must resolve to the package default rather than to
+// "unbounded" -- an unbounded DLQ is the failure mode the cap exists to
+// prevent, so it must not be reachable by forgetting to set a field.
+func TestDLQMaxLen_UnsetConfigStillBounded(t *testing.T) {
+	t.Parallel()
+
+	if got := (Config{}).effectiveDLQMaxLen(); got != defaultDLQMaxLen {
+		t.Fatalf("Config{}.effectiveDLQMaxLen() = %d, want %d", got, defaultDLQMaxLen)
+	}
+	if got := (Config{DLQMaxLen: 42}).effectiveDLQMaxLen(); got != 42 {
+		t.Fatalf("Config{DLQMaxLen: 42}.effectiveDLQMaxLen() = %d, want 42", got)
+	}
+	if cfg := DefaultConfig(); cfg.DLQMaxLen <= 0 {
+		t.Fatalf("DefaultConfig().DLQMaxLen = %d, want a positive cap", cfg.DLQMaxLen)
+	}
+}
+
+// recordCapture collects slog records so a test can assert on the fields a
+// log line actually carries. Records are appended under a mutex because the
+// loops Start() spawns log concurrently with the assertions.
+type recordCapture struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordCapture) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *recordCapture) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *recordCapture) WithGroup(string) slog.Handler { return h }
+
+// attr returns the value logged under key by the first record with the given
+// message, plus every key that record did carry, so a failure can report what
+// was logged instead of just what was missing.
+func (h *recordCapture) attr(msg, key string) (slog.Value, []string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, r := range h.records {
+		if r.Message != msg {
+			continue
+		}
+		var (
+			value slog.Value
+			found bool
+			keys  []string
+		)
+		r.Attrs(func(a slog.Attr) bool {
+			keys = append(keys, a.Key)
+			if a.Key == key {
+				value, found = a.Value, true
+			}
+			return true
+		})
+		return value, keys, found
+	}
+	return slog.Value{}, nil, false
+}
+
+// TestConsumer_Start_LogsEffectiveDLQMaxLen pins the operator-visible half of
+// the DLQ cap. effectiveDLQMaxLen resolving a zero DLQMaxLen to the package
+// default is only defensible because the value it picked is loud at startup:
+// without it in the consumer-start log, "an operator configured 10000" and
+// "the field was never wired" look identical from the outside, which is the
+// silent-fallback state CLAUDE.md rule 8 forbids. pre-processor's consumer
+// logs the same field -- both halves of the cap must report it.
+//
+// The cap is deliberately left unset here: the log must carry the value XADD
+// will actually use, not the raw zero the field holds.
+func TestConsumer_Start_LogsEffectiveDLQMaxLen(t *testing.T) {
+	srv := miniredis.RunT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	seedClient := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+	defer func() { _ = seedClient.Close() }()
+
+	if err := seedClient.XGroupCreateMkStream(ctx, reclaimTestStream, reclaimTestGroup, "0").Err(); err != nil {
+		t.Fatalf("seed XGroupCreateMkStream: %v", err)
+	}
+
+	cfg := Config{
+		RedisURL:       fmt.Sprintf("redis://%s", srv.Addr()),
+		GroupName:      reclaimTestGroup,
+		ConsumerName:   "consumer-a",
+		StreamKey:      reclaimTestStream,
+		BatchSize:      10,
+		BlockTimeout:   100 * time.Millisecond,
+		ClaimIdleTime:  time.Minute,
+		ReaperInterval: time.Minute,
+		DLQStreamKey:   "alt:events:articles:dlq",
+		MaxDeliveries:  5,
+		Enabled:        true,
+	}
+
+	capture := &recordCapture{}
+
+	c, err := NewConsumer(cfg, &recordingHandler{}, slog.New(capture))
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Stop()
+
+	value, keys, found := capture.attr("starting consumer", "dlq_max_len")
+	if !found {
+		t.Fatalf("consumer-start log carries no \"dlq_max_len\" field (logged keys: %v); an operator cannot tell a configured cap from an unwired one", keys)
+	}
+	if got := value.Int64(); got != cfg.effectiveDLQMaxLen() {
+		t.Fatalf("consumer-start log dlq_max_len = %d, want %d (the effective cap, not the raw field)", got, cfg.effectiveDLQMaxLen())
+	}
+}

--- a/search-indexer/app/consumer/redis_consumer.go
+++ b/search-indexer/app/consumer/redis_consumer.go
@@ -126,6 +126,11 @@ func (c *Consumer) Start(ctx context.Context) error {
 		"consumer", c.config.ConsumerName,
 		"dlq_stream", c.config.DLQStreamKey,
 		"max_deliveries", c.config.MaxDeliveries,
+		// The effective cap, not the raw field: effectiveDLQMaxLen resolving an
+		// unset DLQMaxLen to the default is only defensible while the value it
+		// picked is visible here, so an operator can tell a configured cap from
+		// an unwired one.
+		"dlq_max_len", c.config.effectiveDLQMaxLen(),
 	)
 
 	c.wg.Add(2)

--- a/search-indexer/app/driver/meilisearch_singleflight.go
+++ b/search-indexer/app/driver/meilisearch_singleflight.go
@@ -8,30 +8,82 @@
 // goroutines* before the first call has populated the cache.
 package driver
 
-import "context"
+import (
+	"context"
+	"errors"
+
+	"github.com/meilisearch/meilisearch-go"
+
+	"search-indexer/logger"
+)
+
+// maxSharedSearchFailovers bounds how many times one caller may re-enter the
+// group after a shared call died on somebody else's cancellation. A failover
+// only happens when another caller hung up, so the loop is already gated on
+// external churn; the cap keeps a pathological burst of short-lived callers
+// from making a patient caller retry forever.
+const maxSharedSearchFailovers = 2
 
 // singleflightSearch coalesces concurrent calls keyed by `key` into a single
 // invocation of `fn`. Other callers wait on the in-flight channel and read
-// the shared result. Per-caller context cancellation is honoured without
-// aborting the underlying fn — that is what keeps later waiters honest when
-// an early caller bails out.
+// the shared result.
+//
+// The shared invocation necessarily runs under whichever caller happened to
+// lead the flight, because `fn` closes over that caller's context at the call
+// site. Cancelling the leader therefore kills the search everybody else is
+// waiting on — exactly in the fan-out that singleflight exists for. So a
+// waiter that is still healthy treats a cancellation it cannot own as *not its
+// error* and re-enters the group, which elects a new leader with a live
+// context. Non-context failures are still returned to every waiter unchanged:
+// re-running those would amplify a broken engine N-fold.
 //
 // The singleflight.Group lives on the driver struct (declared in
 // meilisearch_driver.go) so its lifecycle matches the driver itself.
 func (d *MeilisearchDriver) singleflightSearch(ctx context.Context, key string, fn func() (cacheEntry, error)) (cacheEntry, error) {
-	ch := d.sf.DoChan(key, func() (any, error) {
-		return fn()
-	})
-	select {
-	case <-ctx.Done():
-		return cacheEntry{}, ctx.Err()
-	case res := <-ch:
-		if res.Err != nil {
-			return cacheEntry{}, res.Err
+	for attempt := 0; ; attempt++ {
+		ch := d.sf.DoChan(key, func() (any, error) {
+			return fn()
+		})
+		select {
+		case <-ctx.Done():
+			return cacheEntry{}, ctx.Err()
+		case res := <-ch:
+			if res.Err != nil {
+				if attempt < maxSharedSearchFailovers && ctx.Err() == nil && isContextFailure(res.Err) {
+					// singleflight drops a finished key before it delivers
+					// results (doCall deletes under the same lock), so the
+					// survivors coalesce onto one fresh flight instead of
+					// stampeding Meilisearch.
+					logger.Logger.DebugContext(ctx, "meilisearch singleflight failover",
+						"reason", "shared call cancelled by another caller",
+						"attempt", attempt+1,
+						"err", res.Err,
+					)
+					continue
+				}
+				return cacheEntry{}, res.Err
+			}
+			if e, ok := res.Val.(cacheEntry); ok {
+				return e, nil
+			}
+			return cacheEntry{}, nil
 		}
-		if e, ok := res.Val.(cacheEntry); ok {
-			return e, nil
-		}
-		return cacheEntry{}, nil
 	}
+}
+
+// isContextFailure reports whether err ultimately came from a context
+// cancellation or deadline. errors.Is alone is not enough here: meilisearch-go
+// v0.36.3's *meilisearch.Error has no Unwrap — it parks the transport failure
+// in OriginError instead — so a genuinely cancelled search would otherwise be
+// indistinguishable from an engine error and get fanned out to every waiter.
+func isContextFailure(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var apiErr *meilisearch.Error
+	if errors.As(err, &apiErr) {
+		return errors.Is(apiErr.OriginError, context.Canceled) ||
+			errors.Is(apiErr.OriginError, context.DeadlineExceeded)
+	}
+	return false
 }

--- a/search-indexer/app/driver/meilisearch_singleflight_leader_cancel_test.go
+++ b/search-indexer/app/driver/meilisearch_singleflight_leader_cancel_test.go
@@ -1,0 +1,182 @@
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meilisearch/meilisearch-go"
+)
+
+// stallingSearchIndex holds every SearchWithContext open until release is
+// closed or the caller's context dies. That is the only way to keep a
+// singleflight window provably open while a second caller joins it -- a
+// non-blocking fake would finish the flight before the follower arrives and
+// the test would silently stop exercising the coalescing path.
+type stallingSearchIndex struct {
+	meilisearch.IndexManager
+
+	entered chan context.Context // one value per SearchWithContext invocation
+	release chan struct{}
+
+	mu    sync.Mutex
+	calls int
+}
+
+func newStallingSearchIndex() *stallingSearchIndex {
+	return &stallingSearchIndex{
+		entered: make(chan context.Context, 8),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *stallingSearchIndex) SearchWithContext(ctx context.Context, _ string, _ *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	s.entered <- ctx
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.release:
+		return &meilisearch.SearchResponse{
+			Hits:               meilisearch.Hits{{"id": json.RawMessage(`"a1"`)}},
+			EstimatedTotalHits: 1,
+			ProcessingTimeMs:   3,
+		}, nil
+	}
+}
+
+func (s *stallingSearchIndex) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestMeilisearchDriver_Search_LeaderCancelDoesNotFailOtherCallers reproduces
+// the production fan-out shape that singleflight exists for: RAG fires several
+// identical SearchArticles inside 300ms, the first caller's HTTP client hangs
+// up, and everybody else -- whose own request is still very much alive -- used
+// to get that leader's context.Canceled back as a 500. The shared call runs
+// under the leader's context, so one impatient caller took the whole fan-out
+// down with it.
+func TestMeilisearchDriver_Search_LeaderCancelDoesNotFailOtherCallers(t *testing.T) {
+	idx := newStallingSearchIndex()
+	d := NewMeilisearchDriverWithClients(&fakeServiceManager{idx: idx}, nil, "articles")
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := d.Search(leaderCtx, "vance", 10)
+		leaderErr <- err
+	}()
+
+	// Once the leader is parked inside SearchWithContext its flight is open,
+	// so any caller using the same cache key must join it instead of starting
+	// its own.
+	select {
+	case <-idx.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader never reached SearchWithContext")
+	}
+
+	type searchResult struct {
+		docs []SearchDocumentDriver
+		err  error
+	}
+	follower := make(chan searchResult, 1)
+	go func() {
+		docs, err := d.Search(context.Background(), "vance", 10)
+		follower <- searchResult{docs: docs, err: err}
+	}()
+
+	// singleflight exposes no "the follower has joined" hook, so give it a
+	// generous slice of wall clock -- same approach as the sibling
+	// cancellation test in meilisearch_singleflight_test.go.
+	time.Sleep(200 * time.Millisecond)
+
+	cancelLeader()
+
+	select {
+	case err := <-leaderErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("leader: got %v, want context.Canceled after cancelling its own request", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader: did not return after cancellation")
+	}
+
+	// The follower must now be searching again under its own live context. If
+	// it returns before that, it inherited the leader's cancellation.
+	select {
+	case got := <-follower:
+		t.Fatalf("follower returned err=%v (docs=%d) on the leader's cancellation; a caller whose own context is alive must still get results", got.err, len(got.docs))
+	case <-idx.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("follower never reached SearchWithContext under a live context")
+	}
+	close(idx.release)
+
+	select {
+	case got := <-follower:
+		if got.err != nil {
+			t.Fatalf("follower: got err=%v, want the search to survive the leader's cancellation", got.err)
+		}
+		if len(got.docs) != 1 || got.docs[0].ID != "a1" {
+			t.Fatalf("follower: docs = %+v, want the single stub hit", got.docs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("follower: did not return")
+	}
+
+	if got := idx.callCount(); got != 2 {
+		t.Errorf("SearchWithContext calls = %d, want 2 (the doomed leader flight plus one re-lead)", got)
+	}
+}
+
+// TestMeilisearchDriver_Search_RealFailureIsNotRetried pins the other half of
+// the failover rule: a genuine Meilisearch failure must surface to every
+// waiter as-is. Re-running the search on non-cancellation errors would turn a
+// broken engine into an N-times amplified load.
+func TestMeilisearchDriver_Search_RealFailureIsNotRetried(t *testing.T) {
+	boom := errors.New("index not found")
+	idx := &failingSearchIndex{err: boom}
+	d := NewMeilisearchDriverWithClients(&fakeServiceManager{idx: idx}, nil, "articles")
+
+	_, err := d.Search(context.Background(), "vance", 10)
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want the underlying engine error", err)
+	}
+	if got := idx.callCount(); got != 1 {
+		t.Errorf("SearchWithContext calls = %d, want 1 (engine failures must not be retried)", got)
+	}
+}
+
+// failingSearchIndex fails every search with a fixed non-context error.
+type failingSearchIndex struct {
+	meilisearch.IndexManager
+
+	err error
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *failingSearchIndex) SearchWithContext(_ context.Context, _ string, _ *meilisearch.SearchRequest) (*meilisearch.SearchResponse, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	return nil, s.err
+}
+
+func (s *failingSearchIndex) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}

--- a/tag-generator/app/tag_generator/stream_consumer.py
+++ b/tag-generator/app/tag_generator/stream_consumer.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -41,6 +42,18 @@ _GROUP_CREATE_BACKOFF_CAP_SECONDS = 5.0
 # hung Redis still surfaces as a TimeoutError, just after `_read_and_process`
 # waited the full block window rather than seconds short of it.
 _SOCKET_TIMEOUT_MARGIN_SECONDS = 10.0
+
+# Nothing reads or trims the DLQ -- mq-hub's AllStreamKeys covers only the four
+# live streams -- so an uncapped DLQ grows until redis-streams hits its 1gb
+# maxmemory, and under noeviction that refuses *every* producer's XADD, not just
+# ours. Same cap and same approximate trim as publish_reply below: enough
+# backlog to diagnose a poison-pill run, bounded enough not to lock the instance.
+_DLQ_MAXLEN = 1000
+
+# Entries whose DLQ copy is durable but whose XACK has not landed yet. Bounded:
+# a Redis that keeps refusing XACK must not grow this map without limit, and
+# evicting the oldest entry costs at most one duplicate DLQ copy.
+_DLQ_AWAITING_ACK_MAX = 1024
 
 
 def is_group_already_exists(error: redis.ResponseError) -> bool:
@@ -204,6 +217,7 @@ class StreamConsumer:
         self.handler = handler
         self.client: redis.Redis | None = None
         self._shutdown = False
+        self._dlq_awaiting_ack: OrderedDict[str, None] = OrderedDict()
 
     async def start(self) -> None:
         """Start the consumer."""
@@ -339,17 +353,25 @@ class StreamConsumer:
             cursor = next_cursor
 
     async def _process_claimed_messages(self, messages: list[Any]) -> None:
-        """Reprocess reclaimed messages, dead-lettering ones over the retry limit."""
+        """Reprocess reclaimed messages, dead-lettering ones over the retry limit.
+
+        Every Redis call for an entry -- the PEL lookup and the dead-letter
+        write included -- sits inside that entry's own try. One entry Redis
+        refuses to serve must not unwind the sweep: the healthy entries behind
+        it in the same batch would then wait another interval for the
+        redelivery this loop exists to give them.
+        """
         if self.client is None:
             raise RuntimeError("Redis client is not initialized")
         for message_id, data in messages:
-            delivery_count = await self._get_delivery_count(message_id)
-            if delivery_count > self.config.max_delivery_count:
-                await self._move_to_dlq(message_id, data, delivery_count)
-                continue
-
             event = self._parse_event(message_id, data)
+            delivery_count = 0
             try:
+                delivery_count = await self._get_delivery_count(message_id)
+                if delivery_count > self.config.max_delivery_count:
+                    await self._move_to_dlq(message_id, data, delivery_count)
+                    continue
+
                 await self.handler.handle_event(event)
                 await self.client.xack(self.config.stream_key, self.config.group_name, message_id)
             except Exception as e:
@@ -379,19 +401,67 @@ class StreamConsumer:
 
     async def _move_to_dlq(self, message_id: str, data: dict[str, Any], delivery_count: int) -> None:
         """Dead-letter a message that exceeded max_delivery_count and ACK it
-        so it stops occupying the PEL."""
+        so it stops occupying the PEL.
+
+        The copy and the ACK fail independently, so they are handled apart. A
+        refused XADD must leave the entry in the PEL, or the payload is lost the
+        moment Redis is under the memory pressure that refused it. A landed XADD
+        followed by a refused XACK must not be re-copied on the next sweep --
+        that piles a duplicate of the same payload into the DLQ every reclaim
+        interval, filling the very stream the cap is there to bound.
+        """
         if self.client is None:
             raise RuntimeError("Redis client is not initialized")
         dlq_stream = f"{self.config.stream_key}:dlq"
-        dlq_fields = {**data, "original_message_id": message_id, "delivery_count": str(delivery_count)}
-        await self.client.xadd(dlq_stream, cast(dict[Any, Any], dlq_fields))
-        await self.client.xack(self.config.stream_key, self.config.group_name, message_id)
+
+        if message_id not in self._dlq_awaiting_ack:
+            dlq_fields = {**data, "original_message_id": message_id, "delivery_count": str(delivery_count)}
+            try:
+                await self.client.xadd(
+                    dlq_stream,
+                    cast(dict[Any, Any], dlq_fields),
+                    maxlen=_DLQ_MAXLEN,
+                    approximate=True,
+                )
+            except Exception as e:
+                logger.error(
+                    "dlq_write_failed",
+                    message_id=message_id,
+                    delivery_count=delivery_count,
+                    dlq_stream=dlq_stream,
+                    error=str(e),
+                )
+                # Don't ACK -- a later sweep dead-letters it once Redis is writable.
+                return
+            self._remember_dlq_write(message_id)
+
+        try:
+            await self.client.xack(self.config.stream_key, self.config.group_name, message_id)
+        except Exception as e:
+            logger.error(
+                "dlq_ack_failed",
+                message_id=message_id,
+                delivery_count=delivery_count,
+                dlq_stream=dlq_stream,
+                error=str(e),
+            )
+            # The copy is durable; the next sweep owes only the ACK.
+            return
+
+        self._dlq_awaiting_ack.pop(message_id, None)
         logger.error(
             "message_moved_to_dlq",
             message_id=message_id,
             delivery_count=delivery_count,
             dlq_stream=dlq_stream,
         )
+
+    def _remember_dlq_write(self, message_id: str) -> None:
+        """Record that this entry's DLQ copy is durable, evicting the oldest
+        entries so a Redis that keeps refusing XACK cannot grow the map."""
+        self._dlq_awaiting_ack[message_id] = None
+        while len(self._dlq_awaiting_ack) > _DLQ_AWAITING_ACK_MAX:
+            self._dlq_awaiting_ack.popitem(last=False)
 
     async def _read_and_process(self) -> None:
         """Read events from stream and process them."""

--- a/tag-generator/app/tag_generator/stream_event_handler.py
+++ b/tag-generator/app/tag_generator/stream_event_handler.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import structlog
 from pydantic import ValidationError
 
+from tag_generator.domain.models import TagExtractionResult
 from tag_generator.handler.event_payload import TagGenerationRequestPayload
 from tag_generator.stream_consumer import Event, EventHandler, StreamConsumer
 
@@ -98,30 +99,64 @@ class TagGeneratorEventHandler(EventHandler):
         )
 
     def _process_article_sync(self, article_id: str, feed_id: str = "") -> None:
-        """Synchronous wrapper for processing an article."""
+        """Synchronous wrapper for processing an article.
+
+        Runs the two steps of `TagGeneratorService._process_single_article`
+        separately instead of calling it, because its single bool answer cannot
+        say *which* step declined: an article with no extractable tags (short
+        body, or one the sanitizer strips) and a failed UpsertArticleTags RPC
+        both come back False. Raising on both re-ran the whole ML pipeline
+        every reclaim interval and dead-lettered an article whose only fault was
+        having nothing to tag -- the batch path has always treated an empty
+        extraction as terminal (`max_empty_extraction_retries`).
+        """
         # API mode: conn is None, backend handles everything
         article = self.service.article_fetcher.fetch_article_by_id(None, article_id)
-        if article:
-            if feed_id and not article.get("feed_id"):
-                article["feed_id"] = feed_id
-            success = self.service._process_single_article(None, article)
-            if success:
-                logger.info(
-                    "article_processed_for_tags",
-                    article_id=article_id,
-                )
-            else:
-                # Tag extraction or DB upsert failed. Raise instead of just
-                # logging: the caller's try/except (_handle_article_created)
-                # re-raises so stream_consumer._read_and_process does not
-                # XACK -- the message stays in the PEL for XAUTOCLAIM
-                # redelivery / DLQ instead of being silently dropped.
-                raise RuntimeError(f"tag processing failed for article {article_id}")
-        else:
+        if not article:
             logger.warning(
                 "article_not_found",
                 article_id=article_id,
             )
+            return
+
+        if feed_id and not article.get("feed_id"):
+            article["feed_id"] = feed_id
+
+        # An extraction that raises is a broken run, not a verdict on the
+        # article, so it propagates: _handle_article_created re-raises and
+        # stream_consumer leaves the entry in the PEL for redelivery.
+        outcome = self.service.tag_extractor.extract_tags_with_metrics(
+            article.get("title", ""),
+            article.get("content", ""),
+        )
+        extraction = TagExtractionResult.from_outcome(article_id, outcome)
+
+        if extraction.is_empty:
+            # Terminal: redelivering this costs a full inference and yields the
+            # same nothing. Returning normally lets the consumer XACK.
+            logger.info(
+                "no_tags_extracted_for_article",
+                article_id=article_id,
+            )
+            return
+
+        result = self.service.tag_inserter.upsert_tags(
+            None,
+            article_id,
+            extraction.tag_names,
+            article.get("feed_id") or "",
+        )
+        if not result.get("success"):
+            # Retryable: the tags exist, only persisting them failed. Raise so
+            # the message stays in the PEL for XAUTOCLAIM redelivery / DLQ
+            # instead of being silently dropped.
+            raise RuntimeError(f"tag upsert failed for article {article_id}")
+
+        logger.info(
+            "article_processed_for_tags",
+            article_id=article_id,
+            tag_count=len(extraction.tags),
+        )
 
     async def _handle_tag_generation_requested(self, event: Event) -> None:
         """Handle a synchronous tag generation request with reply.

--- a/tag-generator/app/tests/unit/test_stream_article_ack_semantics.py
+++ b/tag-generator/app/tests/unit/test_stream_article_ack_semantics.py
@@ -1,0 +1,195 @@
+"""An ArticleCreated delivery has three outcomes, not two.
+
+`_process_single_article` collapses "this article has no extractable tags"
+(a short body, or one the sanitizer strips to nothing) and "the upsert RPC
+failed" into the same `False`. The stream path then treated both as a failure
+and withheld the XACK, so an article that will never yield tags was re-run
+through the whole ML pipeline on every reclaim pass and dead-lettered on the
+fifth -- while the batch path has always treated an empty extraction as a
+normal, terminal outcome (`max_empty_extraction_retries`).
+
+These tests drive the real consumer and the real handler, faking only the
+ports, so they pin what a caller observes: which deliveries leave the PEL.
+"""
+
+import asyncio
+from typing import Any, cast
+
+import redis.asyncio as redis
+
+from tag_extractor.extract import TagExtractionOutcome
+from tag_generator.service import TagGeneratorService
+from tag_generator.stream_consumer import ConsumerConfig, StreamConsumer
+from tag_generator.stream_event_handler import TagGeneratorEventHandler
+
+ARTICLE = {
+    "id": "article-123",
+    "title": "Test Article",
+    "content": "Some content",
+    "feed_id": "feed-456",
+}
+
+
+class _FakeFetcher:
+    """Serves one article by id, the way GetArticleContent does."""
+
+    def __init__(self, article: dict[str, Any] | None) -> None:
+        self.article = article
+
+    def fetch_article_by_id(self, conn: Any, article_id: str) -> dict[str, Any] | None:
+        del conn, article_id
+        return dict(self.article) if self.article is not None else None
+
+
+class _FakeExtractor:
+    """Returns a scripted set of tags and counts how often it was asked."""
+
+    def __init__(self, tags: list[str]) -> None:
+        self.tags = tags
+        self.calls = 0
+
+    def extract_tags_with_metrics(self, title: str, content: str) -> TagExtractionOutcome:
+        self.calls += 1
+        return TagExtractionOutcome(
+            tags=list(self.tags),
+            confidence=0.9,
+            tag_count=len(self.tags),
+            inference_ms=1.0,
+            language="en",
+            model_name="fake",
+            sanitized_length=len(content) + len(title),
+            tag_confidences=dict.fromkeys(self.tags, 0.9),
+        )
+
+
+class _FakeInserter:
+    """Records upsert attempts and replays a scripted RPC outcome."""
+
+    def __init__(self, *, success: bool = True) -> None:
+        self.success = success
+        self.calls: list[tuple[str, list[str], str]] = []
+
+    def upsert_tags(
+        self,
+        conn: Any,
+        article_id: str,
+        tags: list[str],
+        feed_id: str,
+        tag_confidences: dict[str, float] | None = None,
+    ) -> dict[str, Any]:
+        del conn, tag_confidences
+        self.calls.append((article_id, list(tags), feed_id))
+        return {"success": self.success}
+
+
+class _ScriptedReadClient:
+    """Replays one XREADGROUP batch and records XACK calls."""
+
+    def __init__(self, batches: list[list[Any]]) -> None:
+        self.batches = list(batches)
+        self.acks: list[str] = []
+
+    async def xreadgroup(self, **kwargs: Any) -> list[Any]:
+        del kwargs
+        return self.batches.pop(0) if self.batches else []
+
+    async def xack(self, stream: str, group: str, message_id: str) -> None:
+        del stream, group
+        self.acks.append(message_id)
+
+
+def _service(extractor: _FakeExtractor, inserter: _FakeInserter, article: dict[str, Any] | None = ARTICLE):
+    """Build a TagGeneratorService with fake ports and no ML warmup.
+
+    `__init__` loads the real extractor, so the instance is created directly and
+    only the three collaborators the article path touches are injected. The
+    service's own logic stays real -- that is the point of the test.
+    """
+    service = object.__new__(TagGeneratorService)
+    service.article_fetcher = cast(Any, _FakeFetcher(article))
+    service.tag_extractor = cast(Any, extractor)
+    service.tag_inserter = cast(Any, inserter)
+    return service
+
+
+def _delivery(message_id: str) -> list[Any]:
+    return [
+        (
+            "alt:events:articles",
+            [
+                (
+                    message_id,
+                    {
+                        "event_id": f"evt-{message_id}",
+                        "event_type": "ArticleCreated",
+                        "source": "alt-backend",
+                        "payload": '{"article_id": "article-123", "title": "Test Article"}',
+                    },
+                )
+            ],
+        )
+    ]
+
+
+def _run(extractor: _FakeExtractor, inserter: _FakeInserter, message_id: str) -> _ScriptedReadClient:
+    consumer = StreamConsumer(ConsumerConfig(enabled=True), handler=cast(Any, None))
+    consumer.handler = TagGeneratorEventHandler(_service(extractor, inserter), consumer)
+    client = _ScriptedReadClient([_delivery(message_id)])
+    consumer.client = cast(redis.Redis, client)
+
+    asyncio.run(consumer._read_and_process())
+    return client
+
+
+def test_article_with_no_extractable_tags_is_acked_and_never_upserted() -> None:
+    """Zero tags is a terminal answer, not a failure. Withholding the XACK here
+    re-ran the ML pipeline every reclaim interval and dead-lettered an article
+    whose only fault is having nothing to tag.
+    """
+    extractor = _FakeExtractor(tags=[])
+    inserter = _FakeInserter()
+
+    client = _run(extractor, inserter, "1-0")
+
+    assert extractor.calls == 1
+    assert inserter.calls == [], "nothing to upsert when nothing was extracted"
+    assert client.acks == ["1-0"], "an untaggable article must leave the PEL"
+
+
+def test_article_whose_upsert_fails_is_left_pending_for_retry() -> None:
+    """The other half of the split: a failed UpsertArticleTags RPC is transient,
+    so the entry must keep its PEL slot for the reclaim loop.
+    """
+    extractor = _FakeExtractor(tags=["technology"])
+    inserter = _FakeInserter(success=False)
+
+    client = _run(extractor, inserter, "2-0")
+
+    assert inserter.calls == [("article-123", ["technology"], "feed-456")]
+    assert client.acks == [], "a failed upsert must be retried, not dropped"
+
+
+def test_successfully_tagged_article_is_acked() -> None:
+    extractor = _FakeExtractor(tags=["technology"])
+    inserter = _FakeInserter()
+
+    client = _run(extractor, inserter, "3-0")
+
+    assert inserter.calls == [("article-123", ["technology"], "feed-456")]
+    assert client.acks == ["3-0"]
+
+
+def test_missing_article_is_acked() -> None:
+    """A GetArticleContent miss was already terminal; keep it that way."""
+    extractor = _FakeExtractor(tags=["technology"])
+    inserter = _FakeInserter()
+
+    consumer = StreamConsumer(ConsumerConfig(enabled=True), handler=cast(Any, None))
+    consumer.handler = TagGeneratorEventHandler(_service(extractor, inserter, article=None), consumer)
+    client = _ScriptedReadClient([_delivery("4-0")])
+    consumer.client = cast(redis.Redis, client)
+
+    asyncio.run(consumer._read_and_process())
+
+    assert extractor.calls == 0
+    assert client.acks == ["4-0"]

--- a/tag-generator/app/tests/unit/test_stream_consumer_dlq.py
+++ b/tag-generator/app/tests/unit/test_stream_consumer_dlq.py
@@ -1,0 +1,167 @@
+"""The reclaim sweep must survive a Redis that rejects the dead-letter write.
+
+`_get_delivery_count` and `_move_to_dlq` ran outside the per-message try, so a
+single failing entry unwound `_reclaim_idle_messages` and the healthy entries
+behind it in the same batch waited another interval for a redelivery the sweep
+exists to give them. The failure is not hypothetical: redis-streams runs at
+maxmemory 1gb under noeviction and XADD is denyoom, so the DLQ write is exactly
+the call that starts failing first -- which is also why the DLQ stream itself
+has to be capped rather than growing until it locks every producer out.
+"""
+
+import asyncio
+from typing import Any, cast
+
+import redis.asyncio as redis
+
+from tag_generator.stream_consumer import ConsumerConfig, EventHandler, StreamConsumer
+
+OOM = redis.ResponseError("OOM command not allowed when used memory > 'maxmemory'.")
+
+
+class _RecordingHandler(EventHandler):
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def handle_event(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class _DlqClient:
+    """Serves one scripted XAUTOCLAIM batch per sweep and records DLQ traffic."""
+
+    def __init__(
+        self,
+        entries: list[tuple[str, dict[str, str]]],
+        times_delivered: dict[str, int],
+        *,
+        xadd_errors: list[Exception | None] | None = None,
+        xack_errors: list[Exception | None] | None = None,
+        xpending_errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self.entries = entries
+        self.times_delivered = times_delivered
+        self.xadd_errors = list(xadd_errors or [])
+        self.xack_errors = list(xack_errors or [])
+        self.xpending_errors = xpending_errors or {}
+        self.xadds: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+        self.acks: list[str] = []
+
+    async def xautoclaim(self, **kwargs: Any) -> tuple[str, list[Any], int]:
+        del kwargs
+        return ("0-0", list(self.entries), 0)
+
+    async def xpending_range(self, *args: Any, **kwargs: Any) -> list[Any]:
+        del args
+        message_id = str(kwargs["min"])
+        error = self.xpending_errors.get(message_id)
+        if error is not None:
+            raise error
+        return [{"times_delivered": self.times_delivered.get(message_id, 1)}]
+
+    async def xadd(self, name: str, fields: dict[str, Any], **kwargs: Any) -> str:
+        error = self.xadd_errors.pop(0) if self.xadd_errors else None
+        if error is not None:
+            raise error
+        self.xadds.append((name, fields, kwargs))
+        return f"dlq-{len(self.xadds)}"
+
+    async def xack(self, stream: str, group: str, message_id: str) -> None:
+        del stream, group
+        error = self.xack_errors.pop(0) if self.xack_errors else None
+        if error is not None:
+            raise error
+        self.acks.append(message_id)
+
+
+def _entry(message_id: str) -> tuple[str, dict[str, str]]:
+    return (
+        message_id,
+        {
+            "event_id": f"evt-{message_id}",
+            "event_type": "ArticleCreated",
+            "source": "alt-backend",
+            "payload": '{"article_id": "article-123"}',
+        },
+    )
+
+
+def _consumer(client: _DlqClient) -> tuple[StreamConsumer, _RecordingHandler]:
+    handler = _RecordingHandler()
+    consumer = StreamConsumer(ConsumerConfig(enabled=True, max_delivery_count=5), handler)
+    consumer.client = cast(redis.Redis, client)
+    return consumer, handler
+
+
+def test_a_rejected_dlq_write_does_not_abort_the_sweep() -> None:
+    """One entry Redis refuses to dead-letter must not cost the rest of the
+    batch their redelivery -- and it must keep its own PEL slot so a later
+    sweep can dead-letter it once Redis accepts writes again.
+    """
+    client = _DlqClient(
+        entries=[_entry("1-0"), _entry("2-0")],
+        times_delivered={"1-0": 99, "2-0": 1},
+        xadd_errors=[OOM],
+    )
+    consumer, handler = _consumer(client)
+
+    asyncio.run(consumer._reclaim_idle_messages())
+
+    assert [e.message_id for e in handler.events] == ["2-0"], "the healthy entry must still be reprocessed"
+    assert client.acks == ["2-0"], "only the reprocessed entry leaves the PEL"
+
+
+def test_a_failing_pel_lookup_does_not_abort_the_sweep() -> None:
+    """Same obligation one call earlier: XPENDING is Redis traffic too."""
+    client = _DlqClient(
+        entries=[_entry("1-0"), _entry("2-0")],
+        times_delivered={"2-0": 1},
+        xpending_errors={"1-0": redis.TimeoutError("Timeout reading from socket")},
+    )
+    consumer, handler = _consumer(client)
+
+    asyncio.run(consumer._reclaim_idle_messages())
+
+    assert [e.message_id for e in handler.events] == ["2-0"]
+    assert client.acks == ["2-0"]
+
+
+def test_dlq_copy_is_not_duplicated_when_the_ack_fails() -> None:
+    """XADD landing and XACK failing leaves the entry in the PEL, so the next
+    sweep dead-letters it again -- piling duplicate copies of the same payload
+    into the stream every reclaim interval. The copy is durable after the first
+    write; only the ACK is owed.
+    """
+    client = _DlqClient(
+        entries=[_entry("1-0")],
+        times_delivered={"1-0": 99},
+        xack_errors=[OOM],
+    )
+    consumer, _handler = _consumer(client)
+
+    asyncio.run(consumer._reclaim_idle_messages())
+    assert len(client.xadds) == 1
+    assert client.acks == []
+
+    asyncio.run(consumer._reclaim_idle_messages())
+
+    assert len(client.xadds) == 1, "the DLQ copy is already durable; do not write it again"
+    assert client.acks == ["1-0"], "the retried ACK must free the PEL slot"
+
+
+def test_dlq_stream_is_capped() -> None:
+    """An uncapped DLQ is a slow-motion outage: redis-streams is maxmemory /
+    noeviction and nothing consumes or trims these streams, so once one fills
+    the instance every producer's XADD starts being refused, not just ours.
+    The reply publisher already caps its own stream the same way.
+    """
+    client = _DlqClient(entries=[_entry("1-0")], times_delivered={"1-0": 99})
+    consumer, _handler = _consumer(client)
+
+    asyncio.run(consumer._reclaim_idle_messages())
+
+    stream, _fields, kwargs = client.xadds[0]
+    assert stream.endswith(":dlq")
+    assert kwargs.get("approximate") is True, "an exact trim on every write is not worth the cost"
+    maxlen = kwargs.get("maxlen")
+    assert isinstance(maxlen, int) and 0 < maxlen <= 10_000, "the DLQ must be bounded"

--- a/tag-generator/app/tests/unit/test_stream_event_handler.py
+++ b/tag-generator/app/tests/unit/test_stream_event_handler.py
@@ -194,14 +194,11 @@ class TestTagGeneratorEventHandler:
             "title": "Test Article",
             "content": "Some content",
         }
-        mock_service._process_single_article.return_value = True
-
         await handler._handle_article_created(event)
 
-        # Verify _process_single_article received article with feed_id supplemented
-        mock_service._process_single_article.assert_called_once()
-        article_arg = mock_service._process_single_article.call_args[0][1]
-        assert article_arg["feed_id"] == "feed-456"
+        # Verify the upsert received the feed_id supplemented from the event
+        mock_service.tag_inserter.upsert_tags.assert_called_once()
+        assert mock_service.tag_inserter.upsert_tags.call_args[0][3] == "feed-456"
 
     @pytest.mark.anyio
     async def test_handle_article_created_without_feed_id(self, handler, mock_service):
@@ -224,13 +221,10 @@ class TestTagGeneratorEventHandler:
             "title": "Test Article",
             "content": "Some content",
         }
-        mock_service._process_single_article.return_value = True
-
         await handler._handle_article_created(event)
 
-        # Article should not have feed_id added
-        article_arg = mock_service._process_single_article.call_args[0][1]
-        assert "feed_id" not in article_arg
+        # No feed_id anywhere means the upsert is told so explicitly
+        assert mock_service.tag_inserter.upsert_tags.call_args[0][3] == ""
 
     @pytest.mark.anyio
     async def test_handle_article_created_does_not_overwrite_existing_feed_id(self, handler, mock_service):
@@ -256,12 +250,9 @@ class TestTagGeneratorEventHandler:
             "content": "Some content",
             "feed_id": "feed-existing",
         }
-        mock_service._process_single_article.return_value = True
-
         await handler._handle_article_created(event)
 
-        article_arg = mock_service._process_single_article.call_args[0][1]
-        assert article_arg["feed_id"] == "feed-existing"
+        assert mock_service.tag_inserter.upsert_tags.call_args[0][3] == "feed-existing"
 
     @pytest.mark.anyio
     async def test_handle_event_ignores_unknown_events(self, handler, mock_stream_consumer):
@@ -282,11 +273,11 @@ class TestTagGeneratorEventHandler:
         mock_stream_consumer.publish_reply.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_handle_article_created_raises_when_processing_fails(self, handler, mock_service):
-        """A False result from _process_single_article (extraction/upsert failure)
-        must propagate as an exception so the stream consumer does not XACK the
-        message -- otherwise the failed article is silently dropped from the PEL
-        with no redelivery/DLQ path (see event-stream-consumer.md ACK discipline).
+    async def test_handle_article_created_raises_when_upsert_fails(self, handler, mock_service):
+        """A failed upsert must propagate as an exception so the stream consumer
+        does not XACK the message -- otherwise the article's tags are silently
+        lost with no redelivery/DLQ path (see event-stream-consumer.md ACK
+        discipline).
         """
         event = Event(
             message_id="msg-1",
@@ -303,7 +294,34 @@ class TestTagGeneratorEventHandler:
             "title": "Test Article",
             "content": "Some content",
         }
-        mock_service._process_single_article.return_value = False
+        mock_service.tag_inserter.upsert_tags.return_value = {"success": False}
 
-        with pytest.raises(RuntimeError, match="tag processing failed for article article-123"):
+        with pytest.raises(RuntimeError, match="tag upsert failed for article article-123"):
             await handler._handle_article_created(event)
+
+    @pytest.mark.anyio
+    async def test_handle_article_created_does_not_raise_when_nothing_is_extractable(self, handler, mock_service):
+        """The counterpart: zero extracted tags is a terminal answer, not a
+        failure. Raising here re-ran the ML pipeline on every reclaim pass and
+        dead-lettered the article on the fifth.
+        """
+        event = Event(
+            message_id="msg-1",
+            event_id="evt-1",
+            event_type="ArticleCreated",
+            source="alt-backend",
+            created_at=datetime.now(),
+            payload={"article_id": "article-123", "title": "Test Article"},
+            metadata={},
+        )
+
+        mock_service.article_fetcher.fetch_article_by_id.return_value = {
+            "article_id": "article-123",
+            "title": "Test Article",
+            "content": "Some content",
+        }
+        mock_service.tag_extractor.extract_tags_with_metrics.return_value.tags = []
+
+        await handler._handle_article_created(event)
+
+        mock_service.tag_inserter.upsert_tags.assert_not_called()


### PR DESCRIPTION
Outside-in TDD sweep over the alt-backend/app module (backend + harvester +
datahub), one agent per finding group, each proving RED before GREEN.

- 021 cursor handlers clamped `limit` to 100 then asked the usecase for
  limit+1, which the usecase rejects above 100 — the documented maximum page
  size answered 500. All four sites now clamp to 99 so the has_more probe row
  stays inside the ceiling.
- 023 BatchPrefetchImages fanned out one detached 60s goroutine per image with
  no ceiling; a fixed 32-slot pool now sheds instead of queueing.
- 022 the two Augur RAG routes were registered on the bare v1 group, reachable
  without a JWT; they now sit under RequireAuth.
- 024 a deadline exceeded during redeploy wrote outbox events to terminal
  FAILED with no path back; deadline expiry now returns to PENDING.
- 028 ArticleCreated emit failures bypassed the retry budget and re-ran the
  embedding every tick; they now share the attempt budget.
- 025 the 403 retry ladder bypassed the host rate limiter, sending 4 requests
  in 7s against the 5s floor; retries now wait on the limiter.
- 026 getEnvIntOrDefault's bounds expression was -1 on both sides, so every
  DB pool setting fell back to its default; out-of-range values now fail
  startup instead.
- 027 an omitted published_at was written as year 1 into both articles and the
  immutable ArticleCreated event; NULL now propagates.
- 077 CreateArticle skipped the event publish behind a nil guard (CLAUDE.md
  rule 8); the dependency is now required.
- 078 an unreadable BACKEND_TOKEN_SECRET left the service healthy and denying
  every request; the read error now fails startup (rule 9).
- 080 an explicitly-enabled AdminMonitor was downgraded to disabled on client
  init failure while logging the config value as false; it now fails startup.
- 079 TrackHomeAction discarded the HomeItemDismissed append failure after
  write-through, so a reproject resurrected dismissed items; the append now
  runs first and its error reaches the caller.

Finding 050 was verified as already fixed by ddb635e and left alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015LaM315FRrm7bkxrCxh72a