### PR TITLE
Add thread-safe syncBuffer for concurrent slog output capture

### DIFF
--- a/alt-butterfly-facade/internal/pki/manager_secret_log_test.go
+++ b/alt-butterfly-facade/internal/pki/manager_secret_log_test.go
@@ -66,7 +66,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 		m, _, _ := newTestManager(t, iss, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC))
 		m.Cfg.PasswordFile = passwordFile
 		m.Cfg.TickInterval = time.Millisecond
-		var buf bytes.Buffer
+		var buf syncBuffer
 		m.Log = slog.New(slog.NewJSONHandler(&buf, nil))
 		ctx, cancel := context.WithCancel(withT(context.Background(), t))
 		done := make(chan struct{})
@@ -75,10 +75,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 			_ = m.Run(ctx)
 		}()
 		deadline := time.After(2 * time.Second)
-		for {
-			if strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
-				break
-			}
+		for !strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
 			select {
 			case <-deadline:
 				cancel()

--- a/alt-butterfly-facade/internal/pki/secret_log_test.go
+++ b/alt-butterfly-facade/internal/pki/secret_log_test.go
@@ -1,7 +1,9 @@
 package pki
 
 import (
+	"bytes"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -31,4 +33,23 @@ func assertNoPasswordFileInError(t *testing.T, err error, secrets ...string) {
 			t.Fatalf("secret material %q leaked in error: %v", s, err)
 		}
 	}
+}
+
+// syncBuffer captures slog output that a test polls while the code under test
+// is still writing to it from another goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/auth-hub/internal/pki/manager_secret_log_test.go
+++ b/auth-hub/internal/pki/manager_secret_log_test.go
@@ -66,7 +66,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 		m, _, _ := newTestManager(t, iss, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC))
 		m.Cfg.PasswordFile = passwordFile
 		m.Cfg.TickInterval = time.Millisecond
-		var buf bytes.Buffer
+		var buf syncBuffer
 		m.Log = slog.New(slog.NewJSONHandler(&buf, nil))
 		ctx, cancel := context.WithCancel(withT(context.Background(), t))
 		done := make(chan struct{})
@@ -75,10 +75,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 			_ = m.Run(ctx)
 		}()
 		deadline := time.After(2 * time.Second)
-		for {
-			if strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
-				break
-			}
+		for !strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
 			select {
 			case <-deadline:
 				cancel()

--- a/auth-hub/internal/pki/secret_log_test.go
+++ b/auth-hub/internal/pki/secret_log_test.go
@@ -1,7 +1,9 @@
 package pki
 
 import (
+	"bytes"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -31,4 +33,23 @@ func assertNoPasswordFileInError(t *testing.T, err error, secrets ...string) {
 			t.Fatalf("secret material %q leaked in error: %v", s, err)
 		}
 	}
+}
+
+// syncBuffer captures slog output that a test polls while the code under test
+// is still writing to it from another goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/pre-processor/app/internal/pki/manager_secret_log_test.go
+++ b/pre-processor/app/internal/pki/manager_secret_log_test.go
@@ -66,7 +66,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 		m, _, _ := newTestManager(t, iss, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC))
 		m.Cfg.PasswordFile = passwordFile
 		m.Cfg.TickInterval = time.Millisecond
-		var buf bytes.Buffer
+		var buf syncBuffer
 		m.Log = slog.New(slog.NewJSONHandler(&buf, nil))
 		ctx, cancel := context.WithCancel(withT(context.Background(), t))
 		done := make(chan struct{})
@@ -75,10 +75,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 			_ = m.Run(ctx)
 		}()
 		deadline := time.After(2 * time.Second)
-		for {
-			if strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
-				break
-			}
+		for !strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
 			select {
 			case <-deadline:
 				cancel()

--- a/pre-processor/app/internal/pki/secret_log_test.go
+++ b/pre-processor/app/internal/pki/secret_log_test.go
@@ -1,7 +1,9 @@
 package pki
 
 import (
+	"bytes"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -31,4 +33,23 @@ func assertNoPasswordFileInError(t *testing.T, err error, secrets ...string) {
 			t.Fatalf("secret material %q leaked in error: %v", s, err)
 		}
 	}
+}
+
+// syncBuffer captures slog output that a test polls while the code under test
+// is still writing to it from another goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/rag-orchestrator/internal/pki/manager_secret_log_test.go
+++ b/rag-orchestrator/internal/pki/manager_secret_log_test.go
@@ -66,7 +66,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 		m, _, _ := newTestManager(t, iss, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC))
 		m.Cfg.PasswordFile = passwordFile
 		m.Cfg.TickInterval = time.Millisecond
-		var buf bytes.Buffer
+		var buf syncBuffer
 		m.Log = slog.New(slog.NewJSONHandler(&buf, nil))
 		ctx, cancel := context.WithCancel(withT(context.Background(), t))
 		done := make(chan struct{})
@@ -75,10 +75,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 			_ = m.Run(ctx)
 		}()
 		deadline := time.After(2 * time.Second)
-		for {
-			if strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
-				break
-			}
+		for !strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
 			select {
 			case <-deadline:
 				cancel()

--- a/rag-orchestrator/internal/pki/secret_log_test.go
+++ b/rag-orchestrator/internal/pki/secret_log_test.go
@@ -1,7 +1,9 @@
 package pki
 
 import (
+	"bytes"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -31,4 +33,23 @@ func assertNoPasswordFileInError(t *testing.T, err error, secrets ...string) {
 			t.Fatalf("secret material %q leaked in error: %v", s, err)
 		}
 	}
+}
+
+// syncBuffer captures slog output that a test polls while the code under test
+// is still writing to it from another goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/search-indexer/app/internal/pki/manager_secret_log_test.go
+++ b/search-indexer/app/internal/pki/manager_secret_log_test.go
@@ -66,7 +66,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 		m, _, _ := newTestManager(t, iss, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC))
 		m.Cfg.PasswordFile = passwordFile
 		m.Cfg.TickInterval = time.Millisecond
-		var buf bytes.Buffer
+		var buf syncBuffer
 		m.Log = slog.New(slog.NewJSONHandler(&buf, nil))
 		ctx, cancel := context.WithCancel(withT(context.Background(), t))
 		done := make(chan struct{})
@@ -75,10 +75,7 @@ func TestManager_DoesNotLogPasswordFile(t *testing.T) {
 			_ = m.Run(ctx)
 		}()
 		deadline := time.After(2 * time.Second)
-		for {
-			if strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
-				break
-			}
+		for !strings.Contains(buf.String(), "pki_enrollment_tick_failed") {
 			select {
 			case <-deadline:
 				cancel()

--- a/search-indexer/app/internal/pki/secret_log_test.go
+++ b/search-indexer/app/internal/pki/secret_log_test.go
@@ -1,7 +1,9 @@
 package pki
 
 import (
+	"bytes"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -31,4 +33,23 @@ func assertNoPasswordFileInError(t *testing.T, err error, secrets ...string) {
 			t.Fatalf("secret material %q leaked in error: %v", s, err)
 		}
 	}
+}
+
+// syncBuffer captures slog output that a test polls while the code under test
+// is still writing to it from another goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }


### PR DESCRIPTION
## Summary

Add a thread-safe `syncBuffer` type to support testing concurrent logging scenarios where the code under test writes to a log handler from one goroutine while the test polls the buffer from another.

## Changes

- **secret_log_test.go** (5 services): Add `syncBuffer` struct with mutex-protected `Write()` and `String()` methods to safely capture slog output across goroutine boundaries
  - Import `bytes` and `sync` packages
  - Define `syncBuffer` with `sync.Mutex` and `bytes.Buffer` fields
  - Implement `io.Writer` interface via `Write()` method
  - Implement `String()` method for safe buffer reads

- **manager_secret_log_test.go** (5 services): Update `TestManager_DoesNotLogPasswordFile` to use `syncBuffer` instead of plain `bytes.Buffer`
  - Replace `var buf bytes.Buffer` with `var buf syncBuffer`
  - Simplify polling loop from `for { if ... break }` to `for !condition` pattern
  - Maintains same test semantics with thread-safe buffer access

## Implementation Details

The `syncBuffer` type wraps `bytes.Buffer` with a `sync.Mutex` to prevent data races when:
- The manager's `Run()` goroutine writes log entries via `slog.JSONHandler`
- The test's main goroutine polls `buf.String()` to check for expected log messages

This pattern is applied consistently across all five services (alt-butterfly-facade, auth-hub, pre-processor, rag-orchestrator, search-indexer) that share the same PKI manager test structure.

https://claude.ai/code/session_018xVYMMRkKzN5ic4iAVZzGi